### PR TITLE
翻訳忘れを追記

### DIFF
--- a/doc/if_mzsch.jax
+++ b/doc/if_mzsch.jax
@@ -168,7 +168,7 @@ NOTE
 				    ジェクトに変換する。リスト (|Lists|) は
 				    Scheme のリスト、辞書 (|Dictionaries|) は
 				    はハッシュテーブル、関数参照 (|Funcref|)
-				    は関数になる。
+				    は関数になる。(|mzscheme-funcref| も参照)
 				    NOTE: MzScheme の eval と名前が衝突してい
 				    るので、呼び出すにはモジュール限定子を使っ
 				    てください。


### PR DESCRIPTION
原文: L171-172  (see also |mzscheme-funcref|)
が未訳になっていました。
