### PR TITLE
Update help from Vim 8.0 to 8.1

### DIFF
--- a/doc/help.jax
+++ b/doc/help.jax
@@ -1,4 +1,4 @@
-*help.txt*	For Vim バージョン 8.0.  Last change: 2016 Sep 12
+*help.txt*	For Vim バージョン 8.1.  Last change: 2017 Oct 28
 
 			   VIM - メインヘルプファイル
 									 k
@@ -143,6 +143,7 @@ Vim は Vi IMproved の略です。Vim の大部分は Bram Moolenaar によっ�
 |print.txt|	印刷
 |remote.txt|	クライアント/サーバー機能
 |term.txt|	いろいろな端末やマウスについて
+|terminal.txt|	端末ウィンドウのサポート
 |digraph.txt|	利用可能なダイグラフ (digraph) の一覧
 |mbyte.txt|	マルチバイトテキストのサポート
 |mlang.txt|	英語以外の言語のサポート
@@ -151,6 +152,7 @@ Vim は Vi IMproved の略です。Vim の大部分は Bram Moolenaar によっ�
 |hebrew.txt|	ヘブライ語のサポート
 |russian.txt|	ロシア語のサポート
 |ft_ada.txt|	Ada (プログラミング言語) のサポート
+|ft_rust.txt|	Rust ファイルタイププラグイン
 |ft_sql.txt|	SQL ファイルタイププラグイン
 |hangulin.txt|	ハングル (韓国語) の入力
 |rileft.txt|	右横書き (書字方向が右から左になるモード)
@@ -203,6 +205,7 @@ GUI ~
 |pi_logipat.txt|   パターンにおける論理演算子
 |pi_netrw.txt|     ネットワークファイルの読み書き
 |pi_paren.txt|     対括弧の強調表示
+|pi_spec.txt|      RPM spec ファイル用ファイルタイププラグイン
 |pi_tar.txt|       Tar ファイルエクスプローラー
 |pi_vimball.txt|   Vim script インストーラを作成する
 |pi_zip.txt|       Zip アーカイブエクスプローラー

--- a/en/help.txt
+++ b/en/help.txt
@@ -1,4 +1,4 @@
-*help.txt*	For Vim version 8.0.  Last change: 2016 Sep 12
+*help.txt*	For Vim version 8.1.  Last change: 2017 Oct 28
 
 			VIM - main help file
 									 k
@@ -142,6 +142,7 @@ Special issues ~
 |print.txt|	printing
 |remote.txt|	using Vim as a server or client
 |term.txt|	using different terminals and mice
+|terminal.txt|	Terminal window support
 |digraph.txt|	list of available digraphs
 |mbyte.txt|	multi-byte text support
 |mlang.txt|	non-English language support
@@ -150,6 +151,7 @@ Special issues ~
 |hebrew.txt|	Hebrew language support and editing
 |russian.txt|	Russian language support and editing
 |ft_ada.txt|	Ada (the programming language) support
+|ft_rust.txt|	Filetype plugin for Rust
 |ft_sql.txt|	about the SQL filetype plugin
 |hangulin.txt|	Hangul (Korean) input mode
 |rileft.txt|	right-to-left editing mode
@@ -202,6 +204,7 @@ Standard plugins ~
 |pi_logipat.txt|   Logical operators on patterns
 |pi_netrw.txt|     Reading and writing files over a network
 |pi_paren.txt|     Highlight matching parens
+|pi_spec.txt|      Filetype plugin to work with rpm spec files
 |pi_tar.txt|       Tar file explorer
 |pi_vimball.txt|   Create a self-installing Vim script
 |pi_zip.txt|       Zip archive explorer


### PR DESCRIPTION
For issue #207
help.txt および help.jax を Vim 8.1 用に更新しました。
ご確認お願いいたします。