### PR TITLE
Translate a |packages| feature

### DIFF
--- a/doc/repeat.jax
+++ b/doc/repeat.jax
@@ -8,12 +8,13 @@
 
 繰り返しについてはユーザーマニュアルの26章|usr_26.txt|に紹介がある。
 
-1. 単発繰り返し		|single-repeat|
-2. 多重繰り返し		|multi-repeat|
-3. 複雑な繰り返し	|complex-repeat|
-4. Vimスクリプトを使う	|using-scripts|
-5. スクリプトのデバッグ	|debug-scripts|
-6. プロファイリング	|profiling|
+1. 単発繰り返し			|single-repeat|
+2. 多重繰り返し			|multi-repeat|
+3. 複雑な繰り返し		|complex-repeat|
+4. Vimスクリプトを使う		|using-scripts|
+5. Vimスクリプトのパッケージ	|packages|
+6. スクリプトのデバッグ		|debug-scripts|
+7. プロファイリング		|profiling|
 
 ==============================================================================
 1. 単発繰り返し						*single-repeat*
@@ -181,10 +182,10 @@ Vimスクリプトの書き方はユーザーマニュアルの41章|usr_41.txt|
 			{Vi にはない}
 
 							*:ru* *:runtime*
-:ru[ntime][!] {file} ..
-			'runtimepath' で示された各ディレクトリの{file}からExコ
-			マンドを読み込む。ファイルがなくてもエラーにはならな
-			い。例: >
+:ru[ntime][!] [where] {file} ..
+			'runtimepath' か 'packpath' で示された各ディレクトリの
+			{file}からExコマンドを読み込む。ファイルがなくてもエラ
+			ーにはならない。例: >
 				:runtime syntax/c.vim
 
 <			{file}には空白で区切って複数のファイルを指定できる。指
@@ -195,6 +196,18 @@ Vimスクリプトの書き方はユーザーマニュアルの41章|usr_41.txt|
 
 			[!] を付けると見つかった全てのファイルを読み込む。付け
 			なければ最初に見つかったファイルだけを読み込む。
+
+			[where] が省略された場合は 'runtimepath' が使われる。
+			他の値は以下の通り:
+				START	'packpath' の"start"ディレクトリ以下を
+					検索する
+				OPT	'packpath' の"opt"ディレクトリ以下を
+					検索する
+				PACK	'packpath' の"start"と"opt"ディレクトリ
+					以下を検索する
+				ALL	まず'runtimepath'が使われ、次に
+					'packpath' の"start"と"opt"ディレクトリ
+					以下を検索する
 
 			{file}がワイルドカードを含んでいるとそれは展開される。
 			例: >
@@ -209,6 +222,47 @@ Vimスクリプトの書き方はユーザーマニュアルの41章|usr_41.txt|
 			'verbose' が2以上なら見つかった全てのファイルについて
 			メッセージが表示される。
 			{Vi にはない}
