### PR TITLE
原文の変更に追随 (usr_12)

### DIFF
--- a/doc/usr_12.jax
+++ b/doc/usr_12.jax
@@ -1,4 +1,4 @@
-*usr_12.txt*	For Vim バージョン 8.0.  Last change: 2007 May 11
+*usr_12.txt*	For Vim バージョン 8.0.  Last change: 2017 Aug 11
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_12.txt
+++ b/en/usr_12.txt
@@ -1,4 +1,4 @@
-*usr_12.txt*	For Vim version 8.0.  Last change: 2007 May 11
+*usr_12.txt*	For Vim version 8.0.  Last change: 2017 Aug 11
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -290,7 +290,7 @@ command: >
 The line range "%" is used, thus this works on the whole file.  The pattern
 that the ":substitute" command matches with is "\s\+$".  This finds white
 space characters (\s), 1 or more of them (\+), before the end-of-line ($).
-Later will be explained how you write patterns like this |usr_27.txt|.
+Later will be explained how you write patterns like this, see |usr_27.txt|.
    The "to" part of the substitute command is empty: "//".  Thus it replaces
 with nothing, effectively deleting the matched white space.
 


### PR DESCRIPTION
日本語訳は「このようなパターンの書き方は |usr_27.txt| で説明されています。」と自然なので、
他で使っている「 |usr_27.txt| を参照」のようにはしませんでした。
