### PR TITLE
translate fuctions in eval.jax

### DIFF
--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -1951,9 +1951,9 @@ atan2({expr}, {expr})		浮動小数点数	{expr1} / {expr2} のアークタン
 browse({save}, {title}, {initdir}, {default})
 				文字列	ファイル選択ダイアログを表示
 browsedir({title}, {initdir})	文字列	ディレクトリ選択ダイアログを表示
-bufexists({expr})		数値	バッファ{expr}が存在すればTRUE
-buflisted({expr})		数値	バッファ{expr}がリストにあるならTRUE
-bufloaded({expr})		数値	バッファ{expr}がロード済みならTRUE
+bufexists({expr})		数値	バッファ{expr}が存在すれば|TRUE|
+buflisted({expr})		数値	バッファ{expr}がリストにあるなら|TRUE|
+bufloaded({expr})		数値	バッファ{expr}がロード済みなら|TRUE|
 bufname({expr})			文字列	バッファ{expr}の名前
 bufnr({expr} [, {create}])	数値	バッファ{expr}の番号
 bufwinid({expr})		数値	バッファ{expr}のウィンドウID
@@ -1992,7 +1992,7 @@ ch_sendraw({handle}, {string} [, {options}])
 ch_setoptions({handle}, {options})
 				なし	{handle}にオプションを設定する
 ch_status({handle} [, {options}])
-				文字列	チャンネル{handle}のステータス
+				文字列	チャンネル{handle}の状態
 changenr()			数値	現在の変更番号
 char2nr({expr}[, {utf8}])	数値	{expr}の先頭文字のASCII/UTF8コード
 cindent({lnum})			数値	{lnum}行目のCインデント量
@@ -2018,22 +2018,22 @@ delete({fname} [, {flags}])	数値	ファイルやディレクトリ{fname}を�
 did_filetype()			数値	FileTypeのautocommandが実行されたか?
 diff_filler({lnum})		数値	差分モードで{lnum}に挿入された行
 diff_hlID({lnum}, {col})	数値	差分モードで{lnum}/{col}位置の強調
-empty({expr})			数値	{expr}が空ならTRUE
+empty({expr})			数値	{expr}が空なら|TRUE|
 escape({string}, {chars})	文字列	{string}内の{chars}を '\' でエスケープ
 eval({string})			任意	{string}を評価し、値を得る
-eventhandler()			数値	イベントハンドラの内側ならTRUE
+eventhandler()			数値	イベントハンドラの内側なら|TRUE|
 executable({expr})		数値	実行可能な{expr}が存在するなら1
 execute({command})		String	execute {command} and get the output
 exepath({expr})			文字列	コマンド {expr} のフルパス
-exists({var})			数値	変数{var}が存在したらTRUE
+exists({var})			数値	変数{var}が存在したら|TRUE|
 extend({expr1}, {expr2} [, {expr3}])
 				リスト/辞書 {expr1}に{expr2}の要素を挿入
 exp({expr})			浮動小数点数	{expr}の指数
 expand({expr} [, {nosuf} [, {list}]])
 				任意	{expr}内の特別なキーワードを展開
 feedkeys({string} [, {mode}])	数値	先行入力バッファにキーシーケンスを追加
-filereadable({file})		数値	{file}が読みこみ可能ならTRUE
-filewritable({file})		数値	{file}が書き込み可能ならTRUE
+filereadable({file})		数値	{file}が読みこみ可能なら|TRUE|
+filewritable({file})		数値	{file}が書き込み可能なら|TRUE|
 filter({expr1}, {expr2})	リスト/辞書  {expr2}が0となる要素を{expr1}から
 					とり除く
 finddir({name}[, {path}[, {count}]])
@@ -2108,18 +2108,18 @@ glob2regpat({expr})		文字列  globパターンを検索パターンに変換
 globpath({path}, {expr} [, {nosuf} [, {list} [, {alllinks}]]])
 				文字列	{path}の全ディレクトリに対し
 					glob({expr})を行う
-has({feature})			数値	機能{feature}がサポートならばTRUE
-has_key({dict}, {key})		数値	{dict}が要素{key}を持つならTRUE
+has({feature})			数値	機能{feature}がサポートならば|TRUE|
+has_key({dict}, {key})		数値	{dict}が要素{key}を持つなら|TRUE|
 haslocaldir([{winnr} [, {tabnr}]])
 				数値	現在のウィンドウで|:lcd|が実行された
