### PR TITLE
Update usr_27 from Vim 8.0 to 8.1

### DIFF
--- a/doc/usr_27.jax
+++ b/doc/usr_27.jax
@@ -1,4 +1,4 @@
-*usr_27.txt*	For Vim バージョン 8.0.  Last change: 2010 Mar 28
+*usr_27.txt*	For Vim バージョン 8.1.  Last change: 2018 Jan 26
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/en/usr_27.txt
+++ b/en/usr_27.txt
@@ -1,4 +1,4 @@
-*usr_27.txt*	For Vim version 8.0.  Last change: 2010 Mar 28
+*usr_27.txt*	For Vim version 8.1.  Last change: 2018 Jan 26
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -225,9 +225,9 @@ specify a line offset, this can cause trouble.  For example: >
 	/const/-2
 
 This finds the next word "const" and then moves two lines up.  If you
-use "n" to search again, Vim could start at the current position and find the same
-"const" match.  Then using the offset again, you would be back where you started.
-You would be stuck!
+use "n" to search again, Vim could start at the current position and find the
+same "const" match.  Then using the offset again, you would be back where you
+started.  You would be stuck!
    It could be worse: Suppose there is another match with "const" in the next
 line.  Then repeating the forward search would find this match and move two
 lines up.  Thus you would actually move the cursor back!


### PR DESCRIPTION
For issue #207
usr_27.txt および usr_27.jax を Vim 8.1 用に更新しました。

英語版の改行の修正は、日本語版には影響ありません。

ご確認お願いいたします。