### PR TITLE
Improve syntax highlight

### DIFF
--- a/syntax/help_ja.vim
+++ b/syntax/help_ja.vim
@@ -2,4 +2,4 @@ scriptencoding utf-8
 
 syn match helpVim "Vim バージョン [0-9.a-z]\+"
 syn match helpVim "VIMリファレンス.*"
-syn region helpNotVi start="{Vim" end="}" contains=helpLeadBlank,helpHyperTextJump
+syn region helpNotVi start="{Vim" start="{|+[a-z0-9_]\+|" end="}" contains=helpLeadBlank,helpHyperTextJump

--- a/syntax/help_ja.vim
+++ b/syntax/help_ja.vim
@@ -2,4 +2,4 @@ scriptencoding utf-8
 
 syn match helpVim "Vim バージョン [0-9.a-z]\+"
 syn match helpVim "VIMリファレンス.*"
-syn region helpNotVi start="{Vim" start="{|+[a-z0-9_]\+|" end="}" contains=helpLeadBlank,helpHyperTextJump
+syn region helpNotVi start="{Vim" start="{|++\?[A-Za-z0-9_/()]\+|" end="}" contains=helpLeadBlank,helpHyperTextJump


### PR DESCRIPTION
以下のように、 `{|+foobar|` 形式で始まるものも色づけするようにしてみました。

```
{|+timers| 機能を有効にしてコンパイルしたときのみ有効}
```