### PR TITLE
replace variables semi-automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ all:
 check:
 	nvcheck doc/*.jax vim_faq/*.jax
 
+replace:
+	nvcheck -i doc/*.jax vim_faq/*.jax
+
 html:
 	rm -rf target/html
 	mkdir -p target/html/doc


### PR DESCRIPTION
自動で表記ゆれを直してくれる `make replace` を追加しました。

**使い方**

1.  最新の nvcheck をインストールする `go get -u github.com/koron/nvcheck`
2.  dict.yml を編集する
3.  make replace
4.  2に戻って繰り返す

**説明**

nvcheck の新機能である `-i` オプションにより、
dict.ymlで指定した表記ゆれを半自動で修正します。
この機能では、単語の途中にある改行やインデントは概ね良い感じに維持しますが、
単語の長さが変わる書き換えに伴う wrap については面倒を見ません。
よってそれらは手動で直す必要があります。ゆえに「半自動」です。

ですが、無いよりは遥かに表記ゆれの統一&修正がしやすくなると思われます。
