### PR TITLE
Just update the Vim version in the first line from 8.0 to 8.1

### DIFF
--- a/doc/debug.jax
+++ b/doc/debug.jax
@@ -1,4 +1,4 @@
-*debug.txt*     For Vim バージョン 8.0.  Last change: 2017 Jul 15
+*debug.txt*     For Vim バージョン 8.1.  Last change: 2017 Jul 15
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/ft_sql.jax
+++ b/doc/ft_sql.jax
@@ -1,4 +1,4 @@
-*ft_sql.txt*	For Vim バージョン 8.0.  Last change: 2013 May 15
+*ft_sql.txt*	For Vim バージョン 8.1.  Last change: 2013 May 15
 
 by David Fishburn
 

--- a/doc/gui_w32.jax
+++ b/doc/gui_w32.jax
@@ -1,4 +1,4 @@
-*gui_w32.txt*   For Vim バージョン 8.0.  Last change: 2017 Oct 27
+*gui_w32.txt*   For Vim バージョン 8.1.  Last change: 2017 Oct 27
 
 
 		VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/helphelp.jax
+++ b/doc/helphelp.jax
@@ -1,4 +1,4 @@
-*helphelp.txt*	For Vim バージョン 8.0.  Last change: 2017 Mar 19
+*helphelp.txt*	For Vim バージョン 8.1.  Last change: 2017 Mar 19
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/howto.jax
+++ b/doc/howto.jax
@@ -1,4 +1,4 @@
-*howto.txt*	For Vim バージョン 8.0.  Last change: 2006 Apr 02
+*howto.txt*	For Vim バージョン 8.1.  Last change: 2006 Apr 02
 
 
 		  VIMリファレンスマニュアル	  by Bram Moolenaar

--- a/doc/if_lua.jax
+++ b/doc/if_lua.jax
@@ -1,4 +1,4 @@
-*if_lua.txt*    For Vim バージョン 8.0.  Last change: 2015 Oct 16
+*if_lua.txt*    For Vim バージョン 8.1.  Last change: 2015 Oct 16
 
 
 		  VIMリファレンスマニュアル    by Luis Carvalho

--- a/doc/if_sniff.jax
+++ b/doc/if_sniff.jax
@@ -1,4 +1,4 @@
-*if_sniff.txt*	For Vim バージョン 8.0.  Last change: 2016 Feb 27
+*if_sniff.txt*	For Vim バージョン 8.1.  Last change: 2016 Feb 27
 
 
 		  VIMリファレンスマニュアル

--- a/doc/if_tcl.jax
+++ b/doc/if_tcl.jax
@@ -1,4 +1,4 @@
-*if_tcl.txt*    For Vim バージョン 8.0.  Last change: 2016 Jan 01
+*if_tcl.txt*    For Vim バージョン 8.1.  Last change: 2016 Jan 01
 
 
 		  VIMリファレンスマニュアル    by Ingo Wilken

--- a/doc/os_390.jax
+++ b/doc/os_390.jax
@@ -1,4 +1,4 @@
-*os_390.txt*    For Vim バージョン 8.0.  Last change: 2016 Feb 27
+*os_390.txt*    For Vim バージョン 8.1.  Last change: 2016 Feb 27
 
 
 		 VIMリファレンスマニュアル    by Ralf Schandl

--- a/doc/os_amiga.jax
+++ b/doc/os_amiga.jax
@@ -1,4 +1,4 @@
-*os_amiga.txt*  For Vim バージョン 8.0.  Last change: 2010 Aug 14
+*os_amiga.txt*  For Vim バージョン 8.1.  Last change: 2010 Aug 14
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/os_dos.jax
+++ b/doc/os_dos.jax
@@ -1,4 +1,4 @@
-*os_dos.txt*    For Vim バージョン 8.0.  Last change: 2006 Mar 30
+*os_dos.txt*    For Vim バージョン 8.1.  Last change: 2006 Mar 30
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/os_mint.jax
+++ b/doc/os_mint.jax
@@ -1,4 +1,4 @@
-*os_mint.txt*   For Vim バージョン 8.0.  Last change: 2005 Mar 29
+*os_mint.txt*   For Vim バージョン 8.1.  Last change: 2005 Mar 29
 
 
 		  VIMリファレンスマニュアル    by Jens M. Felderhoff

--- a/doc/os_msdos.jax
+++ b/doc/os_msdos.jax
@@ -1,4 +1,4 @@
-*os_msdos.txt*  For Vim バージョン 8.0.  Last change: 2016 Feb 26
+*os_msdos.txt*  For Vim バージョン 8.1.  Last change: 2016 Feb 26
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/os_os2.jax
+++ b/doc/os_os2.jax
@@ -1,4 +1,4 @@
-*os_os2.txt*    For Vim バージョン 8.0.  Last change: 2015 Dec 31
+*os_os2.txt*    For Vim バージョン 8.1.  Last change: 2015 Dec 31
 
 
 		VIMリファレンスマニュアル    by Paul Slootman

