### PR TITLE
Update pi_zip from Vim 8.0 to 8.1

### DIFF
--- a/doc/pi_zip.jax
+++ b/doc/pi_zip.jax
@@ -1,4 +1,4 @@
-*pi_zip.txt*	For Vim バージョン 8.0.  Last change: 2016 Sep 13
+*pi_zip.txt*	For Vim バージョン 8.1.  Last change: 2016 Sep 13
 
 				+====================+
 				| Zip File Interface |

--- a/en/pi_zip.txt
+++ b/en/pi_zip.txt
@@ -1,4 +1,4 @@
-*pi_zip.txt*	For Vim version 8.0.  Last change: 2016 Sep 13
+*pi_zip.txt*	For Vim version 8.1.  Last change: 2016 Sep 13
 
 				+====================+
 				| Zip File Interface |


### PR DESCRIPTION
For issue #207
pi_zip.txt および pi_zip.jax を Vim 8.1 用に更新しました。
ご確認お願いいたします。