### PR TITLE
Correct the description for getcompletion()

### DIFF
--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -4240,7 +4240,7 @@ getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
 		command		Exコマンド (および引数)
 		compiler	コンパイラ
 		cscope		|:cscope|のサブオプション
-		dir		辞書名
+		dir		ディレクトリ名
 		environment	環境変数名
 		event		自動コマンドのイベント
 		expression	Vim式


### PR DESCRIPTION
「辞書名」→「ディレクトリ名」

`path` にあわせて「ディレクトリ名」表記にしました。問題があれば教えてください。