--- a/doc/os_qnx.jax
+++ b/doc/os_qnx.jax
@@ -1,4 +1,4 @@
-*os_qnx.txt*    For Vim バージョン 8.0.  Last change: 2005 Mar 29
+*os_qnx.txt*    For Vim バージョン 8.1.  Last change: 2005 Mar 29
 
 
 		VIMリファレンスマニュアル    by Julian Kinraid

--- a/doc/os_risc.jax
+++ b/doc/os_risc.jax
@@ -1,4 +1,4 @@
-*os_risc.txt*   For Vim バージョン 8.0.  Last change: 2011 May 10
+*os_risc.txt*   For Vim バージョン 8.1.  Last change: 2011 May 10
 
 
 		VIMリファレンスマニュアル    by Thomas Leonard

--- a/doc/os_unix.jax
+++ b/doc/os_unix.jax
@@ -1,4 +1,4 @@
-*os_unix.txt*   For Vim バージョン 8.0.  Last change: 2005 Mar 29
+*os_unix.txt*   For Vim バージョン 8.1.  Last change: 2005 Mar 29
 
 
 		  VIMリファレンスマニュアル	  by Bram Moolenaar

--- a/doc/os_win32.jax
+++ b/doc/os_win32.jax
@@ -1,4 +1,4 @@
-*os_win32.txt*  For Vim バージョン 8.0.  Last change: 2017 Mar 21
+*os_win32.txt*  For Vim バージョン 8.1.  Last change: 2017 Mar 21
 
 
 		  VIMリファレンスマニュアル    by George Reilly

--- a/doc/pi_gzip.jax
+++ b/doc/pi_gzip.jax
@@ -1,4 +1,4 @@
-*pi_gzip.txt*   For Vim バージョン 8.0.  Last change: 2016 Nov 06
+*pi_gzip.txt*   For Vim バージョン 8.1.  Last change: 2016 Nov 06
 
 
 		VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/pi_paren.jax
+++ b/doc/pi_paren.jax
@@ -1,4 +1,4 @@
-*pi_paren.txt*  For Vim バージョン 8.0.  Last change: 2013 May 08
+*pi_paren.txt*  For Vim バージョン 8.1.  Last change: 2013 May 08
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/pi_spec.jax
+++ b/doc/pi_spec.jax
@@ -1,4 +1,4 @@
-*pi_spec.txt*   For Vim バージョン 8.0.  Last change: 2006 Apr 24
+*pi_spec.txt*   For Vim バージョン 8.1.  Last change: 2006 Apr 24
 
 by Gustavo Niemeyer ~
 

--- a/doc/pi_tar.jax
+++ b/doc/pi_tar.jax
@@ -1,4 +1,4 @@
-*pi_tar.txt*	For Vim バージョン 8.0.  Last change: 2013 Apr 17
+*pi_tar.txt*	For Vim バージョン 8.1.  Last change: 2013 Apr 17
 
 		       +====================+
 		       | Tar File Interface |

--- a/doc/pi_vimball.jax
+++ b/doc/pi_vimball.jax
@@ -1,4 +1,4 @@
-*pi_vimball.txt*	For Vim バージョン 8.0.  Last change: 2016 Apr 11
+*pi_vimball.txt*	For Vim バージョン 8.1.  Last change: 2016 Apr 11
 
 			       ----------------
 			       Vimball Archiver

--- a/doc/recover.jax
+++ b/doc/recover.jax
@@ -1,4 +1,4 @@
-*recover.txt*   For Vim バージョン 8.0.  Last change: 2014 Mar 27
+*recover.txt*   For Vim バージョン 8.1.  Last change: 2014 Mar 27
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/rileft.jax
+++ b/doc/rileft.jax
@@ -1,4 +1,4 @@
-*rileft.txt*    For Vim バージョン 8.0.  Last change: 2006 Apr 24
+*rileft.txt*    For Vim バージョン 8.1.  Last change: 2006 Apr 24
 
 
 		VIMリファレンスマニュアル    by Avner Lottem

--- a/doc/russian.jax
+++ b/doc/russian.jax
@@ -1,4 +1,4 @@
-*russian.txt*   For Vim バージョン 8.0.  Last change: 2006 Apr 24
+*russian.txt*   For Vim バージョン 8.1.  Last change: 2006 Apr 24
 
 
 		  VIMリファレンスマニュアル    by Vassily Ragosin

--- a/doc/sign.jax
+++ b/doc/sign.jax
@@ -1,4 +1,4 @@
-*sign.txt*      For Vim バージョン 8.0.  Last change: 2016 Aug 17
+*sign.txt*      For Vim バージョン 8.1.  Last change: 2016 Aug 17
 
 
 		VIMリファレンスマニュアル    by Gordon Prieur

