### PR TITLE
Support tag aliases (Fix #124)

### DIFF
--- a/tools/buildhtml.vim
+++ b/tools/buildhtml.vim
@@ -8,6 +8,7 @@ let g:html_no_progress = 1
 
 enew!
 
+source <sfile>:h/tag_aliases.vim
 source <sfile>:h/untranslated.vim
 source <sfile>:h/makehtml.vim
 

--- a/tools/makehtml.vim
+++ b/tools/makehtml.vim
@@ -170,6 +170,9 @@ function! s:MakeLink(lang, hlname, tagname, conceal)
     endif
   endif
   let tags = s:GetTags(a:lang)
+  if !has_key(tags, tagname) && has_key(g:makehtml_tag_aliases, tagname)
+    let tagname = g:makehtml_tag_aliases[tagname]
+  endif
   if has_key(tags, tagname)
     let href = tags[tagname]["html"]
     if tagname !~ '\.txt$' && tagname != "help-tags"

--- a/tools/tag_aliases.vim
+++ b/tools/tag_aliases.vim
@@ -1,0 +1,3 @@
+let g:makehtml_tag_aliases = {
+  \ '=~': 'expr-=~',
+  \ }


### PR DESCRIPTION
#124 の `=~` のタグがない問題は、untranslated.vim と同じような感じで、手動で置き換えてしまうのがよいのではないかと思います。