### PR TITLE
Update tabpage from Vim 8.0 to 8.1

### DIFF
--- a/doc/tabpage.jax
+++ b/doc/tabpage.jax
@@ -1,4 +1,4 @@
-*tabpage.txt*   For Vim バージョン 8.0.  Last change: 2016 Oct 20
+*tabpage.txt*   For Vim バージョン 8.1.  Last change: 2018 Mar 29
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar
@@ -212,7 +212,9 @@ gT		前のタブページに移動します。前のタブページがない場�
 :tabN[ext] {count}
 {count}<C-PageUp>
 {count}gT	{count} の数だけ前のタブページに移動します。前のタブページがな
-		い場合は最後のタブページに移動します。
+		い場合は最後のタブページに移動します。 Note: |:tabnext| とは
+		{count} の使われ方が異なっていて、そちらでは移動先のタブ番号と
+		して扱われます。
 
 :tabr[ewind]			*:tabfir* *:tabfirst* *:tabr* *:tabrewind*
 :tabfir[st]	最初のタブページに移動します。
@@ -286,7 +288,6 @@ Note :Ntabmove を使うことでタブを N 番目のタブの後ろに移動�
 		{cmd} はタブページを開いたり閉じたり並べ替えたりしてはいけませ
 		ん。
 		{Vi にはありません}
-		{|+listcmds| が有効な場合のみ利用できます}
 		|:windo|、|:argdo|、|:bufdo|、|:cdo|、|:ldo|、|:cfdo|、|:lfdo|
 		も参照してください。
 

--- a/en/tabpage.txt
+++ b/en/tabpage.txt
@@ -1,4 +1,4 @@
-*tabpage.txt*   For Vim version 8.0.  Last change: 2016 Oct 20
+*tabpage.txt*   For Vim version 8.1.  Last change: 2018 Mar 29
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -213,7 +213,8 @@ gT		Go to the previous tab page.  Wraps around from the first one
 :tabN[ext] {count}
 {count}<C-PageUp>
 {count}gT	Go {count} tab pages back.  Wraps around from the first one
-		to the last one.
+		to the last one.  Note that the use of {count} is different
+		from |:tabnext|, where it is used as the tab page number.
 
 :tabr[ewind]			*:tabfir* *:tabfirst* *:tabr* *:tabrewind*
 :tabfir[st]	Go to the first tab page.
@@ -286,8 +287,7 @@ LOOPING OVER TAB PAGES:
 		current tab page.
 		{cmd} can contain '|' to concatenate several commands.
 		{cmd} must not open or close tab pages or reorder them.
-		{not in Vi} {not available when compiled without the
-		|+listcmds| feature}
+		{not in Vi}
 		Also see |:windo|, |:argdo|, |:bufdo|, |:cdo|, |:ldo|, |:cfdo|
 		and |:lfdo|
 


### PR DESCRIPTION
For issue #207
tabpage.txt および tabpage.jax を Vim 8.1 用に更新しました。
ご確認お願いいたします。