--- a/doc/sponsor.jax
+++ b/doc/sponsor.jax
@@ -1,4 +1,4 @@
-*sponsor.txt*   For Vim バージョン 8.0.  Last change: 2008 Jun 21
+*sponsor.txt*   For Vim バージョン 8.1.  Last change: 2008 Jun 21
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/tips.jax
+++ b/doc/tips.jax
@@ -1,4 +1,4 @@
-*tips.txt*      For Vim バージョン 8.0.  Last change: 2009 Nov 07
+*tips.txt*      For Vim バージョン 8.1.  Last change: 2009 Nov 07
 
 
 		  VIMリファレンスマニュアル	  by Bram Moolenaar

--- a/doc/uganda.jax
+++ b/doc/uganda.jax
@@ -1,4 +1,4 @@
-*uganda.txt*    For Vim バージョン 8.1.  Last change: 2013 Jul 06
+*uganda.txt*    For Vim バージョン 8.1.  Last change: 2018 May 17
 
 
 		  VIMリファレンスマニュアル	  by Bram Moolenaar

--- a/doc/uganda.jax
+++ b/doc/uganda.jax
@@ -1,4 +1,4 @@
-*uganda.txt*    For Vim バージョン 8.0.  Last change: 2013 Jul 06
+*uganda.txt*    For Vim バージョン 8.1.  Last change: 2013 Jul 06
 
 
 		  VIMリファレンスマニュアル	  by Bram Moolenaar

