### PR TITLE
Update if_cscop from Vim 8.0 to 8.1

### DIFF
--- a/doc/if_cscop.jax
+++ b/doc/if_cscop.jax
@@ -1,4 +1,4 @@
-*if_cscop.txt*  For Vim バージョン 8.0.  Last change: 2011 Jun 12
+*if_cscop.txt*  For Vim バージョン 8.1.  Last change: 2018 Jan 21
 
 
 		  VIMリファレンスマニュアル    by Andy Kahn
@@ -87,9 +87,12 @@ tagsのようになるので、普通のタグのようなジャンプ操作 (Ct
 2. Cscopeに関係するコマンド				*cscope-commands*
 
 		*:cscope* *:cs* *:scs* *:scscope* *E259* *E262* *E561* *E560*
-全てのcscopeのコマンドはメインコマンド ":cscope" のサブコマンドとしてアクセス
-することができる。最も短い省略形は ":cs" である。":scscope" コマンドはウィンド
-ウ分割を伴って同じ事を行う (省略形: "scs")。
+全ての cscope のコマンドは cscope コマンドのサブコマンドとしてアクセスすること
+ができる。
+	`:cscope` または `:cs` がメインコマンドである。
+	`:scscope` または `:scs` はウィンドウ分割を伴って同じことを行う。
+	`:lcscope` または `:lcs` はロケーションリストを使用する。|:lcscope| を
+	参照のこと。
 
 利用可能なサブコマンドは:
 
@@ -451,37 +454,19 @@ http://cscope.sourceforge.net でダウンロードできる、DJGPP でビル�
 	http://cscope.sourceforge.net/
 cscopeはSCOによりBSDライセンスに基づいて配布されている。
 
-より新しいバージョンのcscopeを入手したいのならば、恐らく購入する必要があるだろ
-う。(古い)nviのドキュメントによれば:
-
-	バージョン13.3の無制限ライセンス付きのソースコードが、AT&Tソフトウェア
-	ソリューション(電話番号+1-800-462-8146)から400ドルで購入できる。
-
-また cscope 13.x や mlcscope 14.x (多言語バージョンのcscopeで、C, C++, Java,
-lex, yacc, breakpoint listing, Ingres, and SDL をサポートしている) を次のサイ
-トからダウンロードできる。
-	World-Wide Exptools Open Source packages page:
-	http://www.bell-labs.com/project/wwexptools/packages.html
-
 Solaris 2.xでは、Cコンパイラのライセンスを入手していれば、cscopeも入手している
 だろう。どちらも通常は/opt/SUNWspro/binに格納される。
-
-SGIの開発者もまた入手可能である。このページからCscopeを検索すること
-	http://freeware.sgi.com/index-by-alpha.html
-	https://toolbox.sgi.com/toolbox/utilities/cscope/
-2番目のアドレスはSGIツールボックスのパスワードを持っているユーザー用である。
 
 古いcscopeのクローン("cs" という名)のソースコードがネットで入手可能である。た
 だし様々な理由で、これはVimではサポートされない。
 
 オリジナルのcscopeインターフェイス/サポートはAndy Kahn <ackahn@netapp.com>に
 よって書かれた。元となった構造(かなり小さいコードだった)はnviのcscopeインター
-フェイスから改作された。問題、提案、パッチそのほか何でも、Vimでcscopeを使うの
-に何か持っているものがあれば彼に送って欲しい。
-{訳注: もちろん日本語では送らないで下さい}
+フェイスから改作された。
 							*cscope-win32*
-Win32バージョンのcscopeについてはこのサイトを参照すること
-	http://code.google.com/p/cscope-win32/
+Win32バージョンのcscopeについてはこのサイトを参照すること (放置されているよう
+に見える)
+	https://code.google.com/archive/p/cscope-win32/
 
 Win32への対応は Sergey Khorev <khorev@softlab.ru> がしてくれた。Win32に固有の
 問題については彼に問い合わせていただきたい。

--- a/en/if_cscop.txt
+++ b/en/if_cscop.txt
@@ -1,4 +1,4 @@
-*if_cscop.txt*  For Vim version 8.0.  Last change: 2011 Jun 12
+*if_cscop.txt*  For Vim version 8.1.  Last change: 2018 Jan 21
 
 
 		  VIM REFERENCE MANUAL    by Andy Kahn
@@ -91,9 +91,10 @@ suggested use.)
 2. Cscope related commands				*cscope-commands*
 
 		*:cscope* *:cs* *:scs* *:scscope* *E259* *E262* *E561* *E560*
-All cscope commands are accessed through suboptions to the main cscope
-command ":cscope".  The shortest abbreviation is ":cs".  The ":scscope"
-command does the same and also splits the window (short: "scs").
+All cscope commands are accessed through suboptions to the cscope commands.
+	`:cscope` or `:cs` is the main command
+	`:scscope` or `:scs` does the same and splits the window
+	`:lcscope` or `:lcs` uses the location list, see |:lcscope|
 
 The available subcommands are:
 
@@ -467,36 +468,18 @@ license or OS distribution), then you can download it for free from:
 	http://cscope.sourceforge.net/
 This is released by SCO under the BSD license.
 
-If you want a newer version of cscope, you will probably have to buy it.
-According to the (old) nvi documentation:
-
-	You can buy version 13.3 source with an unrestricted license
-	for $400 from AT&T Software Solutions by calling +1-800-462-8146.
-
-Also you can download cscope 13.x and mlcscope 14.x (multi-lingual cscope
-which supports C, C++, Java, lex, yacc, breakpoint listing, Ingres, and SDL)
-from World-Wide Exptools Open Source packages page:
-	http://www.bell-labs.com/project/wwexptools/packages.html
-
 In Solaris 2.x, if you have the C compiler license, you will also have
 cscope.  Both are usually located under /opt/SUNWspro/bin
-
-SGI developers can also get it.  Search for Cscope on this page:
-	http://freeware.sgi.com/index-by-alpha.html
-	https://toolbox.sgi.com/toolbox/utilities/cscope/
-The second one is for those who have a password for the SGI toolbox.
 
 There is source to an older version of a cscope clone (called "cs") available
 on the net.  Due to various reasons, this is not supported with Vim.
 
 The cscope interface/support for Vim was originally written by
 Andy Kahn <ackahn@netapp.com>.  The original structure (as well as a tiny
-bit of code) was adapted from the cscope interface in nvi.  Please report
-any problems, suggestions, patches, et al., you have for the usage of
-cscope within Vim to him.
+bit of code) was adapted from the cscope interface in nvi.
 							*cscope-win32*
-For a cscope version for Win32 see:
-	http://code.google.com/p/cscope-win32/
+For a cscope version for Win32 see (seems abandoned):
+	https://code.google.com/archive/p/cscope-win32/
 
 Win32 support was added by Sergey Khorev <sergey.khorev@gmail.com>.  Contact
 him if you have Win32-specific issues.


### PR DESCRIPTION
For issue #207
if_cscop.txt および if_cscop.jax を Vim 8.1 用に更新しました。
ご確認お願いいたします。