### PR TITLE
Update pi_getscript from Vim 8.0 to 8.1

### DIFF
--- a/doc/pi_getscript.jax
+++ b/doc/pi_getscript.jax
@@ -66,7 +66,7 @@ GetLatestVimScripts の動作には wget か curl が必要です。
 		mv GetLatestVimScripts.dist GetLatestVimScripts.dat
 		(GetLatestVimScripts.dat を編集して、インストールしたいプラグ
 		インの一覧を書いてください。|GetLatestVimScripts_dat| 参照)
-	
+
 	3. Windows:
 		vim getscript.vba
 		:so %

--- a/doc/pi_getscript.jax
+++ b/doc/pi_getscript.jax
@@ -1,4 +1,4 @@
-*pi_getscript.txt*  For Vim バージョン 8.0.  Last change: 2013 Nov 29
+*pi_getscript.txt*  For Vim バージョン 8.1.  Last change: 2017 Aug 01
 >
 		GETSCRIPT REFERENCE MANUAL  by Charles E. Campbell
 <
@@ -9,7 +9,7 @@ Copyright: (c) 2004-2012 by Charles E. Campbell	*glvs-copyright*
 	The VIM LICENSE (see |copyright|) applies to the files in this
 	package, including getscriptPlugin.vim, getscript.vim,
 	GetLatestVimScripts.dist, and pi_getscript.txt, except use "getscript"
-	instead of "VIM".  Like anything else that's free, getscript and its
+	instead of "Vim".  Like anything else that's free, getscript and its
 	associated files are provided *as is* and comes with no warranty of
 	any kind, either expressed or implied.  No guarantees of
 	merchantability.  No guarantees of suitability for any purpose.  By
@@ -127,7 +127,7 @@ GetLatest/GetLatestVimScripts.dist ファイルはそのようなデータファ
 
 一列目の数値はスクリプトの ScriptID です。Web ブラウザーで http://vim.sf.net/
 にあるスクリプトを探すとき、スクリプトへのリンクにマウスカーソルを合わせると、
-次のような url が確認できますが
+次のような URL が確認できますが
 
 	http://vim.sourceforge.net/scripts/script.php?script_id=40
 

--- a/en/pi_getscript.txt
+++ b/en/pi_getscript.txt
@@ -1,4 +1,4 @@
-*pi_getscript.txt*  For Vim version 7.0.  Last change: 2013 Nov 29
+*pi_getscript.txt*  For Vim version 8.1.  Last change: 2017 Aug 01
 >
 		GETSCRIPT REFERENCE MANUAL  by Charles E. Campbell
 <
@@ -9,7 +9,7 @@ Copyright: (c) 2004-2012 by Charles E. Campbell	*glvs-copyright*
 	The VIM LICENSE (see |copyright|) applies to the files in this
 	package, including getscriptPlugin.vim, getscript.vim,
 	GetLatestVimScripts.dist, and pi_getscript.txt, except use "getscript"
-	instead of "VIM".  Like anything else that's free, getscript and its
+	instead of "Vim".  Like anything else that's free, getscript and its
 	associated files are provided *as is* and comes with no warranty of
 	any kind, either expressed or implied.  No guarantees of
 	merchantability.  No guarantees of suitability for any purpose.  By
@@ -68,7 +68,7 @@ Your computer needs to have wget or curl for GetLatestVimScripts to do its work.
 		mv GetLatestVimScripts.dist GetLatestVimScripts.dat
 		(edit GetLatestVimScripts.dat to install your own personal
 		list of desired plugins -- see |GetLatestVimScripts_dat|)
-	
+
 	3. Windows:
 		vim getscript.vba
 		:so %
@@ -389,7 +389,7 @@ v36 Apr 22, 2013 : * (glts) suggested use of plugin/**/*.vim instead of
 		     plugin/*.vim in globpath() call.
 		   * (Andy Wokula) got warning message when setting
 		     g:loaded_getscriptPlugin
-v35 Apr 07, 2012 : * (MengHuan Yu) pointed out that the script url has
+v35 Apr 07, 2012 : * (MengHuan Yu) pointed out that the script URL has
 		     changed (somewhat).  However, it doesn't work, and
 		     the original one does (under Linux). I'll make it
 		     yet-another-option.


### PR DESCRIPTION
For issue #207
pi_getscript.txt および pi_getscript.jax を Vim 8.1 用に更新しました。
ご確認お願いいたします。