--- a/doc/undo.jax
+++ b/doc/undo.jax
@@ -1,4 +1,4 @@
-*undo.txt*      For Vim バージョン 8.0.  Last change: 2014 May 24
+*undo.txt*      For Vim バージョン 8.1.  Last change: 2014 May 24
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/usr_01.jax
+++ b/doc/usr_01.jax
@@ -1,4 +1,4 @@
-*usr_01.txt*	For Vim バージョン 8.0.  Last change: 2017 Jul 15
+*usr_01.txt*	For Vim バージョン 8.1.  Last change: 2017 Jul 15
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_02.jax
+++ b/doc/usr_02.jax
@@ -1,4 +1,4 @@
-*usr_02.txt*	For Vim バージョン 8.0.  Last change: 2017 Mar 14
+*usr_02.txt*	For Vim バージョン 8.1.  Last change: 2017 Mar 14
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_03.jax
+++ b/doc/usr_03.jax
@@ -1,4 +1,4 @@
-*usr_03.txt*	For Vim バージョン 8.0.  Last change: 2017 Jul 21
+*usr_03.txt*	For Vim バージョン 8.1.  Last change: 2017 Jul 21
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_04.jax
+++ b/doc/usr_04.jax
@@ -1,4 +1,4 @@
-*usr_04.txt*	For Vim バージョン 8.0.  Last change: 2014 Aug 29
+*usr_04.txt*	For Vim バージョン 8.1.  Last change: 2014 Aug 29
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_06.jax
+++ b/doc/usr_06.jax
@@ -1,4 +1,4 @@
-*usr_06.txt*	For Vim バージョン 8.0.  Last change: 2009 Oct 28
+*usr_06.txt*	For Vim バージョン 8.1.  Last change: 2009 Oct 28
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_08.jax
+++ b/doc/usr_08.jax
@@ -1,4 +1,4 @@
-*usr_08.txt*	For Vim バージョン 8.0.  Last change: 2017 Aug 11
+*usr_08.txt*	For Vim バージョン 8.1.  Last change: 2017 Aug 11
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_10.jax
+++ b/doc/usr_10.jax
@@ -1,4 +1,4 @@
-*usr_10.txt*	For Vim バージョン 8.0.  Last change: 2006 Nov 05
+*usr_10.txt*	For Vim バージョン 8.1.  Last change: 2006 Nov 05
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_12.jax
+++ b/doc/usr_12.jax
@@ -1,4 +1,4 @@
-*usr_12.txt*	For Vim バージョン 8.0.  Last change: 2017 Aug 11
+*usr_12.txt*	For Vim バージョン 8.1.  Last change: 2017 Aug 11
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_20.jax
+++ b/doc/usr_20.jax
@@ -1,4 +1,4 @@
-*usr_20.txt*	For Vim バージョン 8.0.  Last change: 2006 Apr 24
+*usr_20.txt*	For Vim バージョン 8.1.  Last change: 2006 Apr 24
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_21.jax
+++ b/doc/usr_21.jax
@@ -1,4 +1,4 @@
-*usr_21.txt*	For Vim バージョン 8.0.  Last change: 2012 Nov 02
+*usr_21.txt*	For Vim バージョン 8.1.  Last change: 2012 Nov 02
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_22.jax
+++ b/doc/usr_22.jax
@@ -1,4 +1,4 @@
-*usr_22.txt*	For Vim バージョン 8.0.  Last change: 2016 Dec 13
+*usr_22.txt*	For Vim バージョン 8.1.  Last change: 2016 Dec 13
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_23.jax
+++ b/doc/usr_23.jax
@@ -1,4 +1,4 @@
-*usr_23.txt*	For Vim バージョン 8.0.  Last change: 2006 Apr 24
+*usr_23.txt*	For Vim バージョン 8.1.  Last change: 2006 Apr 24
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_25.jax
+++ b/doc/usr_25.jax
@@ -1,4 +1,4 @@
-*usr_25.txt*	For Vim バージョン 8.0.  Last change: 2016 Mar 28
+*usr_25.txt*	For Vim バージョン 8.1.  Last change: 2016 Mar 28
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_26.jax
+++ b/doc/usr_26.jax
@@ -1,4 +1,4 @@
-*usr_26.txt*	For Vim バージョン 8.0.  Last change: 2006 Apr 24
+*usr_26.txt*	For Vim バージョン 8.1.  Last change: 2006 Apr 24
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_28.jax
+++ b/doc/usr_28.jax
@@ -1,4 +1,4 @@
-*usr_28.txt*	For Vim バージョン 8.0.  Last change: 2008 Jun 14
+*usr_28.txt*	For Vim バージョン 8.1.  Last change: 2008 Jun 14
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_29.jax
+++ b/doc/usr_29.jax
@@ -1,4 +1,4 @@
-*usr_29.txt*	For Vim バージョン 8.0.  Last change: 2016 Feb 27
+*usr_29.txt*	For Vim バージョン 8.1.  Last change: 2016 Feb 27
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_30.jax
+++ b/doc/usr_30.jax
@@ -1,4 +1,4 @@
-*usr_30.txt*	For Vim バージョン 8.0.  Last change: 2007 Nov 10
+*usr_30.txt*	For Vim バージョン 8.1.  Last change: 2007 Nov 10
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_31.jax
+++ b/doc/usr_31.jax
@@ -1,4 +1,4 @@
-*usr_31.txt*	For Vim バージョン 8.0.  Last change: 2007 May 08
+*usr_31.txt*	For Vim バージョン 8.1.  Last change: 2007 May 08
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_32.jax
+++ b/doc/usr_32.jax
@@ -1,4 +1,4 @@
-*usr_32.txt*	For Vim バージョン 8.0.  Last change: 2010 Jul 20
+*usr_32.txt*	For Vim バージョン 8.1.  Last change: 2010 Jul 20
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_40.jax
+++ b/doc/usr_40.jax
@@ -1,4 +1,4 @@
-*usr_40.txt*	For Vim バージョン 8.0.  Last change: 2013 Aug 05
+*usr_40.txt*	For Vim バージョン 8.1.  Last change: 2013 Aug 05
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_42.jax
+++ b/doc/usr_42.jax
@@ -1,4 +1,4 @@
-*usr_42.txt*	For Vim バージョン 8.0.  Last change: 2008 May 05
+*usr_42.txt*	For Vim バージョン 8.1.  Last change: 2008 May 05
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_43.jax
+++ b/doc/usr_43.jax
@@ -1,4 +1,4 @@
-*usr_43.txt*	For Vim バージョン 8.0.  Last change: 2015 Oct 23
+*usr_43.txt*	For Vim バージョン 8.1.  Last change: 2015 Oct 23
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_44.jax
+++ b/doc/usr_44.jax
@@ -1,4 +1,4 @@
-*usr_44.txt*	For Vim バージョン 8.0.  Last change: 2017 May 06
+*usr_44.txt*	For Vim バージョン 8.1.  Last change: 2017 May 06
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_45.jax
+++ b/doc/usr_45.jax
@@ -1,4 +1,4 @@
-*usr_45.txt*	For Vim バージョン 8.0.  Last change: 2008 Nov 15
+*usr_45.txt*	For Vim バージョン 8.1.  Last change: 2008 Nov 15
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_90.jax
+++ b/doc/usr_90.jax
@@ -1,4 +1,4 @@
-*usr_90.txt*	For Vim バージョン 8.0.  Last change: 2008 Sep 10
+*usr_90.txt*	For Vim バージョン 8.1.  Last change: 2008 Sep 10
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/usr_toc.jax
+++ b/doc/usr_toc.jax
@@ -1,4 +1,4 @@
-*usr_toc.txt*	For Vim バージョン 8.0.  Last change: 2016 Mar 25
+*usr_toc.txt*	For Vim バージョン 8.1.  Last change: 2016 Mar 25
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/doc/vi_diff.jax
+++ b/doc/vi_diff.jax
@@ -1,4 +1,4 @@
-*vi_diff.txt*   For Vim バージョン 8.0.  Last change: 2016 Aug 16
+*vi_diff.txt*   For Vim バージョン 8.1.  Last change: 2016 Aug 16
 
 
 		  VIMリファレンスマニュアル	  by Bram Moolenaar

