### PR TITLE
原文の変更に追随 (usr_07)

### DIFF
--- a/doc/usr_07.jax
+++ b/doc/usr_07.jax
@@ -1,4 +1,4 @@
-*usr_07.txt*	For Vim バージョン 8.0.  Last change: 2006 Apr 24
+*usr_07.txt*	For Vim バージョン 8.0.  Last change: 2017 Aug 11
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_07.txt
+++ b/en/usr_07.txt
@@ -1,4 +1,4 @@
-*usr_07.txt*	For Vim version 8.0.  Last change: 2006 Apr 24
+*usr_07.txt*	For Vim version 8.0.  Last change: 2017 Aug 11
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -355,7 +355,7 @@ a sentence to the f register (f for First): >
 	"fyas
 
 The "yas" command yanks a sentence like before.  It's the "f that tells Vim
-the text should be place in the f register.  This must come just before the
+the text should be placed in the f register.  This must come just before the
 yank command.
    Now yank three whole lines to the l register (l for line): >
 


### PR DESCRIPTION
"should be placed" は「レジスタ f に置かれるべき(置かれることになる)テキスト」という意味だと思いますが、現状の「"f はテキストをレジスタ f に入れるための指定です。」の方がわかりやすいので、日本語訳には変更を加えませんでした。