### PR TITLE
Update os_beos from Vim 8.0 to 8.1

### DIFF
--- a/doc/os_beos.jax
+++ b/doc/os_beos.jax
@@ -1,4 +1,4 @@
-*os_beos.txt*	For Vim バージョン 8.0.  Last change: 2016 Mar 28
+*os_beos.txt*	For Vim バージョン 8.1.  Last change: 2016 Mar 28
 
 
 		VIMリファレンスマニュアル    by Bram Moolenaar
@@ -151,7 +151,7 @@ $VIMにはVim支援ファイルの格納場所が記憶されている。$VIMの
 
   :version
 
-通常の値は/boot/home/config/share/vimである。これが気に入らなければ環境変数VIM
+通常の値は/boot/home/config/share/vimである。これが気に入らなければ環境変数Vim
 を設定することでこれを上書するか、.vimrcで 'helpfile' を設定する: >
 
   :if version >= 500

--- a/en/os_beos.txt
+++ b/en/os_beos.txt
@@ -1,4 +1,4 @@
-*os_beos.txt*	For Vim version 8.0.  Last change: 2016 Mar 28
+*os_beos.txt*	For Vim version 8.1.  Last change: 2016 Mar 28
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -144,7 +144,7 @@ The default value for $VIM is set at compile time and can be determined with >
   :version
 
 The normal value is /boot/home/config/share/vim.  If you don't like it you can
-set the VIM environment variable to override this, or set 'helpfile' in your
+set the Vim environment variable to override this, or set 'helpfile' in your
 .vimrc: >
 
   :if version >= 500


### PR DESCRIPTION
For issue #207
os_beos.txt および os_beos.jax を Vim 8.1 用に更新しました。

環境変数の "VIM" -> "Vim" は、変更しないほうが正しい？のではないかと思ったのですが、
今のところ本家に合わせてあります。

ご確認お願いいたします。