--- a/doc/visual.jax
+++ b/doc/visual.jax
@@ -1,4 +1,4 @@
-*visual.txt*    For Vim バージョン 8.0.  Last change: 2017 Sep 02
+*visual.txt*    For Vim バージョン 8.1.  Last change: 2017 Sep 02
 
 
 		VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/workshop.jax
+++ b/doc/workshop.jax
@@ -1,4 +1,4 @@
-*workshop.txt*  For Vim バージョン 8.0.  Last change: 2013 Jul 06
+*workshop.txt*  For Vim バージョン 8.1.  Last change: 2013 Jul 06
 
 
 		VIM リファレンスマニュアル    by Gordon Prieur

--- a/en/debug.txt
+++ b/en/debug.txt
@@ -1,4 +1,4 @@
-*debug.txt*     For Vim version 8.0.  Last change: 2017 Jul 15
+*debug.txt*     For Vim version 8.1.  Last change: 2017 Jul 15
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/en/ft_sql.txt
+++ b/en/ft_sql.txt
@@ -1,4 +1,4 @@
-*ft_sql.txt*	For Vim version 8.0.  Last change: 2013 May 15
+*ft_sql.txt*	For Vim version 8.1.  Last change: 2013 May 15
 
 by David Fishburn
 

--- a/en/gui_w32.txt
+++ b/en/gui_w32.txt
@@ -1,4 +1,4 @@
-*gui_w32.txt*   For Vim version 8.0.  Last change: 2017 Oct 27
+*gui_w32.txt*   For Vim version 8.1.  Last change: 2017 Oct 27
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/en/helphelp.txt
+++ b/en/helphelp.txt
@@ -1,4 +1,4 @@
-*helphelp.txt*	For Vim version 8.0.  Last change: 2017 Mar 19
+*helphelp.txt*	For Vim version 8.1.  Last change: 2017 Mar 19
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/en/howto.txt
+++ b/en/howto.txt
@@ -1,4 +1,4 @@
-*howto.txt*	For Vim version 8.0.  Last change: 2006 Apr 02
+*howto.txt*	For Vim version 8.1.  Last change: 2006 Apr 02
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar

--- a/en/if_lua.txt
+++ b/en/if_lua.txt
@@ -1,4 +1,4 @@
-*if_lua.txt*    For Vim version 8.0.  Last change: 2015 Oct 16
+*if_lua.txt*    For Vim version 8.1.  Last change: 2015 Oct 16
 
 
 		  VIM REFERENCE MANUAL    by Luis Carvalho

--- a/en/if_sniff.txt
+++ b/en/if_sniff.txt
@@ -1,4 +1,4 @@
-*if_sniff.txt*	For Vim version 8.0.  Last change: 2016 Feb 27
+*if_sniff.txt*	For Vim version 8.1.  Last change: 2016 Feb 27
 
 
 		  VIM REFERENCE MANUAL

--- a/en/if_tcl.txt
+++ b/en/if_tcl.txt
@@ -1,4 +1,4 @@
-*if_tcl.txt*    For Vim version 8.0.  Last change: 2016 Jan 01
+*if_tcl.txt*    For Vim version 8.1.  Last change: 2016 Jan 01
 
 
 		  VIM REFERENCE MANUAL    by Ingo Wilken

--- a/en/os_390.txt
+++ b/en/os_390.txt
@@ -1,4 +1,4 @@
-*os_390.txt*    For Vim version 8.0.  Last change: 2016 Feb 27
+*os_390.txt*    For Vim version 8.1.  Last change: 2016 Feb 27
 
 
 		  VIM REFERENCE MANUAL	  by Ralf Schandl

--- a/en/os_amiga.txt
+++ b/en/os_amiga.txt
@@ -1,4 +1,4 @@
-*os_amiga.txt*  For Vim version 8.0.  Last change: 2010 Aug 14
+*os_amiga.txt*  For Vim version 8.1.  Last change: 2010 Aug 14
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/en/os_dos.txt
+++ b/en/os_dos.txt
@@ -1,4 +1,4 @@
-*os_dos.txt*    For Vim version 8.0.  Last change: 2006 Mar 30
+*os_dos.txt*    For Vim version 8.1.  Last change: 2006 Mar 30
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/en/os_mint.txt
+++ b/en/os_mint.txt
@@ -1,4 +1,4 @@
-*os_mint.txt*   For Vim version 8.0.  Last change: 2005 Mar 29
+*os_mint.txt*   For Vim version 8.1.  Last change: 2005 Mar 29
 
 
 		  VIM REFERENCE MANUAL    by Jens M. Felderhoff

--- a/en/os_msdos.txt
+++ b/en/os_msdos.txt
@@ -1,4 +1,4 @@
-*os_msdos.txt*  For Vim version 8.0.  Last change: 2016 Feb 26
+*os_msdos.txt*  For Vim version 8.1.  Last change: 2016 Feb 26
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/en/os_os2.txt
+++ b/en/os_os2.txt
@@ -1,4 +1,4 @@
-*os_os2.txt*    For Vim version 8.0.  Last change: 2015 Dec 31
+*os_os2.txt*    For Vim version 8.1.  Last change: 2015 Dec 31
 
 
 		  VIM REFERENCE MANUAL    by Paul Slootman

