### PR TITLE
update READMEs

### DIFF
--- a/README-dist.md
+++ b/README-dist.md
@@ -2,17 +2,15 @@
 
 [![Build Status](https://travis-ci.org/vim-jp/vimdoc-ja-working.svg?branch=master)](https://travis-ci.org/vim-jp/vimdoc-ja-working)
 
-日本語に翻訳したVimの付属ドキュメントを配布するためのプロジェクトです。
+日本語に翻訳した Vim 付属のヘルプを配布するためのプロジェクトです。
 
-間違いを見つけたらメーリングリストかissueトラッカーでお知らせください。
+詳しい利用方法については [wiki](https://github.com/vim-jp/vimdoc-ja/wiki) を参照してください。
 
-- **利用者向け**
-  - HTML版 http://vim-jp.org/vimdoc-ja/
-  - Gitレポジトリ https://github.com/vim-jp/vimdoc-ja
-  - メーリングリスト http://groups.google.com/group/vimdoc-ja
-  - issueトラッカー https://github.com/vim-jp/vimdoc-ja-working/issues
-    - [旧 issue トラッカー](https://github.com/vim-jp/vimdoc-ja/issues)
-- 翻訳作業者向け
-  - Gitレポジトリ https://github.com/vim-jp/vimdoc-ja-working
-  - Wiki https://github.com/vim-jp/vimdoc-ja/wiki (旧)
-    - [新Wiki予定地](https://github.com/vim-jp/vimdoc-ja-working/wiki)
+HTML 版は [http://vim-jp.org/vimdoc-ja/](http://vim-jp.org/vimdoc-ja/) から参照することができます。
+
+間違いを見つけた場合、メーリングリストか issue トラッカーでお知らせください。
+
+- メーリングリスト http://groups.google.com/group/vimdoc-ja
+- issue トラッカー https://github.com/vim-jp/vimdoc-ja-working/issues
+
+翻訳作業に協力していただける方は [https://github.com/vim-jp/vimdoc-ja-working](https://github.com/vim-jp/vimdoc-ja-working) をご覧ください。

--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
-# vimdoc-ja
+# vimdoc-ja-working
 
 [![Build Status](https://travis-ci.org/vim-jp/vimdoc-ja-working.svg?branch=master)](https://travis-ci.org/vim-jp/vimdoc-ja-working)
 
-Vimの付属ドキュメントを日本語に翻訳するためのプロジェクトです。
+Vim 付属のヘルプを日本語に翻訳するためのプロジェクトです。
 
-間違いを見つけたらメーリングリストかissueトラッカーでお知らせください。
+### ヘルプを利用したい
+配布専用の[ページ](https://github.com/vim-jp/vimdoc-ja)にアクセス！
 
-- **利用者向け**
-  - HTML版 http://vim-jp.org/vimdoc-ja/
-  - Gitレポジトリ https://github.com/vim-jp/vimdoc-ja
-  - メーリングリスト http://groups.google.com/group/vimdoc-ja
-  - issueトラッカー https://github.com/vim-jp/vimdoc-ja-working/issues
-    - [旧 issue トラッカー](https://github.com/vim-jp/vimdoc-ja/issues)
-- 翻訳作業者向け
-  - Gitレポジトリ https://github.com/vim-jp/vimdoc-ja-working
-  - Wiki https://github.com/vim-jp/vimdoc-ja/wiki (旧)
-    - [新Wiki予定地](https://github.com/vim-jp/vimdoc-ja-working/wiki)
+### ヘルプの翻訳に協力したい
+作業手順については [wiki](https://github.com/vim-jp/vimdoc-ja-working/wiki) をご覧ください。
+
+間違いを見付けた場合、[issue](https://github.com/vim-jp/vimdoc-ja-working/issues)トラッカーでお知らせください。プルリクエストも大歓迎です。
+
+GitHub のアカウントをお持ちでない場合は、次の方法による連絡も可能です。
+
+- メーリングリスト http://groups.google.com/group/vimdoc-ja
+
+#### 姉妹プロジェクトがあります！
+Vim 本体の日本語メッセージ、GUI 版の日本語メニュー、日本語チュートリアル、日本語 man ファイルについては [vim-jp/lang-ja](https://github.com/vim-jp/lang-ja) でやっています！お気軽にどうぞ。
 
 ## 注意事項
-
 README-dist.md は vim-jp/vimdoc-ja の README.md として配布されます。
 内容を変更する際はそれに相応しい変更であるよう留意してください。


### PR DESCRIPTION
改造してみましたがいかがでしょうか？

「ヘルプ」としたのは lang-ja のドキュメントが分割されたので。「マニュアル」でも良いかもしれません。

本来は「リポジトリ」だけれども、あえて「ページ」としました。リンクはたくさんあってわかりづらいので削除しました。

旧 wiki は利用方法のみを vimdoc-ja に残して、あとは vimdoc-ja-working に引越す。

その他の連絡方法。twitter、facebook、LINE、はてな匿名ダイアリー？

vimdoc-ja の issue トラッカーは閉鎖することが出来ないので vimdoc-ja-working の方を利用するようにリンクを張る(けれども強制はしない)。