-					ならTRUE
+					なら|TRUE|
 hasmapto({what} [, {mode} [, {abbr}]])
-				数値	{what}へのマッピングが存在するならTRUE
+				数値	{what}のマッピングが存在するなら|TRUE|
 histadd({history}, {item})	文字列	ヒストリに追加
 histdel({history} [, {item}])	文字列	ヒストリからitemを削除
 histget({history} [, {index}])	文字列	ヒストリから{index}アイテムを取得
 histnr({history})		数値	ヒストリの数
-hlexists({name})		数値	highlight group {name}が存在したらTRUE
+hlexists({name})		数値	highlight group {name}が存在したら|TRUE|
 hlID({name})			数値	highlight group {name}のID
 hostname()			文字列	vimが動作しているマシンの名前
 iconv({expr}, {from}, {to})	文字列	{expr}のエンコーディングを変換する
@@ -2136,9 +2136,9 @@ inputsave()			数値	先行入力を保存し、クリアする
 inputsecret({prompt} [, {text}]) 文字列	input()だがテキストを隠す
 insert({list}, {item} [, {idx}]) リスト	{list}に要素{item}を挿入 [{idx}の前]
 invert({expr})			数値	ビット反転
-isdirectory({directory})	数値	{directory}がディレクトリならばTRUE
-islocked({expr})		数値	{expr}がロックされているならTRUE
-isnan({expr})			数値	{expr}がNanならばTRUE
+isdirectory({directory})	数値	{directory}がディレクトリならば|TRUE|
+islocked({expr})		数値	{expr}がロックされているなら|TRUE|
+isnan({expr})			数値	{expr}がNaNならば|TRUE|
 items({dict})			リスト	{dict}のキーと値のペアを取得
 job_getchannel({job})		チャンネル  {job}のチャンネルハンドルを取得
 job_info({job})			辞書	{job}についての情報を取得

--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -1956,7 +1956,7 @@ buflisted({expr})		数値	バッファ{expr}がリストにあるならTRUE
 bufloaded({expr})		数値	バッファ{expr}がロード済みならTRUE
 bufname({expr})			文字列	バッファ{expr}の名前
 bufnr({expr} [, {create}])	数値	バッファ{expr}の番号
-bufwinid({expr})		Number	window ID of buffer {expr}
+bufwinid({expr})		数値	バッファ{expr}のウィンドウID
 bufwinnr({nr})			数値	バッファ{nr}のウィンドウ番号
 byte2line({byte})		数値	{byte}番目のバイトの行番号
 byteidx({expr}, {nr})		数値	{expr}の{nr}文字目のバイトインデックス
@@ -1964,7 +1964,7 @@ byteidxcomp({expr}, {nr})	数値	{expr}の{nr}文字目のバイトインデッ�
 call({func}, {arglist} [, {dict}])
 				任意	引数{arglist}をつけて{func}を呼ぶ
 ceil({expr})			浮動小数点数	{expr} を切り上げる
-ch_canread({handle})		Number	check if there is something to read
+ch_canread({handle})		数値	何か読むものがあるかをチェックする
 ch_close({handle})		なし	{handle} を閉じる
 ch_close_in({handle})		なし	{handle} の入力を閉じる
 ch_evalexpr({handle}, {expr} [, {options}])
@@ -1973,7 +1973,7 @@ ch_evalexpr({handle}, {expr} [, {options}])
 ch_evalraw({handle}, {string} [, {options}])
 				任意	{handle} に {string} を送り応答を生の
 					文字列として評価する
-ch_getbufnr({handle}, {what})	Number	{handle}/{what} に割り当てられたバッ
+ch_getbufnr({handle}, {what})	数値	{handle}/{what} に割り当てられたバッ
 					ファ番号を得る
 ch_getjob({channel})		ジョブ	{channel} の Job を得る
 ch_info({handle})		文字列	チャンネル {handle} に関する情報を得る
@@ -1990,9 +1990,9 @@ ch_sendexpr({handle}, {expr} [, {options}])
 ch_sendraw({handle}, {string} [, {options}])
 				任意	{string}をrawチャンネル{handle}に送る
 ch_setoptions({handle}, {options})
-				なし	set options for {handle}
+				なし	{handle}にオプションを設定する
 ch_status({handle} [, {options}])
-				文字列	status of channel {handle}
+				文字列	チャンネル{handle}のステータス
 changenr()			数値	現在の変更番号
 char2nr({expr}[, {utf8}])	数値	{expr}の先頭文字のASCII/UTF8コード
 cindent({lnum})			数値	{lnum}行目のCインデント量
