### PR TITLE
Update usr_41 from Vim 8.0 to 8.1

### DIFF
--- a/doc/usr_41.jax
+++ b/doc/usr_41.jax
@@ -1,4 +1,4 @@
-*usr_41.txt*	For Vim バージョン 8.0.  Last change: 2017 Aug 22
+*usr_41.txt*	For Vim バージョン 8.1.  Last change: 2018 Apr 11
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -786,6 +786,8 @@ substitute() コマンドの前後にいろいろな処理を入れたりする�
 	getbufinfo()		バッファの情報一覧を得る
 	gettabinfo()		タブページの情報一覧を得る
 	getwininfo()		ウィンドウの情報一覧を得る
+	getchangelist()		変更リストのエントリ一覧を得る
+	getjumplist()		ジャンプリストのエントリ一覧を得る
 
 コマンドライン:					*command-line-functions*
 	getcmdline()		現在のコマンドラインを取得
@@ -861,13 +863,15 @@ Quickfixとロケーションリスト:			*quickfix-functions*
 
 GUI:						*gui-functions*
 	getfontname()		現在使われているフォントの名前を取得
-	getwinposx()		GUIのVimウィンドウのX座標
-	getwinposy()		GUIのVimウィンドウのY座標
+	getwinpos()		Vimウィンドウの座標
+	getwinposx()		VimウィンドウのX座標
+	getwinposy()		VimウィンドウのY座標
 	balloon_show()		バルーンの内容を設定する
+	balloon_split()		バルーン用にメッセージを分割する
 
 Vimサーバー:					*server-functions*
 	serverlist()		サーバー名のリストを返す
-	remote_startserve()	サーバーをスタートする
+	remote_startserver()	サーバーをスタートする
 	remote_send()		Vimサーバーにコマンド文字を送る
 	remote_expr()		Vimサーバーで式を評価する
 	server2client()		Vimサーバーのクライアントに応答を返す
@@ -879,6 +883,7 @@ Vimサーバー:					*server-functions*
 ウィンドウサイズと位置:				*window-size-functions*
 	winheight()		ウィンドウの高さを取得
 	winwidth()		ウィンドウの幅を取得
+	win_screenpos()		ウィンドウのスクリーン座標を取得
 	winrestcmd()		ウィンドウサイズを復元するコマンドを返す
 	winsaveview()		カレントウィンドウのビューを取得
 	winrestview()		カレントウィンドウのビューを復元
@@ -898,7 +903,8 @@ Vimサーバー:					*server-functions*
 	assert_false()		式がfalseかどうかテストする
 	assert_true()		式がtrueかどうかテストする
 	assert_exception()	コマンドが例外を投げる事をテストする
-	assert_fails()		関数呼び出しが失敗する事をテストする
+	assert_beeps()		コマンドがビープ音を鳴らすことをテストする
+	assert_fails()		コマンドが失敗する事をテストする
 	assert_report()		テストの失敗をレポートする
 	test_alloc_fail()	メモリの確保を失敗させる
 	test_autochdir()	起動中に 'autochdir' を有効にする
@@ -960,6 +966,10 @@ Terminal window:				*terminal-functions*
 	term_getstatus()	ターミナルのステータスを取得する
 	term_gettitle()		ターミナルのタイトルを取得する
 	term_gettty()		ターミナルの tty 名を取得する
+	term_setansicolors()	GUI で使用される 16 色の ANSI カラーパレットを
+				設定する
+	term_getansicolors()	GUI で使用される 16 色の ANSI カラーパレットを
+				取得する
 
 Timers:						*timer-functions*
 	timer_start()		タイマーを作る
@@ -988,6 +998,8 @@ Timers:						*timer-functions*
 	getreg()		レジスタの値を得る
 	getregtype()		レジスタのタイプを得る
 	setreg()		レジスタの値を設定する
+	reg_executing()		実行中のレジスタ名を返す
+	reg_recording()		記録中のレジスタ名を返す
 
 	shiftwidth()		'shiftwidth' の実際の値
 

--- a/en/usr_41.txt
+++ b/en/usr_41.txt
@@ -1,4 +1,4 @@
-*usr_41.txt*	For Vim version 8.0.  Last change: 2017 Aug 22
+*usr_41.txt*	For Vim version 8.1.  Last change: 2018 Apr 11
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -807,6 +807,8 @@ Buffers, windows and the argument list:
 	getbufinfo()		get a list with buffer information
 	gettabinfo()		get a list with tab page information
 	getwininfo()		get a list with window information
+	getchangelist()		get a list of change list entries
+	getjumplist()		get a list of jump list entries
 
 Command line:					*command-line-functions*
 	getcmdline()		get the current command line
@@ -883,13 +885,15 @@ Interactive:					*interactive-functions*
 
 GUI:						*gui-functions*
 	getfontname()		get name of current font being used
-	getwinposx()		X position of the GUI Vim window
-	getwinposy()		Y position of the GUI Vim window
+	getwinpos()		position of the Vim window
+	getwinposx()		X position of the Vim window
+	getwinposy()		Y position of the Vim window
 	balloon_show()		set the balloon content
+	balloon_split()		split a message for a balloon
 
 Vim server:					*server-functions*
 	serverlist()		return the list of server names
-	remote_startserve()	run a server
+	remote_startserver()	run a server
 	remote_send()		send command characters to a Vim server
 	remote_expr()		evaluate an expression in a Vim server
 	server2client()		send a reply to a client of a Vim server
@@ -901,6 +905,7 @@ Vim server:					*server-functions*
 Window size and position:			*window-size-functions*
 	winheight()		get height of a specific window
 	winwidth()		get width of a specific window
+	win_screenpos()		get screen position of a window
 	winrestcmd()		return command to restore window sizes
 	winsaveview()		get view of current window
 	winrestview()		restore saved view of current window
@@ -920,7 +925,8 @@ Testing:				    *test-functions*
 	assert_false()		assert that an expression is false
 	assert_true()		assert that an expression is true
 	assert_exception()	assert that a command throws an exception
-	assert_fails()		assert that a function call fails
+	assert_beeps()		assert that a command beeps
+	assert_fails()		assert that a command fails
 	assert_report()		report a test failure
 	test_alloc_fail()	make memory allocation fail
 	test_autochdir()	enable 'autochdir' during startup
@@ -982,6 +988,8 @@ Terminal window:				*terminal-functions*
 	term_getstatus()	get the status of a terminal
 	term_gettitle()		get the title of a terminal
 	term_gettty()		get the tty name of a terminal
+	term_setansicolors()	set 16 ANSI colors, used for GUI
+	term_getansicolors()	get 16 ANSI colors, used for GUI
 
 Timers:						*timer-functions*
 	timer_start()		create a timer
@@ -1010,6 +1018,8 @@ Various:					*various-functions*
 	getreg()		get contents of a register
 	getregtype()		get type of a register
 	setreg()		set contents and type of a register
+	reg_executing()		return the name of the register being executed
+	reg_recording()		return the name of the register being recorded
 
 	shiftwidth()		effective value of 'shiftwidth'
 


### PR DESCRIPTION
For issue #207
usr_41.txt および usr_41.jax を Vim 8.1 用に更新しました。
ご確認お願いいたします。