--- a/en/os_qnx.txt
+++ b/en/os_qnx.txt
@@ -1,4 +1,4 @@
-*os_qnx.txt*    For Vim version 8.0.  Last change: 2005 Mar 29
+*os_qnx.txt*    For Vim version 8.1.  Last change: 2005 Mar 29
 
 
 		  VIM REFERENCE MANUAL    by Julian Kinraid

--- a/en/os_risc.txt
+++ b/en/os_risc.txt
@@ -1,4 +1,4 @@
-*os_risc.txt*   For Vim version 8.0.  Last change: 2011 May 10
+*os_risc.txt*   For Vim version 8.1.  Last change: 2011 May 10
 
 
 		  VIM REFERENCE MANUAL    by Thomas Leonard

--- a/en/os_unix.txt
+++ b/en/os_unix.txt
@@ -1,4 +1,4 @@
-*os_unix.txt*   For Vim version 8.0.  Last change: 2005 Mar 29
+*os_unix.txt*   For Vim version 8.1.  Last change: 2005 Mar 29
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/en/os_win32.txt
+++ b/en/os_win32.txt
@@ -1,4 +1,4 @@
-*os_win32.txt*  For Vim version 8.0.  Last change: 2017 Mar 21
+*os_win32.txt*  For Vim version 8.1.  Last change: 2017 Mar 21
 
 
 		  VIM REFERENCE MANUAL    by George Reilly

--- a/en/pi_gzip.txt
+++ b/en/pi_gzip.txt
@@ -1,4 +1,4 @@
-*pi_gzip.txt*   For Vim version 8.0.  Last change: 2016 Nov 06
+*pi_gzip.txt*   For Vim version 8.1.  Last change: 2016 Nov 06
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/en/pi_paren.txt
+++ b/en/pi_paren.txt
@@ -1,4 +1,4 @@
-*pi_paren.txt*  For Vim version 8.0.  Last change: 2013 May 08
+*pi_paren.txt*  For Vim version 8.1.  Last change: 2013 May 08
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/en/pi_spec.txt
+++ b/en/pi_spec.txt
@@ -1,4 +1,4 @@
-*pi_spec.txt*   For Vim version 8.0.  Last change: 2006 Apr 24
+*pi_spec.txt*   For Vim version 8.1.  Last change: 2006 Apr 24
 
 by Gustavo Niemeyer ~
 

--- a/en/pi_tar.txt
+++ b/en/pi_tar.txt
@@ -1,4 +1,4 @@
-*pi_tar.txt*	For Vim version 8.0.  Last change: 2013 Apr 17
+*pi_tar.txt*	For Vim version 8.1.  Last change: 2013 Apr 17
 
 		       +====================+
 		       | Tar File Interface |

--- a/en/pi_vimball.txt
+++ b/en/pi_vimball.txt
@@ -1,4 +1,4 @@
-*pi_vimball.txt*	For Vim version 8.0.  Last change: 2016 Apr 11
+*pi_vimball.txt*	For Vim version 8.1.  Last change: 2016 Apr 11
 
 			       ----------------
 			       Vimball Archiver

--- a/en/recover.txt
+++ b/en/recover.txt
@@ -1,4 +1,4 @@
-*recover.txt*   For Vim version 8.0.  Last change: 2014 Mar 27
+*recover.txt*   For Vim version 8.1.  Last change: 2014 Mar 27
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/en/rileft.txt
+++ b/en/rileft.txt
@@ -1,4 +1,4 @@
-*rileft.txt*    For Vim version 8.0.  Last change: 2006 Apr 24
+*rileft.txt*    For Vim version 8.1.  Last change: 2006 Apr 24
 
 
 		  VIM REFERENCE MANUAL    by Avner Lottem

--- a/en/russian.txt
+++ b/en/russian.txt
@@ -1,4 +1,4 @@
-*russian.txt*   For Vim version 8.0.  Last change: 2006 Apr 24
+*russian.txt*   For Vim version 8.1.  Last change: 2006 Apr 24
 
 
 		  VIM REFERENCE MANUAL    by Vassily Ragosin

--- a/en/sign.txt
+++ b/en/sign.txt
@@ -1,4 +1,4 @@
-*sign.txt*      For Vim version 8.0.  Last change: 2016 Aug 17
+*sign.txt*      For Vim version 8.1.  Last change: 2016 Aug 17
 
 
 		  VIM REFERENCE MANUAL    by Gordon Prieur

