### PR TITLE
Update ft_ada from Vim 8.0 to 8.1

### DIFF
--- a/doc/ft_ada.jax
+++ b/doc/ft_ada.jax
@@ -1,4 +1,4 @@
-*ft_ada.txt*	For Vim バージョン 8.0.  Last change: 2010 Jul 20
+*ft_ada.txt*	For Vim バージョン 8.1.  Last change: 2010 Jul 20
 
 
 		    ADAファイルタイププラグイン リファレンスマニュアル~

--- a/en/ft_ada.txt
+++ b/en/ft_ada.txt
@@ -1,4 +1,4 @@
-*ft_ada.txt*	For Vim version 8.0.  Last change: 2010 Jul 20
+*ft_ada.txt*	For Vim version 8.1.  Last change: 2010 Jul 20
 
 
 		    ADA FILE TYPE PLUG-INS REFERENCE MANUAL~
@@ -116,7 +116,7 @@ NOTE: "gnat xref -v" is very tricky to use as it has almost no diagnostic
     then "gnat xref -v *.ad?"
 4)  Project manager support is completely broken - don't even try "gnat xref
     -Padacl.gpr".
-5)  VIM is faster when the tags file is sorted - use "sort --unique
+5)  Vim is faster when the tags file is sorted - use "sort --unique
     --ignore-case --output=tags tags" .
 6)  Remember to insert "!_TAG_FILE_SORTED 2 %sort ui" as first line to mark
     the file assorted.


### PR DESCRIPTION
For issue #207
ft_ada.txt および ft_ada.jax を Vim 8.1 用に更新しました。

"VIM" -> "Vim" の変更については、日本語では既に "Vim"と記述されていました。

ご確認お願いいたします。