### PR TITLE
Translate the untranslated paragraph in `:h cterm-colors`

### DIFF
--- a/doc/syntax.jax
+++ b/doc/syntax.jax
@@ -4532,7 +4532,7 @@ ctermbg={color-nr}				*highlight-ctermbg*
 	カラーターミナルによっては、色名を使うと間違った色で表示される場合
 	もあることに注意。
 
-	You can also use "NONE" to remove the color.
+	色をなしにするのに "NONE" も使える。
 
 							*:hi-normal-cterm*
 	Normalグループに対して "ctermfg" や "ctermbg" を設定すると、これらはハ


### PR DESCRIPTION
`:h cterm-colors` の末尾，または `:h :hi-normal-cterm` の直前に存在する未翻訳の1段落が気になったので翻訳してみました。

removeの翻訳は `:h cterm-colors` に存在する 「Without the '*' the bold attribute is removed.」の翻訳である，「'*' がないものはbold属性なしになる。」に合わせました。

もし意図があって未翻訳のままにしていたのならば，お手数ですがコメントお願いします。