### PR TITLE
原文の変更に追随 (usr_41)

### DIFF
--- a/doc/usr_41.jax
+++ b/doc/usr_41.jax
@@ -1,4 +1,4 @@
-*usr_41.txt*	For Vim バージョン 8.0.  Last change: 2017 Mar 09
+*usr_41.txt*	For Vim バージョン 8.0.  Last change: 2017 Aug 22
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -867,6 +867,7 @@ GUI:						*gui-functions*
 
 Vimサーバー:					*server-functions*
 	serverlist()		サーバー名のリストを返す
+	remote_startserve()	サーバーをスタートする
 	remote_send()		Vimサーバーにコマンド文字を送る
 	remote_expr()		Vimサーバーで式を評価する
 	server2client()		Vimサーバーのクライアントに応答を返す
@@ -898,6 +899,7 @@ Vimサーバー:					*server-functions*
 	assert_true()		式がtrueかどうかテストする
 	assert_exception()	コマンドが例外を投げる事をテストする
 	assert_fails()		関数呼び出しが失敗する事をテストする
+	assert_report()		テストの失敗をレポートする
 	test_alloc_fail()	メモリの確保を失敗させる
 	test_autochdir()	起動中に 'autochdir' を有効にする
 	test_override()		Vimの内部処理を置き換えてテストする
@@ -941,6 +943,23 @@ Jobs:		    			        *job-functions*
 	job_getchannel()	Job が使用する channel を取得する
 	job_info()		Job の情報を取得する
 	job_setoptions()	Job のオプションを設定する
+
+Terminal window:				*terminal-functions*
+	term_start()		ターミナルウィンドウを開いてジョブを開始する
+	term_list()		ターミナルバッファのリストを取得する
+	term_sendkeys()		ターミナルにキーストロークを送る
+	term_wait()		スクリーンがアップデートされるのを待つ
+	term_getjob()		ターミナルに関連するジョブを取得する
+	term_scrape()		ターミナルスクリーンの列を取得する
+	term_getline()		ターミナルからテキストの行を取得する
+	term_getattr()		{what} の属性値を取得する
+	term_getcursor()	ターミナルのカーソル位置を取得する
+	term_getscrolled()	ターミナルのスクロール数を取得する
+	term_getaltscreen()	代替のスクリーンフラグを取得する
+	term_getsize()		ターミナルのサイズを取得する
+	term_getstatus()	ターミナルのステータスを取得する
+	term_gettitle()		ターミナルのタイトルを取得する
+	term_gettty()		ターミナルの tty 名を取得する
 
 Timers:						*timer-functions*
 	timer_start()		タイマーを作る
@@ -2247,8 +2266,8 @@ exists(":Cmd")		ユーザー定義コマンドが既にあるかどうかをチ�
 	endif
 
 ここでは二つのグローバル変数が使われています:
-  no_plugin_maps	すべてのファイルタイププラグインのマップを無効化
-  no_mail_maps		特定のファイルタイププラグインのマップを無効化
+  |no_plugin_maps|	すべてのファイルタイププラグインのマップを無効化
+  |no_mail_maps|	"mail" ファイルタイプのマップを無効化
 
 
 ユーザー定義コマンド

--- a/en/usr_41.txt
+++ b/en/usr_41.txt
@@ -1,4 +1,4 @@
-*usr_41.txt*	For Vim version 8.0.  Last change: 2017 Mar 09
+*usr_41.txt*	For Vim version 8.0.  Last change: 2017 Aug 22
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -889,6 +889,7 @@ GUI:						*gui-functions*
 
 Vim server:					*server-functions*
 	serverlist()		return the list of server names
+	remote_startserve()	run a server
 	remote_send()		send command characters to a Vim server
 	remote_expr()		evaluate an expression in a Vim server
 	server2client()		send a reply to a client of a Vim server
@@ -920,6 +921,7 @@ Testing:				    *test-functions*
 	assert_true()		assert that an expression is true
 	assert_exception()	assert that a command throws an exception
 	assert_fails()		assert that a function call fails
+	assert_report()		report a test failure
 	test_alloc_fail()	make memory allocation fail
 	test_autochdir()	enable 'autochdir' during startup
 	test_override()		test with Vim internal overrides
@@ -963,6 +965,23 @@ Jobs:		    			        *job-functions*
 	job_getchannel()	get the channel used by a job
 	job_info()		get information about a job
 	job_setoptions()	set options for a job
+
+Terminal window:				*terminal-functions*
+	term_start()		open a terminal window and run a job
+	term_list()		get the list of terminal buffers
+	term_sendkeys()		send keystrokes to a terminal
+	term_wait()		wait for screen to be updated
+	term_getjob()		get the job associated with a terminal
+	term_scrape()		get row of a terminal screen
+	term_getline()		get a line of text from a terminal
+	term_getattr()		get the value of attribute {what}
+	term_getcursor()	get the cursor position of a terminal
+	term_getscrolled()	get the scroll count of a terminal
+	term_getaltscreen()	get the alternate screen flag
+	term_getsize()		get the size of a terminal
+	term_getstatus()	get the status of a terminal
+	term_gettitle()		get the title of a terminal
+	term_gettty()		get the tty name of a terminal
 
 Timers:						*timer-functions*
 	timer_start()		create a timer
@@ -2275,8 +2294,8 @@ plugin for the mail filetype: >
 	endif
 
 Two global variables are used:
-no_plugin_maps		disables mappings for all filetype plugins
-no_mail_maps		disables mappings for a specific filetype
+|no_plugin_maps|	disables mappings for all filetype plugins
+|no_mail_maps|		disables mappings for the "mail" filetype
 
 
 USER COMMANDS


### PR DESCRIPTION
no_mail_maps は「"mail" ファイルタイプのマップを無効化」としましたが、
旧訳のように (plugins はついていなけれども)「"mail" ファイルタイププラグイン」
とすべきか迷いました。

確認をお願いします。
