### PR TITLE
少数 を 小数点以下 に修正

### DIFF
--- a/doc/usr_41.jax
+++ b/doc/usr_41.jax
@@ -642,7 +642,7 @@ substitute() コマンドの前後にいろいろな処理を入れたりする�
 	round()			丸め
 	ceil()			切り上げ
 	floor()			切り下げ
-	trunc()			少数切り捨て
+	trunc()			小数点以下切り捨て
 	fmod()			除法の余り
 	exp()			指数
 	log()			自然対数 (eを底とする対数)


### PR DESCRIPTION
「少数点」の方も若干使われているようですが、こちらに修正してみました。