+
+							*:pa* *:packadd* *E919*
+:pa[ckadd][!] {name}	'packpath' 中の任意のプラグインディレクトリを検索し、
+			見つかったプラグインのファイルを読み込みます。ディレク
+			トリは以下にマッチしなければなりません:
+				pack/*/opt/{name} ~
+			見つかったディレクトリは、もし含まれていなければ
+			'runtimepath' に追加されます。
+			there yet.
+
+			Note {name} はディレクトリの名前です。.vimファイルの
+			名前ではありません。もし "{name}/plugin" ディレクトリが
+			1つより多くのファイルを含むなら全て読み込まれます。
+
+			もしファイルタイプの検知が有効化されていない場合(これは
+			通常.vimrc中の "syntax enable" か "filetype on" コマン
+			ドにより行われます)、"{name}/ftdetect/*.vim" ファイルを
+			参照します。
+
+			任意の ! が付けられた場合、プラグインのファイルや
+			ftdetectのスクリプトは読み込まれず、マッチしたディレク
+			トリのみ 'runtimepath' に追加されます。これは.vimrcに書
+			く場合は便利です。追加されたプラグインは初期化時に読み
+			込まれます。|load-plugins|を参照してください。また
+			|pack-add|も参照してください。
+
+						*:packl* *:packloadall*
+:packloadall[!]		'packpath' 以下の"start"ディレクトリ中の全パッケージを
+			読み込みます。見つかったディレクトリは 'runtimepath' に
+			追加されます。これは通常起動時に.vimrcが読み込まれた後
+			に自動的に行われます。このコマンドはそれよりも前に行う
+			ことができます。
+			パッケージの読み込みは一度だけ行われます。よってこのコ
+			マンドを実行した後に読み込みは行われません。任意の ! が
+			付けられた場合はすでに読み込みが行われていてもパッケー
+			ジを読み込みます。
+			(スクリプトを読み込む際の)エラーは読み込んでいるスクリ
+			プトの読み込みのみを中止させます。その他のプラグインは
+			読み込まれます。
+			|packages|を参照してください。
+
 
 :scripte[ncoding] [encoding]		*:scripte* *:scriptencoding* *E167*
 			スクリプトで使われている文字コードを宣言する。
@@ -376,7 +430,94 @@ Note 関数の中でその手のコマンドを実行するには、関数定義
 <	従って一般的ではないが行頭のバックスラッシュを採用している。
 
 ==============================================================================
-5. スクリプトのデバッグ					*debug-scripts*
+5. Vimスクリプトのパッケージ				*packages*
+
+Vimスクリプトのパッケージは1つかそれ以上のプラグインを含むディレクトリです。
+通常のプラグインと比べた長所は以下の通りです:
+- パッケージは圧縮ファイルとしてダウンロードでき、独自のディレクトリに展開され
+  ます。よってそのファイルは他のプラグインと混在することがありません。これは更
+  新と削除を簡素化します。
+- パッケージには git, mercurial などのリポジトリも使用可能です。これはとても更
+  新を簡素化します。
+- パッケージはお互いに依存する複数のプラグインを含むことができます。
+- パッケージは起動時に自動的に読み込まれるプラグインと、必要になった時のみ
+  `:packadd`により読み込まれるプラグインを含むことができます。
+
+
+パッケージの使用と自動読み込み ~
+
+あなたの Vim 関連のファイルは "~/.vim/" にあるとします。
+さらにZIP圧縮ファイル "/tmp/foopack.zip" からパッケージを追加したい場合は以下
+の通りです:
+	% mkdir -p ~/.vim/pack/foo
+	% cd ~/.vim/pack/foo
+	% unzip /tmp/foopack.zip
+
+"foo" というディレクトリ名は任意です。あなたのお好きな名前を付けてください。
+
+今あなたの ~/.vim の下に以下のファイルがあるはずです:
+	pack/foo/README.txt
+	pack/foo/start/foobar/plugin/foo.vim
+	pack/foo/start/foobar/syntax/some.vim
+	pack/foo/opt/foodebug/plugin/debugger.vim
+
+Vim が起動した時、.vimrcを処理した後、'packpath' に含まれる "pack/*/start" ディ
+レクトリの下の全てのディレクトリをスキャンして読み込みます。そのディレクトリは
+'runtimepath' に追加されます。
+
+上記の例では "pack/foo/start/foobar/plugin/foo.vim" を見つけて
+"~/.vim/pack/foo/start/foobar" を 'runtimepath' に追加します。
+
+もし "foobar" プラグインが作動し 'filetype' を "some" にセットした場合、
+'runtimepath' に含まれているため、Vim は上記の syntax/some.vim ファイルを見つけ
+ます。
+
+もし存在するなら、Vim は ftdetect ファイルもロードします。
+
+Note "pack/foo/opt" 以下のファイルは自動的に読み込まれず、"pack/foo/start"
+以下のファイルのみ読み込まれることに注意してください。"opt"ディレクトリがどの
+ように使われるかについては下記の|pack-add|を参照してください。
+
+パッケージの自動読み込みはプラグインの読み込みを無効化している場合は起こりませ
+ん。|load-plugins|を参照してください。
+
+'runtimepath' を更新するためにパッケージを読み込むには: >
+	:packloadall
+これはプラグインの読み込みを無効化していても効果があります。自動読み込みは一度
+だけ行われます。
+
+
+Using a single plugin and loading it automatically ~
+
+If you don't have a package but a single plugin, you need to create the extra
+directory level:
+	% mkdir -p ~/.vim/pack/foo/start/foobar
+	% cd ~/.vim/pack/foo/start/foobar
+	% unzip /tmp/someplugin.zip
+
+You would now have these files:
+	pack/foo/start/foobar/plugin/foo.vim
+	pack/foo/start/foobar/syntax/some.vim
+
+From here it works like above.
+
+
+任意のプラグイン ~
+							*pack-add*
+上記の pack ディレクトリから任意のプラグインをロードするには`:packadd`コマンドを
+使います: >
+	:packadd foodebug
+これは 'packpath' の "pack/*/opt/foodebug" から
+~/.vim/pack/foo/opt/foodebug/plugin/debugger.vim を見つけ読み込みます。
+
+This could be done inside always.vim, if some conditions are met.  Or you
+could add this command to your |.vimrc|.
+
+もしパッケージが "opt" ディレクトリしか持たなかったとしても一向に構いません。
+もしあなたがそれを使いたければ(明示的に)読み込む必要があります。
+
+==============================================================================
+6. スクリプトのデバッグ					*debug-scripts*
 
 スクリプトの動作を知るためのコードを追加することができるのは当り前として、Vim
 はデバッグモードを提供している。これはスクリプトファイルやユーザーファンクショ
