### PR TITLE
Fix Japanese highlight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,8 @@ replace:
 html:
 	rm -rf target/html
 	mkdir -p target/html/doc
-	cp -R syntax target/html
 	cp doc/*.jax vim_faq/*.jax target/html/doc
-	-cd target/html/doc ; vim --cmd "set rtp^=../../../tools" -eu ../../../tools/buildhtml.vim -c "qall!"
+	-cd target/html/doc ; vim -eu ../../../tools/buildhtml.vim -c "qall!"
 
 clean:
 	rm -rf target

--- a/tools/buildhtml.vim
+++ b/tools/buildhtml.vim
@@ -11,9 +11,14 @@ enew!
 source <sfile>:h/untranslated.vim
 source <sfile>:h/makehtml.vim
 
+let s:tools_dir = expand('<sfile>:p:h')
+let s:proj_dir = expand('<sfile>:p:h:h')
+
 function! s:main()
+  " for the lastest help syntax
+  let &runtimepath = s:tools_dir . ',' . &runtimepath
   " for ja custom syntax
-  let &runtimepath .= ',' . expand('<sfile>:p:h')
+  let &runtimepath .= ',' . s:proj_dir
   call s:BuildHtml()
 endfunction
 


### PR DESCRIPTION
help_ja.vim was not loaded after d5e6ad9adca2009089c11cd0662e08c2f42f3e0d.

Also note that `<sfile>` is replaced with the function name when executing
a function.  It is different from when executing a script not inside a
function.