### PR TITLE
Update os_vms from Vim 8.0 to 8.1

### DIFF
--- a/doc/os_vms.jax
+++ b/doc/os_vms.jax
@@ -1,4 +1,4 @@
-*os_vms.txt*    For Vim バージョン 8.0.  Last change: 2014 Aug 29
+*os_vms.txt*    For Vim バージョン 8.1.  Last change: 2018 May 06
 
 
 			  VIMリファレンスマニュアル
@@ -58,7 +58,7 @@ Vimのソースコードは公式サイトからftpでダウンロードする�
 
 アーカイブには次のファイルが含まれる: vim.exe, ctags.exe, xxd.exe, mms_vim.exe
 
-GTK 用実行可能ファイルでは Alpha と IA64 プラットフォームで利用可能な GTKLIB 
+GTK 用実行可能ファイルでは Alpha と IA64 プラットフォームで利用可能な GTKLIB
 が必要。
 
 ==============================================================================
@@ -540,7 +540,7 @@ VMSで(GUIモードの)Vimからの印刷を可能にするには論理名$TMP�
 
 8.10 シンボルの設定
 
-このようにGVIMを使用している際に、親となるターミナルで<CTRL-Y>を押すと、gvimが
+このようにgvimを使用している際に、親となるターミナルで<CTRL-Y>を押すと、gvimが
 終了してしまう問題がある。この問題は異なるシンボルを定義することで回避できるよ
 うだ。それは: >
 
@@ -548,7 +548,7 @@ VMSで(GUIモードの)Vimからの印刷を可能にするには論理名$TMP�
 
 /INPUT=NLA0: が親ウィンドウからの停止信号をブロックするために、親の端末とgvim
 のプロセスの標準入力を切り離す。
--GEOMETRYがない場合、GVIMウィンドウのサイズは最小となり、大きさを修正したあと
+-GEOMETRYがない場合、gvimウィンドウのサイズは最小となり、大きさを修正したあと
 でもメニューが混乱しておかしなことになるだろう。
 
 (Carlo Mekenkamp, Coen Engelbarts, Vim 6.0ac)
@@ -702,13 +702,13 @@ GUI/GTK 版の Vim はコンソールモードでも同じように動作する�
 $show cluster
 View of Cluster from system ID 11655  node: TOR                                                                     18-AUG-2008 11:58:31
 +---------------------------------+
-¦        SYSTEMS        ¦ MEMBERS ¦
-+-----------------------+---------¦
-¦  NODE  ¦   SOFTWARE   ¦  STATUS ¦
-+--------+--------------+---------¦
-¦ TOR    ¦ VMS V7.3-2   ¦ MEMBER  ¦
-¦ TITAN2 ¦ VMS V8.3     ¦ MEMBER  ¦
-¦ ODIN   ¦ VMS V7.3-2   ¦ MEMBER  ¦
+|        SYSTEMS        | MEMBERS |
++-----------------------+---------|
+|  NODE  |   SOFTWARE   |  STATUS |
++--------+--------------+---------|
+| TOR    | VMS V7.3-2   | MEMBER  |
+| TITAN2 | VMS V8.3     | MEMBER  |
+| ODIN   | VMS V7.3-2   | MEMBER  |
 +---------------------------------+
 
 VIM ディレクトリは共通にし、実行ファイルだけ異なるようにすると便利である。この
@@ -763,7 +763,7 @@ GNU_TOOLS.ZIP の [GNU]gnu_tools.com スクリプトである。
 
 9. VMS関連の変更点					*vms-changes*
 
-Version 7.4 
+Version 7.4
 - Undo: VMS はファイル名に複数のドットを使えないので "dir/name" -> "dir/_un_name" とする
   先頭に _un_ を追加して拡張子を維持する
 - スワップファイル名のワイルドカードの扱いを修正

--- a/en/os_vms.txt
+++ b/en/os_vms.txt
@@ -1,4 +1,4 @@
-*os_vms.txt*    For Vim version 8.0.  Last change: 2014 Aug 29
+*os_vms.txt*    For Vim version 8.1.  Last change: 2018 May 06
 
 
 		  VIM REFERENCE MANUAL
@@ -539,7 +539,7 @@ More info under :help hardcopy
 
 8.10 Setting up the symbols
 
-When I use GVIM this way and press CTRL-Y in the parent terminal, gvim exits.
+When I use gvim this way and press CTRL-Y in the parent terminal, gvim exits.
 I now use a different symbol that seems to work OK and fixes the problem.
 I suggest this instead: >
 
@@ -547,7 +547,7 @@ I suggest this instead: >
 
 The /INPUT=NLA0: separates the standard input of the gvim process from the
 parent terminal, to block signals from the parent window.
-Without the -GEOMETRY, the GVIM window size will be minimal and the menu
+Without the -GEOMETRY, the gvim window size will be minimal and the menu
 will be confused after a window-resize.
 
 (Carlo Mekenkamp, Coen Engelbarts, Vim 6.0ac)
@@ -702,13 +702,13 @@ In a cluster that contains nodes with different architectures like below:
 $show cluster
 View of Cluster from system ID 11655  node: TOR                                                                     18-AUG-2008 11:58:31
 +---------------------------------+
-¦        SYSTEMS        ¦ MEMBERS ¦
-+-----------------------+---------¦
-¦  NODE  ¦   SOFTWARE   ¦  STATUS ¦
-+--------+--------------+---------¦
-¦ TOR    ¦ VMS V7.3-2   ¦ MEMBER  ¦
-¦ TITAN2 ¦ VMS V8.3     ¦ MEMBER  ¦
-¦ ODIN   ¦ VMS V7.3-2   ¦ MEMBER  ¦
+|        SYSTEMS        | MEMBERS |
++-----------------------+---------|
+|  NODE  |   SOFTWARE   |  STATUS |
++--------+--------------+---------|
+| TOR    | VMS V7.3-2   | MEMBER  |
+| TITAN2 | VMS V8.3     | MEMBER  |
+| ODIN   | VMS V7.3-2   | MEMBER  |
 +---------------------------------+
 
 It is convenient to have a common VIM directory but execute different
@@ -764,14 +764,14 @@ GNU_TOOLS.ZIP package downloadable from http://www.polarhome.com/vim/
 
 9. VMS related changes					*vms-changes*
 
-Version 7.4 
-- Undo: VMS can not handle more than one dot in the filenames use "dir/name" -> "dir/_un_name" 
+Version 7.4
+- Undo: VMS can not handle more than one dot in the filenames use "dir/name" -> "dir/_un_name"
   add _un_ at the beginning to keep the extension
 - correct swap file name wildcard handling
 - handle iconv usage correctly
 - do not optimize on vax - otherwise it hangs compiling crypto files
 - fileio.c fix the comment
-- correct RealWaitForChar 
+- correct RealWaitForChar
 - after 7.4-119 use different functions lib$cvtf_to_internal_time because Alpha and VAX have
   G_FLOAT but IA64 uses IEEE float otherwise Vim crashes
 - guard against crashes that are caused by mixed filenames


### PR DESCRIPTION
For issue #207
os_vms.txt および os_vms.jax を Vim 8.1 用に更新しました。
ご確認お願いいたします。