@@ -597,7 +738,7 @@ Note 関数はまず読み込まれ、後で実行される。読み込まれた
 		使わず、ユーザーから直接デバッグモードコマンドを受け取る。
 
 ==============================================================================
-6. プロファイリング					*profile* *profiling*
+7. プロファイリング					*profile* *profiling*
 
 プロファイリングとは、関数やスクリプトの実行にかかる時間を計測することである。
 これを行うには |+profile| 機能が必要である。

--- a/doc/repeat.jax
+++ b/doc/repeat.jax
@@ -1,4 +1,4 @@
-*repeat.txt*    For Vim バージョン 7.4.  Last change: 2016 Jan 16
+*repeat.txt*    For Vim バージョン 7.4.  Last change: 2016 Mar 15
 
 
 		VIMリファレンスマニュアル    by Bram Moolenaar
@@ -185,7 +185,9 @@ Vimスクリプトの書き方はユーザーマニュアルの41章|usr_41.txt|
 :ru[ntime][!] [where] {file} ..
 			'runtimepath' か 'packpath' で示された各ディレクトリの
 			{file}からExコマンドを読み込む。ファイルがなくてもエラ
-			ーにはならない。例: >
+			ーにはならない。
+			
+			例: >
 				:runtime syntax/c.vim
 
 <			{file}には空白で区切って複数のファイルを指定できる。指
@@ -262,7 +264,6 @@ Vimスクリプトの書き方はユーザーマニュアルの41章|usr_41.txt|
 			プトの読み込みのみを中止させます。その他のプラグインは
 			読み込まれます。
 			|packages|を参照してください。
-
 
 :scripte[ncoding] [encoding]		*:scripte* *:scriptencoding* *E167*
 			スクリプトで使われている文字コードを宣言する。