@@ -2138,7 +2138,7 @@ insert({list}, {item} [, {idx}]) リスト	{list}に要素{item}を挿入 [{idx}
 invert({expr})			数値	ビット反転
 isdirectory({directory})	数値	{directory}がディレクトリならばTRUE
 islocked({expr})		数値	{expr}がロックされているならTRUE
-isnan({expr})			Number	|TRUE| if {expr} is NaN
+isnan({expr})			数値	{expr}がNanならばTRUE
 items({dict})			リスト	{dict}のキーと値のペアを取得
 job_getchannel({job})		チャンネル  {job}のチャンネルハンドルを取得
 job_info({job})			辞書	{job}についての情報を取得
@@ -2326,22 +2326,22 @@ tanh({expr})			浮動小数点数	{expr}のハイパボリックタンジェ
 tempname()			文字列	テンポラリファイルの名前
 test_alloc_fail({id}, {countdown}, {repeat})
 				なし	メモリの確保を失敗にさせる
-test_autochdir()		none	enable 'autochdir' during startup
-test_disable_char_avail({expr}) none	test without typeahead
-test_garbagecollect_now()	none	free memory right now for testing
-test_null_channel()		Channel	null value for testing
-test_null_dict()		Dict	null value for testing
-test_null_job()			Job	null value for testing
-test_null_list()		List	null value for testing
-test_null_partial()		Funcref	null value for testing
-test_null_string()		String	null value for testing
-test_settime({expr})		none	set current time for testing
-timer_info([{id}])		List	information about timers
-timer_pause({id}, {pause})	none	pause or unpause a timer
+test_autochdir()		なし	起動時に 'autochdir' を有効にする
+test_disable_char_avail({expr}) なし	先行入力のないテスト
+test_garbagecollect_now()	なし	テスト用に直ちにメモリを解放する
+test_null_channel()		チャンネル	テスト用のnull値
+test_null_dict()		辞書	テスト用のnull値
+test_null_job()			ジョブ	テスト用のnull値
+test_null_list()		リスト	テスト用のnull値
+test_null_partial()		Funcref	テスト用のnull値
+test_null_string()		文字列	テスト用のnull値
+test_settime({expr})		なし	テスト用に現在の時刻を設定する
+timer_info([{id}])		リスト	タイマーに関する情報
+timer_pause({id}, {pause})	なし	タイマーの一時停止または一時停止解除
 timer_start({time}, {callback} [, {options}])
-				Number	create a timer
-timer_stop({timer})		none	stop a timer
-timer_stopall()			none	stop all timers
+				数値	タイマーを作成する
+timer_stop({timer})		なし	タイマーを停止する
+timer_stopall()			なし	すべてのタイマーを停止する
 tolower({expr})			文字列	文字列{expr}を小文字にする
 toupper({expr})			文字列	文字列{expr}を大文字にする
 tr({src}, {fromstr}, {tostr})	文字列	{src}中に現れる文字{fromstr}を{tostr}
@@ -2356,11 +2356,11 @@ values({dict})			リスト	{dict}の値のリスト
 virtcol({expr})			数値	カーソルのスクリーンカラム位置
 visualmode([expr])		文字列	最後に使われたビジュアルモード
 wildmenumode()			数値	'wildmenu' モードが有効かどうか
-win_findbuf({bufnr})		List	find windows containing {bufnr}
-win_getid([{win} [, {tab}]])	Number	get window ID for {win} in {tab}
-win_gotoid({expr})		Number	go to window with ID {expr}
-win_id2tabwin({expr})		List	get tab and window nr from window ID
-win_id2win({expr})		Number	get window nr from window ID
+win_findbuf({bufnr})		リスト	{bufnr}を含むウィンドウを見つける
+win_getid([{win} [, {tab}]])	数値	{tab}の{win}のウィンドウIDを取得
+win_gotoid({expr})		数値	ID {expr}のウィンドウに行く
+win_id2tabwin({expr})		リスト	ウィンドウIDからタブとウィンドウnr取得
+win_id2win({expr})		数値	ウィンドウIDからウィンドウnr取得
 winbufnr({nr})			数値	ウィンドウ{nr}のバッファ番号
 wincol()			数値	カーソル位置のウィンドウ桁
 winheight({nr})			数値	ウィンドウ{nr}の高さ


### PR DESCRIPTION
Relate: #48 

`execute()`と`funcref()`は@yassuさんに担当していただけるということなのでそのままになっています。