--- a/en/sponsor.txt
+++ b/en/sponsor.txt
@@ -1,4 +1,4 @@
-*sponsor.txt*   For Vim version 8.0.  Last change: 2008 Jun 21
+*sponsor.txt*   For Vim version 8.1.  Last change: 2008 Jun 21
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/en/tips.txt
+++ b/en/tips.txt
@@ -1,4 +1,4 @@
-*tips.txt*      For Vim version 8.0.  Last change: 2009 Nov 07
+*tips.txt*      For Vim version 8.1.  Last change: 2009 Nov 07
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/en/uganda.txt
+++ b/en/uganda.txt
@@ -1,4 +1,4 @@
-*uganda.txt*    For Vim version 8.0.  Last change: 2013 Jul 06
+*uganda.txt*    For Vim version 8.1.  Last change: 2018 May 17
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/en/undo.txt
+++ b/en/undo.txt
@@ -1,4 +1,4 @@
-*undo.txt*      For Vim version 8.0.  Last change: 2014 May 24
+*undo.txt*      For Vim version 8.1.  Last change: 2014 May 24
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/en/usr_01.txt
+++ b/en/usr_01.txt
@@ -1,4 +1,4 @@
-*usr_01.txt*	For Vim version 8.0.  Last change: 2017 Jul 15
+*usr_01.txt*	For Vim version 8.1.  Last change: 2017 Jul 15
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_02.txt
+++ b/en/usr_02.txt
@@ -1,4 +1,4 @@
-*usr_02.txt*	For Vim version 8.0.  Last change: 2017 Mar 14
+*usr_02.txt*	For Vim version 8.1.  Last change: 2017 Mar 14
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_03.txt
+++ b/en/usr_03.txt
@@ -1,4 +1,4 @@
-*usr_03.txt*	For Vim version 8.0.  Last change: 2017 Jul 21
+*usr_03.txt*	For Vim version 8.1.  Last change: 2017 Jul 21
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_04.txt
+++ b/en/usr_04.txt
@@ -1,4 +1,4 @@
-*usr_04.txt*	For Vim version 8.0.  Last change: 2014 Aug 29
+*usr_04.txt*	For Vim version 8.1.  Last change: 2014 Aug 29
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_06.txt
+++ b/en/usr_06.txt
@@ -1,4 +1,4 @@
-*usr_06.txt*	For Vim version 8.0.  Last change: 2009 Oct 28
+*usr_06.txt*	For Vim version 8.1.  Last change: 2009 Oct 28
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_08.txt
+++ b/en/usr_08.txt
@@ -1,4 +1,4 @@
-*usr_08.txt*	For Vim version 8.0.  Last change: 2017 Aug 11
+*usr_08.txt*	For Vim version 8.1.  Last change: 2017 Aug 11
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_10.txt
+++ b/en/usr_10.txt
@@ -1,4 +1,4 @@
-*usr_10.txt*	For Vim version 8.0.  Last change: 2006 Nov 05
+*usr_10.txt*	For Vim version 8.1.  Last change: 2006 Nov 05
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_12.txt
+++ b/en/usr_12.txt
@@ -1,4 +1,4 @@
-*usr_12.txt*	For Vim version 8.0.  Last change: 2017 Aug 11
+*usr_12.txt*	For Vim version 8.1.  Last change: 2017 Aug 11
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_20.txt
+++ b/en/usr_20.txt
@@ -1,4 +1,4 @@
-*usr_20.txt*	For Vim version 8.0.  Last change: 2006 Apr 24
+*usr_20.txt*	For Vim version 8.1.  Last change: 2006 Apr 24
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_21.txt
+++ b/en/usr_21.txt
@@ -1,4 +1,4 @@
-*usr_21.txt*	For Vim version 8.0.  Last change: 2012 Nov 02
+*usr_21.txt*	For Vim version 8.1.  Last change: 2012 Nov 02
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_22.txt
+++ b/en/usr_22.txt
@@ -1,4 +1,4 @@
-*usr_22.txt*	For Vim version 8.0.  Last change: 2016 Dec 13
+*usr_22.txt*	For Vim version 8.1.  Last change: 2016 Dec 13
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_23.txt
+++ b/en/usr_23.txt
@@ -1,4 +1,4 @@
-*usr_23.txt*	For Vim version 8.0.  Last change: 2006 Apr 24
+*usr_23.txt*	For Vim version 8.1.  Last change: 2006 Apr 24
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_25.txt
+++ b/en/usr_25.txt
@@ -1,4 +1,4 @@
-*usr_25.txt*	For Vim version 8.0.  Last change: 2016 Mar 28
+*usr_25.txt*	For Vim version 8.1.  Last change: 2016 Mar 28
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_26.txt
+++ b/en/usr_26.txt
@@ -1,4 +1,4 @@
-*usr_26.txt*	For Vim version 8.0.  Last change: 2006 Apr 24
+*usr_26.txt*	For Vim version 8.1.  Last change: 2006 Apr 24
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_28.txt
+++ b/en/usr_28.txt
@@ -1,4 +1,4 @@
-*usr_28.txt*	For Vim version 8.0.  Last change: 2008 Jun 14
+*usr_28.txt*	For Vim version 8.1.  Last change: 2008 Jun 14
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_29.txt
+++ b/en/usr_29.txt
@@ -1,4 +1,4 @@
-*usr_29.txt*	For Vim version 8.0.  Last change: 2016 Feb 27
+*usr_29.txt*	For Vim version 8.1.  Last change: 2016 Feb 27
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_30.txt
+++ b/en/usr_30.txt
@@ -1,4 +1,4 @@
-*usr_30.txt*	For Vim version 8.0.  Last change: 2007 Nov 10
+*usr_30.txt*	For Vim version 8.1.  Last change: 2007 Nov 10
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_31.txt
+++ b/en/usr_31.txt
@@ -1,4 +1,4 @@
-*usr_31.txt*	For Vim version 8.0.  Last change: 2007 May 08
+*usr_31.txt*	For Vim version 8.1.  Last change: 2007 May 08
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_32.txt
+++ b/en/usr_32.txt
@@ -1,4 +1,4 @@
-*usr_32.txt*	For Vim version 8.0.  Last change: 2010 Jul 20
+*usr_32.txt*	For Vim version 8.1.  Last change: 2010 Jul 20
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_40.txt
+++ b/en/usr_40.txt
@@ -1,4 +1,4 @@
-*usr_40.txt*	For Vim version 8.0.  Last change: 2013 Aug 05
+*usr_40.txt*	For Vim version 8.1.  Last change: 2013 Aug 05
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_42.txt
+++ b/en/usr_42.txt
@@ -1,4 +1,4 @@
-*usr_42.txt*	For Vim version 8.0.  Last change: 2008 May 05
+*usr_42.txt*	For Vim version 8.1.  Last change: 2008 May 05
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_43.txt
+++ b/en/usr_43.txt
@@ -1,4 +1,4 @@
-*usr_43.txt*	For Vim version 8.0.  Last change: 2015 Oct 23
+*usr_43.txt*	For Vim version 8.1.  Last change: 2015 Oct 23
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_44.txt
+++ b/en/usr_44.txt
@@ -1,4 +1,4 @@
-*usr_44.txt*	For Vim version 8.0.  Last change: 2017 May 06
+*usr_44.txt*	For Vim version 8.1.  Last change: 2017 May 06
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_45.txt
+++ b/en/usr_45.txt
@@ -1,4 +1,4 @@
-*usr_45.txt*	For Vim version 8.0.  Last change: 2008 Nov 15
+*usr_45.txt*	For Vim version 8.1.  Last change: 2008 Nov 15
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_90.txt
+++ b/en/usr_90.txt
@@ -1,4 +1,4 @@
-*usr_90.txt*	For Vim version 8.0.  Last change: 2008 Sep 10
+*usr_90.txt*	For Vim version 8.1.  Last change: 2008 Sep 10
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_toc.txt
+++ b/en/usr_toc.txt
@@ -1,4 +1,4 @@
-*usr_toc.txt*	For Vim version 8.0.  Last change: 2016 Mar 25
+*usr_toc.txt*	For Vim version 8.1.  Last change: 2016 Mar 25
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/vi_diff.txt
+++ b/en/vi_diff.txt
@@ -1,4 +1,4 @@
-*vi_diff.txt*   For Vim version 8.0.  Last change: 2016 Aug 16
+*vi_diff.txt*   For Vim version 8.1.  Last change: 2016 Aug 16
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/en/visual.txt
+++ b/en/visual.txt
@@ -1,4 +1,4 @@
-*visual.txt*    For Vim version 8.0.  Last change: 2017 Sep 02
+*visual.txt*    For Vim version 8.1.  Last change: 2017 Sep 02
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/en/workshop.txt
+++ b/en/workshop.txt
@@ -1,4 +1,4 @@
-*workshop.txt*  For Vim version 8.0.  Last change: 2013 Jul 06
+*workshop.txt*  For Vim version 8.1.  Last change: 2013 Jul 06
 
 
 		  VIM REFERENCE MANUAL    by Gordon Prieur


### PR DESCRIPTION
Issue #207 に記載されているファイルのうち、単に先頭行のVim versionを8.0から8.1に上げればよいものだけをピックアップして修正しました。
一部文字コードの扱いに自信がないものがあったので、以下のファイルは省きました。

- digraph.jax
- farsi.jax
- pi_zip.jax
- hebrew.jax (そもそもファイルが存在しない？)

> 以下PRとは直接関係ないコメント。
> Twitterの翻訳者募集を見て、貢献したいと思い挑戦しました。
> Vimの翻訳もGitHubも不慣れなので、まずは簡単なものだけに留めました。
> Wikiの[Workflow](https://github.com/vim-jp/vimdoc-ja-working/wiki/Workflow)と[Guide](https://github.com/vim-jp/vimdoc-ja-working/wiki/Guide)には一通り目を通したつもりですが、
> もし手順やマナーに関して不適切なものがあればご教示いただけると幸いです。