### PR TITLE
Update usr_11 from Vim 8.0 to 8.1

### DIFF
--- a/doc/usr_11.jax
+++ b/doc/usr_11.jax
@@ -1,4 +1,4 @@
-*usr_11.txt*	For Vim バージョン 8.0.  Last change: 2010 Jul 20
+*usr_11.txt*	For Vim バージョン 8.1.  Last change: 2018 Apr 13
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -246,7 +246,7 @@ Vim には、うっかりミスを防止するための仕組みがあります�
 どうしますか？					*swap-exists-choices*
 --------------
 
-ダイアログがサポートされている場合、次の五つの選択肢が表示されます:
+ダイアログがサポートされている場合、次の6つの選択肢が表示されます:
 
   スワップファイル ".main.c.swp" が既にあります! ~
   読込専用で開く([O]), とにかく編集する((E)), 復活させる((R)), ~

--- a/en/usr_11.txt
+++ b/en/usr_11.txt
@@ -1,4 +1,4 @@
-*usr_11.txt*	For Vim version 8.0.  Last change: 2010 Jul 20
+*usr_11.txt*	For Vim version 8.1.  Last change: 2018 Apr 13
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -234,7 +234,7 @@ that file, be prepared to redo your last changes.
 
 WHAT TO DO?					*swap-exists-choices*
 
-If dialogs are supported you will be asked to select one of five choices:
+If dialogs are supported you will be asked to select one of six choices:
 
   Swap file ".main.c.swp" already exists! ~
   [O]pen Read-Only, (E)dit anyway, (R)ecover, (Q)uit, (A)bort, (D)elete it: ~


### PR DESCRIPTION
For issue #207
usr_11.txt および usr_11.jax を Vim 8.1 用に更新しました。
ご確認お願いいたします。