--- a/doc/repeat.jax
+++ b/doc/repeat.jax
@@ -232,7 +232,6 @@ Vimスクリプトの書き方はユーザーマニュアルの41章|usr_41.txt|
 				pack/*/opt/{name} ~
 			見つかったディレクトリは、もし含まれていなければ
 			'runtimepath' に追加されます。
-			there yet.
 
 			Note {name} はディレクトリの名前です。.vimファイルの
 			名前ではありません。もし "{name}/plugin" ディレクトリが

--- a/en/repeat.txt
+++ b/en/repeat.txt
@@ -1,4 +1,4 @@
-*repeat.txt*    For Vim version 7.4.  Last change: 2016 Jan 16
+*repeat.txt*    For Vim version 7.4.  Last change: 2016 Mar 15
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -12,8 +12,9 @@ Chapter 26 of the user manual introduces repeating |usr_26.txt|.
 2. Multiple repeats	|multi-repeat|
 3. Complex repeats	|complex-repeat|
 4. Using Vim scripts	|using-scripts|
-5. Debugging scripts	|debug-scripts|
-6. Profiling		|profiling|
+5. Using Vim packages	|packages|
+6. Debugging scripts	|debug-scripts|
+7. Profiling		|profiling|
 
 ==============================================================================
 1. Single repeats					*single-repeat*
@@ -181,10 +182,12 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			{not in Vi}
 
 							*:ru* *:runtime*
-:ru[ntime][!] {file} ..
+:ru[ntime][!] [where] {file} ..
 			Read Ex commands from {file} in each directory given
-			by 'runtimepath'.  There is no error for non-existing
-			files.  Example: >
+			by 'runtimepath' and/or 'packpath'.  There is no error
+			for non-existing files.
+			
+			Example: >
 				:runtime syntax/c.vim
 
 <			There can be multiple {file} arguments, separated by
@@ -197,6 +200,15 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			When [!] is included, all found files are sourced.
 			When it is not included only the first found file is
 			sourced.
+
+			When [where] is omitted only 'runtimepath' is used.
+			Other values:
+				START	search under "start" in 'packpath'
+				OPT 	search under "opt" in 'packpath'
+				PACK	search under "start" and "opt" in
+					'packpath'
+				ALL	first use 'runtimepath', then search
+					under "start" and "opt" in 'packpath'
 
 			When {file} contains wildcards it is expanded to all
 			matching files.  Example: >
@@ -211,6 +223,45 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			When 'verbose' is two or higher, there is a message
 			about each searched file.
 			{not in Vi}
+
+							*:pa* *:packadd* *E919*
+:pa[ckadd][!] {name}	Search for an optional plugin directory in 'packpath'
+			and source any plugin files found.  The directory must
+			match:
+				pack/*/opt/{name} ~
+			The directory is added to 'runtimepath' if it wasn't
+			there yet.
+
+			Note that {name} is the directory name, not the name
+			of the .vim file.  If the "{name}/plugin" directory
+			contains more than one file they are all sourced.
+
+			If the filetype detection was not enabled yet (this
+			is usually done with a "syntax enable" or "filetype
+			on" command in your .vimrc file), this will also look
+			for "{name}/ftdetect/*.vim" files.
+
+			When the optional ! is added no plugin files or
+			ftdetect scripts are loaded, only the matching
+			directories are added to 'runtimepath'.  This is
+			useful in your .vimrc.  The plugins will then be
+			loaded during initialization, see |load-plugins|.
+
+			Also see |pack-add|.
+
+						*:packl* *:packloadall*
+:packloadall[!]		Load all packages in the "start" directories under
+			'packpath'.  The directories found are added to
+			'runtimepath'.
+			This is normally done automatically during startup,
+			after loading your .vimrc file.  With this command it
+			can be done earlier.
+			Packages will be loaded only once.  After this command
+			it won't happen again.  When the optional ! is added
+			this command will load packages even when done before.
+			An Error only causes sourcing the script where it
+			happens to be aborted, further plugins will be loaded.
+			See |packages|.
 
 :scripte[ncoding] [encoding]		*:scripte* *:scriptencoding* *E167*
 			Specify the character encoding used in the script.
@@ -388,7 +439,91 @@ Rationale:
 <	Therefore the unusual leading backslash is used.
 
 ==============================================================================
-5. Debugging scripts					*debug-scripts*
+5. Using Vim packages					*packages*
+
+A Vim package is a directory that contains one or more plugins.  The
+advantages over normal plugins:
+- A package can be downloaded as an archive and unpacked in its own directory.
+  Thus the files are not mixed with files of other plugins.  That makes it
+  easy to update and remove.
+- A package can be a git, mercurial, etc. repository.  That makes it really
+  easy to update.
+- A package can contain multiple plugins that depend on each other.
+- A package can contain plugins that are automatically loaded on startup and
+  ones that are only loaded when needed with `:packadd`.
+
+
+Using a package and loading automatically ~
+
+Let's assume your Vim files are in the "~/.vim" directory and you want to add a
+package from a zip archive "/tmp/foopack.zip":
+	% mkdir -p ~/.vim/pack/foo
+	% cd ~/.vim/pack/foo
+	% unzip /tmp/foopack.zip
+
+The directory name "foo" is arbitrary, you can pick anything you like.
+
+You would now have these files under ~/.vim:
+	pack/foo/README.txt
+	pack/foo/start/foobar/plugin/foo.vim
+	pack/foo/start/foobar/syntax/some.vim
+	pack/foo/opt/foodebug/plugin/debugger.vim
+
+When Vim starts up, after processing your .vimrc, it scans all directories in
+'packpath' for plugins under the "pack/*/start" directory and loads them.  The
+directory is added to 'runtimepath'.
+
+In the example Vim will find "pack/foo/start/foobar/plugin/foo.vim" and adds 
+"~/.vim/pack/foo/start/foobar" to 'runtimepath'.
+
+If the "foobar" plugin kicks in and sets the 'filetype' to "some", Vim will
+find the syntax/some.vim file, because its directory is in 'runtimepath'.
+
+Vim will also load ftdetect files, if there are any.
+
+Note that the files under "pack/foo/opt" or not loaded automatically, only the
+ones under "pack/foo/start".  See |pack-add| below for how the "opt" directory
+is used.
+
+Loading packages automatically will not happen if loading plugins is disabled,
+see |load-plugins|.
+
+To load packages earlier, so that 'runtimepath' gets updated: >
+	:packloadall
+This also works when loading plugins is disabled.  The automatic loading will
+only happen once.
+
+
+Using a single plugin and loading it automatically ~
+
+If you don't have a package but a single plugin, you need to create the extra
+directory level:
+	% mkdir -p ~/.vim/pack/foo/start/foobar
+	% cd ~/.vim/pack/foo/start/foobar
+	% unzip /tmp/someplugin.zip
+
+You would now have these files:
+	pack/foo/start/foobar/plugin/foo.vim
+	pack/foo/start/foobar/syntax/some.vim
+
+From here it works like above.
+
+
+Optional plugins ~
+							*pack-add*
+To load an optional plugin from a pack use the `:packadd` command: >
+	:packadd foodebug
+This searches for "pack/*/opt/foodebug" in 'packpath' and will find
+~/.vim/pack/foo/opt/foodebug/plugin/debugger.vim and source it.
+
+This could be done inside always.vim, if some conditions are met.  Or you
+could add this command to your |.vimrc|.
+
+It is perfectly normal for a package to only have files in the "opt"
+directory.  You then need to load each plugin when you want to use it.
+
+==============================================================================
+6. Debugging scripts					*debug-scripts*
 
 Besides the obvious messages that you can add to your scripts to find out what
 they are doing, Vim offers a debug mode.  This allows you to step through a
@@ -490,7 +625,7 @@ Additionally, these commands can be used:
 	bt
 	where
 							*>frame*
-	frame N		Goes to N bactrace level. + and - signs make movement
+	frame N		Goes to N backtrace level. + and - signs make movement
 			relative.  E.g., ":frame +3" goes three frames up.
 							*>up*
 	up		Goes one level up from call stacktrace.
@@ -500,7 +635,7 @@ Additionally, these commands can be used:
 About the additional commands in debug mode:
 - There is no command-line completion for them, you get the completion for the
   normal Ex commands only.
-- You can shorten them, up to a single character, unless more then one command
+- You can shorten them, up to a single character, unless more than one command
   starts with the same letter.  "f" stands for "finish", use "fr" for "frame".
 - Hitting <CR> will repeat the previous one.  When doing another command, this
   is reset (because it's not clear what you want to repeat).
@@ -613,7 +748,7 @@ OBSCURE
 		user, don't use typeahead for debug commands.
 
 ==============================================================================
-6. Profiling						*profile* *profiling*
+7. Profiling						*profile* *profiling*
 
 Profiling means that Vim measures the time that is spent on executing
 functions and/or scripts.  The |+profile| feature is required for this.


### PR DESCRIPTION
Vim 7.4.1657 時点の doc/repeat.txt に含まれる packages の機能を翻訳しました (一部未訳有り)。

## 未訳

* `Using a single plugin and loading it automatically` の single plugin が何を指すのか汲み取れなかったため翻訳しませんでした (未訳のまま残してあります)。

* 以下の文の意図が汲み取れなかったため翻訳しませんでした (always.vim とは…)。

```
This could be done inside always.vim, if some conditions are met.  Or you
could add this command to your |.vimrc|.
```

## Vim 本家の間違いと思われるもの

上記 always.vim の件も含め、
https://github.com/vim-jp/issues/issues/865#issuecomment-201927282
にコメントしました。

## TODO

- [x] 英語の行残ってたので削除 (thanks @h-east)
- [ ] repeat.txt に追従する (thanks @crazymaster)
- [ ] だである調に修正 (thanks @k-takata)