### PR TITLE
Update netbeans from Vim 8.0 to 8.1

### DIFF
--- a/doc/netbeans.jax
+++ b/doc/netbeans.jax
@@ -1,4 +1,4 @@
-*netbeans.txt*  For Vim バージョン 8.0.  Last change: 2016 Jul 15
+*netbeans.txt*  For Vim バージョン 8.1.  Last change: 2016 Jul 15
 
 
 		  VIMリファレンスマニュアル    by Gordon Prieur et al.
@@ -119,7 +119,7 @@ NetBeans インターフェイスを有効にしたくない場合は、Makefile
 "--disable-netbeans" の行のコメントアウトを解除すれば無効にできます。
 
 現在 NetBeans インターフェイスは端末動作の Vim と GUI (GTK, GNOME, Windows,
-Athena, Motif) の GVim でのみサポートされています。
+Athena, Motif) の gvim でのみサポートされています。
 
 Motif をサポートするためには XPM ライブラリが必要です。XPM の最新バージョン
 を入手する方法については |workshop-xpm| を参照してください。

--- a/doc/netbeans.jax
+++ b/doc/netbeans.jax
@@ -992,11 +992,10 @@ Tools->Options を開き、Editing カテゴリを表示します。External Edi
 定してください。
 
 "Vim Command" を変更するときは注意してください。接続するためには、いくつかの
-コマンドラインオプションを正しく設定する必要があります。
-You can change the command name but that's about it.
-gvim が $PATH の中にあるなら、コマンドを "gvim" から始められます。gvim を
-$PATH から検索させたくないならフルパスで指定してください。以上で、NetBeans
-で開くファイルが gvim で開かれるようになります。
+コマンドラインオプションを正しく設定する必要があります。コマンド名を変更するこ
+とも可能ですが、単にそれだけです。gvim が $PATH の中にあるなら、コマンドを
+"gvim" から始められます。gvim を$PATH から検索させたくないならフルパスで指定し
+てください。以上で、NetBeansで開くファイルが gvim で開かれるようになります。
 
 gvim で開かれるファイルもあるが、NetBeans のエディタで開かれるファイルもある
 (拡張子が異なる)という場合、Expert タブの MIME Type プロパティを確認してくだ

--- a/en/netbeans.txt
+++ b/en/netbeans.txt
@@ -1,4 +1,4 @@
-*netbeans.txt*  For Vim version 8.0.  Last change: 2016 Jul 15
+*netbeans.txt*  For Vim version 8.1.  Last change: 2016 Jul 15
 
 
 		  VIM REFERENCE MANUAL    by Gordon Prieur et al.
@@ -120,7 +120,7 @@ In case you do not want the NetBeans interface you can disable it by
 uncommenting a line with "--disable-netbeans" in the Makefile.
 
 Currently the NetBeans interface is supported by Vim running in a terminal and
-by GVim when it is run with one of the following GUIs: GTK, GNOME, Windows,
+by gvim when it is run with one of the following GUIs: GTK, GNOME, Windows,
 Athena and Motif.
 
 If Motif support is required the user must supply XPM libraries.  See
@@ -996,7 +996,7 @@ to "Vim".  In the Expert tab make sure the "Vim Command" is correct.
 You should be careful if you change the "Vim Command".  There are command
 line options there which must be there for the connection to be properly
 set up.  You can change the command name but that's about it.  If your gvim
-can be found by your $PATH then the VIM Command can start with "gvim".  If
+can be found by your $PATH then the Vim Command can start with "gvim".  If
 you don't want gvim searched from your $PATH then hard code in the full
 Unix path name.  At this point you should get a gvim for any source file
 you open in NetBeans.


### PR DESCRIPTION
For issue #207
netbeans.txt および netbeans.jax を Vim 8.1 用に更新しました。

日本語版には特に "Vim" の表記はありませんでした。
以下の文は訳さずに残してある？？私もあまりよく分かりません。
「別に変えることはできるけど、ただそれだけ」のような感じでしょうか？
> You can change the command name but that's about it.

ご確認お願いいたします。