### PR TITLE
"警告:" をハイライト.

### DIFF
--- a/syntax/help_ja.vim
+++ b/syntax/help_ja.vim
@@ -3,3 +3,4 @@ scriptencoding utf-8
 syn match helpVim "Vim バージョン [0-9.a-z]\+"
 syn match helpVim "VIMリファレンス.*"
 syn region helpNotVi start="{Vim" start="{|++\?[A-Za-z0-9_/()]\+|" end="}" contains=helpLeadBlank,helpHyperTextJump
+syn match helpWarning "\<警告:"


### PR DESCRIPTION
"警告:" をハイライト表示します。

原文ではコロンを含まない "WARNING" キーワードもハイライトされますが、日本語本文では区別がつかないためコロンを含む場合のみが対象です。

* vim-jp/vimdoc-ja#43: Warning の訳についての古い(2012年)議論