### PR TITLE
Update farsi from Vim 8.0 to 8.1

### DIFF
--- a/doc/farsi.jax
+++ b/doc/farsi.jax
@@ -1,4 +1,4 @@
-*farsi.txt*     For Vim バージョン 8.0.  Last change: 2015 Aug 29
+*farsi.txt*     For Vim バージョン 8.1.  Last change: 2015 Aug 29
 
 
 		  VIMリファレンスマニュアル    by Mortaza Ghassab Shiran

--- a/en/farsi.txt
+++ b/en/farsi.txt
@@ -1,4 +1,4 @@
-*farsi.txt*     For Vim version 8.0.  Last change: 2015 Aug 29
+*farsi.txt*     For Vim version 8.1.  Last change: 2015 Aug 29
 
 
 		  VIM REFERENCE MANUAL    by Mortaza Ghassab Shiran


### PR DESCRIPTION
For issue #207 
farsi.txt および farsi.jax を Vim 8.1 用に更新しました。
ご確認お願いいたします。