### PR TITLE
Update hangulin from Vim 8.0 to 8.1

### DIFF
--- a/doc/hangulin.jax
+++ b/doc/hangulin.jax
@@ -1,4 +1,4 @@
-*hangulin.txt*  For Vim バージョン 8.0.  Last change: 2015 Nov 24
+*hangulin.txt*  For Vim バージョン 8.1.  Last change: 2015 Nov 24
 
 
 		VIMリファレンスマニュアル  by Chi-Deok Hwang and Sung-Hyun Nam
@@ -33,7 +33,7 @@ LANG 変数を、ko, ko_KR.euckR および ko_KR.UTF-8 のような韓国語ロ�
 る必要があります。
 LC_ALL 変数をセットしている場合は、それも韓国語ロケールである必要があります。
 
-VIM リソース
+Vim リソース
 ------------
 'encoding' と 'fileencodings' をセットしたいかもしれません。
 例: >
@@ -56,13 +56,13 @@ VIM_KEYBOARD か HANGUL_KEYBOARD_TYPE 環境変数を使うことによって、
 
 ハングル・フォント
 ------------------
-GTK バージョンの GVIM を使用している場合は 'guifont' と 'guifontwide' をセット
+GTK バージョンの gvim を使用している場合は 'guifont' と 'guifontwide' をセット
 するべきです。
 例: >
     set guifont=Courier\ 12
     set guifontwide=NanumGothicCoding\ 12
 
-Motif もしくは Athena バージョンの GVIM を使用している場合は vimrc 内で
+Motif もしくは Athena バージョンの gvim を使用している場合は vimrc 内で
 'guifontset' をセットするべきです。フォントセットは .Xdefaults ファイル内で指定
 できます。
 
@@ -82,7 +82,7 @@ $HOME/.Xdefaults: >
 
 注意! , (コンマ) か ; (セミコロン)です。
 
-そして ':set guifont' が設定されていてはいけません。もし設定されていると GVim
+そして ':set guifont' が設定されていてはいけません。もし設定されていると gvim
 は ':set guifontset' を無視します。つまり、Vim がフォントセットのサポートなし
 で動作することになり、英語の文字だけが見えることになり、ハングルは正しくは表示
 されなくなります。

--- a/en/hangulin.txt
+++ b/en/hangulin.txt
@@ -1,4 +1,4 @@
-*hangulin.txt*  For Vim version 8.0.  Last change: 2015 Nov 24
+*hangulin.txt*  For Vim version 8.1.  Last change: 2015 Nov 24
 
 
 		  VIM REFERENCE MANUAL    by Chi-Deok Hwang and Sung-Hyun Nam
@@ -6,7 +6,7 @@
 
 Introduction					*hangul*
 ------------
-It is to input hangul, the Korean language, with VIM GUI version.
+It is to input hangul, the Korean language, with Vim GUI version.
 If you have a XIM program, you can use another |+xim| feature.
 Basically, it is for anybody who has no XIM program.
 
@@ -31,7 +31,7 @@ You should set LANG variable to Korean locale such as ko, ko_KR.eucKR
 or ko_KR.UTF-8.
 If you set LC_ALL variable, it should be set to Korean locale also.
 
-VIM resource
+Vim resource
 ------------
 You may want to set 'encoding' and 'fileencodings'.
 Next are examples: >
@@ -53,12 +53,12 @@ If both are set, VIM_KEYBOARD has higher priority.
 
 Hangul Fonts
 ------------
-If you use GTK version of GVIM, you should set 'guifont' and 'guifontwide'.
+If you use GTK version of gvim, you should set 'guifont' and 'guifontwide'.
 For example: >
     set guifont=Courier\ 12
     set guifontwide=NanumGothicCoding\ 12
 
-If you use Motif or Athena version of GVIM, you should set 'guifontset' in
+If you use Motif or Athena version of gvim, you should set 'guifontset' in
 your vimrc.  You can set fontset in the .Xdefaults file.
 
 $HOME/.gvimrc: >
@@ -77,11 +77,11 @@ $HOME/.Xdefaults: >
 
 attention! the , (comma) or ; (semicolon)
 
-And there should be no ':set guifont'.  If it exists, then Gvim ignores
-':set guifontset'.  It means VIM runs without fontset supporting.
+And there should be no ':set guifont'.  If it exists, then gvim ignores
+':set guifontset'.  It means Vim runs without fontset supporting.
 So, you can see only English.  Hangul does not be correctly displayed.
 
-After "fontset" feature is enabled, VIM does not allow using english
+After "fontset" feature is enabled, Vim does not allow using english
 font only in "font" setting for syntax.
 For example, if you use >
    :set guifontset=eng_font,your_font
@@ -99,7 +99,7 @@ We don't support Johab font.
 We don't support Hanja input.
 And We don't have any plan to support them.
 
-If you really need such features, you can use console version of VIM with a
+If you really need such features, you can use console version of Vim with a
 capable terminal emulator.
 
 Bug or Comment


### PR DESCRIPTION
For issue #207
hangulin.txt および hangulin.jax を Vim 8.1 用に更新しました。

英語での "gvim" に合わせましたがどうでしょうか。Wikiには特に記述ありませんでした。
個人的には "gVim" かなと思いますが。。

一部日本語では既に "Vim" となっていて修正不要な箇所がありました。

ご確認お願いいたします。