### PR TITLE
Update quickref from Vim 8.0 to 8.1

### DIFF
--- a/doc/quickref.jax
+++ b/doc/quickref.jax
@@ -1,4 +1,4 @@
-*quickref.txt*  For Vim バージョン 8.0.  Last change: 2016 Dec 16
+*quickref.txt*  For Vim バージョン 8.1.  Last change: 2018 Apr 18
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar
@@ -633,7 +633,8 @@
 'backupskip'	  'bsk'     指定のパターンに合致するファイルはバックアップ
 			    しない。
 'balloondelay'	  'bdlay'   バルーンウィンドウが出るまでの遅延時間(ms)
-'ballooneval'	  'beval'   バルーン評価のON/OFF
+'ballooneval'	  'beval'     GUI でのバルーン評価の ON/OFF
+'balloonevalterm' 'bevalterm' 端末でのバルーン評価の ON/OFF
 'balloonexpr'	  'bexpr'   バルーンウィンドウに表示する式
 'belloff'	  'bo'	    指定した場合にベルを鳴らさない
 'binary'	  'bin'     バイナリモードで、読み/書き/編集する
@@ -766,6 +767,7 @@
 'iminsert'	  'imi'     挿入モードで|:lmap|やIMを使う
 'imsearch'	  'ims'     検索パターン入力時に|:lmap|やIMを使う
 'imstatusfunc'    'imsf'    X のインプットメソッドの状態を得る関数
+'imstyle'	  'imst'    インプットメソッドの入力スタイルを指定する
 'include'	  'inc'     インクルードファイルの検索パターン
 'includeexpr'	  'inex'    インクルード行を処理する式
 'incsearch'	  'is'      検索パターン入力中にその文字を強調表示する
@@ -796,6 +798,8 @@
 'listchars'	  'lcs'     'list' オン時に使う文字
 'loadplugins'	  'lpl'     起動時にプラグインスクリプトを読み込む
 'luadll'		    Lua 動的ライブラリの名前
+'mzschemedll'		    MzScheme 動的ライブラリの名前
+'mzschemegcdll'		    MzScheme GC 動的ライブラリの名前
 'macatsui'		    Mac GUI: ATSUI テキスト描画を使う
 'magic'			    検索パターン内の特殊文字を変更する
 'makeef'	  'mef'     |:make|用のエラーファイル
@@ -849,10 +853,13 @@
 'printmbcharset'  'pmbcs'   |:hardcopy|に使われるCJK文字集合
 'printmbfont'	  'pmbfn'   |:hardcopy|の出力に使われるフォント名
 'printoptions'	  'popt'    |:hardcopy|の出力をコントロールする
-'pumheight'	  'ph'	    ポップアップメニューの高さの最大値
 'prompt'	  'prompt'  Ex モードでプロンプトを有効にする
+'pumheight'	  'ph'	    ポップアップメニューの高さの最大値
+'pumwidth'	  'pw'	    ポップアップメニューの幅の最小値
 'pythondll'		    Python 2 動的ライブラリの名前
+'pythonhome'		    Python 2 ホームディレクトリの名前
 'pythonthreedll'	    Python 3 動的ライブラリの名前
+'pythonthreehome'	    Python 3 ホームディレクトリの名前
 'pyxversion'	  'pyx'	    pyx* コマンドに使用される Python のバージョン
 'quoteescape'	  'qe'	    文字列中に使われるエスケープ文字
 'readonly'	  'ro'      バッファの書き込みを制限する
@@ -937,6 +944,9 @@
 'termbidi'	  'tbidi'   ターミナルが双方向性を持っている
 'termencoding'	  'tenc'    ターミナルが使用する文字コード
 'termguicolors'	  'tgc'     ターミナルで GUI カラーを使う
+'termwinkey'	  'twk'     端末で Vim コマンドを開始するためのキー
+'termwinscroll'	  'twsl'    端末ウィンドウでスクロールバックできる行数の最大値
+'termwinsize'	  'tws'     端末ウィンドウのサイズ
 'terse'			    いくつかのメッセージを省略する
 'textauto'	  'ta'      廃止。今は 'fileformats' を使う
 'textmode'	  'tx'      廃止。今は 'fileformat' を使う
@@ -970,6 +980,7 @@
 'viewdir'	  'vdir'    |:mkview|によるファイルを格納するディレクトリ
 'viewoptions'	  'vop'     |:mkview|の保存内容を決める
 'viminfo'	  'vi'      起動時と終了時に.viminfoファイルを使う
+'viminfofile'	  'vif'     viminfo ファイル用のファイル名
 'virtualedit'	  've'      フリーカーソルモードを使う場面
 'visualbell'	  'vb'      ビープの代わりにvisualベル(画面フラッシュ)を使用
 'warn'			    バッファ変更済み時にシェル使用で警告する
@@ -989,6 +1000,7 @@
 'winfixwidth'	  'wfh'     ウィンドウの幅をキープする
 'winminheight'	  'wmh'     カレントウィンドウ以外のウィンドウの高さの最小値
 'winminwidth'	  'wmw'     カレントウィンドウ以外のウィンドウの幅の最小値
+'winptydll'		    winpty 動的ライブラリの名前
 'winwidth'	  'wiw'     カレントウィンドウの幅の最小値
 'wrap'			    長い行を折り返して表示する
 'wrapmargin'	  'wm'      折り返しを開始する右端からの文字数
@@ -1319,6 +1331,7 @@
 |:vertical|	:vertical {cmd}		{cmd}が縦分割するようにする
 |:sfind|	:sf[ind] {file}		ウィンドウを分割し、{file}を 'path'
 					中で探し、それを編集
