### PR TITLE
"vim_faq.txt" no longer exists

### DIFF
--- a/doc/help.jax
+++ b/doc/help.jax
@@ -207,9 +207,6 @@ GUI ~
 |pi_vimball.txt|   Vim script インストーラを作成する
 |pi_zip.txt|       Zip アーカイブエクスプローラー
 
-その他 ~
-|vim_faq.txt|	FAQ
-
 LOCAL ADDITIONS:				*local-additions*
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
`vim_faq.txt` は既に存在しないために(?)無効なタグになっています。