+|:terminal|	:terminal {cmd}		端末ウィンドウを開く
 |CTRL-W_]|	CTRL-W ]		ウィンドウを分割し、カーソル下のタグ
 					にジャンプ
 |CTRL-W_f|	CTRL-W f		ウィンドウを分割し、カーソル下のファ

--- a/en/quickref.txt
+++ b/en/quickref.txt
@@ -1,4 +1,4 @@
-*quickref.txt*  For Vim version 8.0.  Last change: 2016 Dec 16
+*quickref.txt*  For Vim version 8.1.  Last change: 2018 Apr 18
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -618,7 +618,8 @@ Short explanation of each option:		*option-list*
 'backupext'	  'bex'     extension used for the backup file
 'backupskip'	  'bsk'     no backup for files that match these patterns
 'balloondelay'	  'bdlay'   delay in mS before a balloon may pop up
-'ballooneval'	  'beval'   switch on balloon evaluation
+'ballooneval'	  'beval'     switch on balloon evaluation in the GUI
+'balloonevalterm' 'bevalterm' switch on balloon evaluation in the terminal
 'balloonexpr'	  'bexpr'   expression to show in balloon
 'belloff'	  'bo'	    do not ring the bell for these reasons
 'binary'	  'bin'     read/write/edit file in binary mode
@@ -749,6 +750,7 @@ Short explanation of each option:		*option-list*
 'iminsert'	  'imi'     use :lmap or IM in Insert mode
 'imsearch'	  'ims'     use :lmap or IM when typing a search pattern
 'imstatusfunc'    'imsf'    function to obtain X input method status
+'imstyle'	  'imst'    specifies the input style of the input method
 'include'	  'inc'     pattern to be used to find an include file
 'includeexpr'	  'inex'    expression used to process an include line
 'incsearch'	  'is'	    highlight match while typing search pattern
@@ -779,6 +781,8 @@ Short explanation of each option:		*option-list*
 'listchars'	  'lcs'     characters for displaying in list mode
 'loadplugins'	  'lpl'     load plugin scripts when starting up
 'luadll'		    name of the Lua dynamic library
+'mzschemedll'		    name of the MzScheme dynamic library
+'mzschemegcdll'		    name of the MzScheme dynamic library for GC
 'macatsui'		    Mac GUI: use ATSUI text drawing
 'magic'			    changes special characters in search patterns
 'makeef'	  'mef'     name of the errorfile for ":make"
@@ -834,8 +838,11 @@ Short explanation of each option:		*option-list*
 'printoptions'	  'popt'    controls the format of :hardcopy output
 'prompt'	  'prompt'  enable prompt in Ex mode
 'pumheight'	  'ph'	    maximum height of the popup menu
+'pumwidth'	  'pw'	    minimum width of the popup menu
 'pythondll'		    name of the Python 2 dynamic library
+'pythonhome'		    name of the Python 2 home directory
 'pythonthreedll'	    name of the Python 3 dynamic library
+'pythonthreehome'	    name of the Python 3 home directory
 'pyxversion'	  'pyx'	    Python version used for pyx* commands
 'quoteescape'	  'qe'	    escape characters used in a string
 'readonly'	  'ro'	    disallow writing the buffer
@@ -920,6 +927,9 @@ Short explanation of each option:		*option-list*
 'termbidi'	  'tbidi'   terminal takes care of bi-directionality
 'termencoding'	  'tenc'    character encoding used by the terminal
 'termguicolors'	  'tgc'     use GUI colors for the terminal
+'termwinkey'	  'twk'	    key that precedes a Vim command in a terminal
+'termwinscroll'   'twsl'    max number of scrollback lines in a terminal window
+'termwinsize'	  'tws'	    size of a terminal window
 'terse'			    shorten some messages
 'textauto'	  'ta'	    obsolete, use 'fileformats'
 'textmode'	  'tx'	    obsolete, use 'fileformat'
@@ -952,6 +962,7 @@ Short explanation of each option:		*option-list*
 'viewdir'	  'vdir'    directory where to store files with :mkview
 'viewoptions'	  'vop'     specifies what to save for :mkview
 'viminfo'	  'vi'	    use .viminfo file upon startup and exiting
+'viminfofile'	  'vif'	    file name used for the viminfo file
 'virtualedit'	  've'	    when to use virtual editing
 'visualbell'	  'vb'	    use visual bell instead of beeping
 'warn'			    warn for shell command when buffer was changed
@@ -971,6 +982,7 @@ Short explanation of each option:		*option-list*
 'winfixwidth'	  'wfw'     keep window width when opening/closing windows
 'winminheight'	  'wmh'     minimum number of lines for any window
 'winminwidth'	  'wmw'     minimal number of columns for any window
+'winptydll'		    name of the winpty dynamic library
 'winwidth'	  'wiw'     minimal number of columns for current window
 'wrap'			    long lines wrap and continue on the next line
 'wrapmargin'	  'wm'	    chars from the right where wrapping starts
@@ -1309,6 +1321,7 @@ Context-sensitive completion on the command-line:
 
 |:sfind|	:sf[ind] {file}		split window, find {file} in 'path'
 					   and edit it
+|:terminal|	:terminal {cmd}		open a terminal window
 |CTRL-W_]|	CTRL-W ]		split window and jump to tag under
 					   cursor
 |CTRL-W_f|	CTRL-W f		split window and edit file name under


### PR DESCRIPTION
For issue #207
quickref.txt および quickref.jax を Vim 8.1 用に更新しました。
ご確認お願いいたします。