### PR TITLE
Update autocmd from Vim 8.0 to 8.1

### DIFF
--- a/doc/autocmd.jax
+++ b/doc/autocmd.jax
@@ -980,9 +980,9 @@ TermChanged			オプション 'term' を変更した後。色やフォント等�
 				たバッファ全てで発生する。
 							*TerminalOpen*
 TerminalOpen			`:terminal` もしくは |term_start()| により端末
-				バッファが生成された直後。このイベント
-				は、++hidden オプションによってウィンドウなし
-				にバッファが生成された場合でも発生する。
+				バッファが生成された直後。このイベントは、
+				++hidden オプションによってウィンドウなしに
+				バッファが生成された場合でも発生する。
 							*TermResponse*
 TermResponse			|t_RV| に対する応答をターミナルから受け取った
 				とき。Vim変数 |v:termresponse| の値を使って、

--- a/doc/autocmd.jax
+++ b/doc/autocmd.jax
@@ -1,10 +1,10 @@
-*autocmd.txt*   For Vim バージョン 8.0.  Last change: 2017 Jan 14
+*autocmd.txt*   For Vim バージョン 8.1.  Last change: 2018 May 03
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar
 
 
-自動コマンド						*autocommand*
+自動コマンド					*autocommand* *autocommands*
 
 基本的な説明については、ユーザーマニュアルの |40.3| 章を参照。
 
@@ -21,7 +21,6 @@
 11.自動コマンドを無効にする		|autocmd-disable|
 
 {Vi にはこれらのコマンドはない}
-{only: |+autocmd| の機能は、コンパイル時に有効にされていなければ使えない。}
 
 ==============================================================================
 1. はじめに						*autocmd-intro*
@@ -33,7 +32,7 @@
 ることができる。圧縮ファイルを編集するといったような機能だ (|gzip-example| を
 参照)。こういった自動コマンドはファイル .vimrc かファイル .exrc に書き込む。
 
-					*E203* *E204* *E143* *E855* *E937*
+				*E203* *E204* *E143* *E855* *E937* *E952*
 警告: 自動コマンドは大変強力であるので、思いも寄らない副作用をもたらすことがあ
 る。テキストを壊さないように注意しなければならない。
 - 捨ててもよいようなファイルのコピーに対して、最初にテストしておくのがよい。例
@@ -56,6 +55,8 @@
 			{pat} |autocmd-patterns| に一致するファイルで、{event}
 			のときに自動的に実行するコマンドのリストに、{cmd} を加
 			える。
+			Note: クォートは :autocmd への引数と見なされ、コメント
+			を開始しない。
 			{cmd} は常に既存の自動コマンドの後に追加されるので、
 			自動コマンドは指定された順に実行される。 [nested] につ
 			いては|autocmd-nested| を参照。
@@ -67,7 +68,14 @@ Note: '|' が {cmd} の前にある場合、":autocmd" コマンドの後には�
 けることができる。これは動作する: >
 	:augroup mine | au! BufRead | augroup END
 しかし、これは定義されたコマンドの一部として "augroup" を見る: >
+	:augroup mine | au! BufRead * | augroup END
 	:augroup mine | au BufRead * set tw=70 | augroup END
+代わりにグループ名をコマンドの中に置くことができる: >
+	:au! mine BufRead *
+	:au mine BufRead * set tw=70
+もしくは `:execute` を使用する: >
+	:augroup mine | exe "au! BufRead *" | augroup END
+	:augroup mine | exe "au BufRead * set tw=70" | augroup END
 
 Note ":autocmd" の引数の中の特別な文字 (例えば "%" や "<cword>" 等) は、
 自動コマンドが定義されたときに展開されるのではなく、イベントの発生が認識され、
@@ -83,7 +91,8 @@ Note ":autocmd" の引数の中の特別な文字 (例えば "%" や "<cword>" �
 れを避けるには、グループ内に自動コマンドを定義することで、簡単にクリアできる:
 >
 	augroup vimrc
-	  autocmd!	" 「全ての」vimrcの自動コマンドを削除する
+	  " 「全ての」vimrcの自動コマンドを削除する
+	  autocmd!
 	  au BufNewFile,BufRead *.html so <sfile>:h/html.vim
 	augroup END
 
@@ -140,6 +149,8 @@ Note [group] はあらかじめ定義されていなければならないこと�
 			イトなどを壊すことがある。
 
 :au[tocmd]! [group]	「全ての」自動コマンドを除去する。
+			Note: クォートは :autocmd への引数と見なされ、コメント
+			を開始しない。
 			警告: 通常はグループなしでこれを行うべきではない。プラ
 			グインや構文の強調表示などが壊れる。
 
@@ -258,6 +269,7 @@ Vimは以下のイベントを認識する。イベント名が大文字か小�
 |BufCreate|		バッファリストにバッファを追加した直後
 |BufDelete|		バッファリストからバッファを削除する前
 |BufWipeout|		完全にバッファを削除する前
+|TerminalOpen|		端末バッファが生成された後
 
 |BufFilePre|		カレントバッファの名前を変える前
 |BufFilePost|		カレントバッファの名前を変えた後
@@ -286,7 +298,8 @@ Vimは以下のイベントを認識する。イベント名が大文字か小�
 |GUIFailed|		GUIの起動が失敗した後
 |TermResponse|		|t_RV|に対する端末の反応を受け取った後
 
-|QuitPre|		`:quit` を使ったとき、本当に閉じるか決定する前
+|QuitPre|		`:quit` を使ったとき、本当に終了するか決定する前
+|ExitPre|		Vimを終了するコマンドを使ったとき
 |VimLeavePre|		Vimを終了する前、viminfoファイルを書き出す前
 |VimLeave|		Vimを終了する前、viminfoファイルを書き出した後
 
@@ -294,6 +307,8 @@ Vimは以下のイベントを認識する。イベント名が大文字か小�
 |FileChangedShell|	編集を始めた後にファイルが変更されたことを検出したとき
 |FileChangedShellPost|	編集を始めた後にファイルが変更されたことに対処した後
 |FileChangedRO|		読み込み専用ファイルに対して最初に変更を加える前
+
+|DirChanged|		作業ディレクトリが変更された後
 
 |ShellCmdPost|		シェルコマンドを実行した後
 |ShellFilterPost|	シェルコマンドでフィルタをかけた後
@@ -324,6 +339,10 @@ Vimは以下のイベントを認識する。イベント名が大文字か小�
 |CmdwinEnter|		コマンドラインウィンドウに入った後
 |CmdwinLeave|		コマンドラインウィンドウから離れる前
 
+|CmdlineChanged|	コマンドラインのテキストに変更が加えられた後
+|CmdlineEnter|		カーソルがコマンドラインに移動した後
+|CmdlineLeave|		カーソルがコマンドラインを離れる前
+
 |InsertEnter|		挿入モードを開始したとき
 |InsertChange|		挿入や置換モードで<Insert>をタイプしたとき
 |InsertLeave|		挿入モードを抜けるとき
@@ -331,8 +350,13 @@ Vimは以下のイベントを認識する。イベント名が大文字か小�
 			前
 
 |TextChanged|		ノーマルモードでテキストが変更された後
-|TextChangedI|		挿入モードでテキストが変更された後
+|TextChangedI|		ポップアップメニューが表示されていないときに、挿入モー
+			ドでテキストが変更された後
+|TextChangedP|		ポップアップメニューが表示されているときに、挿入モード
+			でテキストが変更された後
+|TextYankPost|		テキストがヤンクもしくは削除された後
 
+|ColorSchemePre|	カラースキームを読み込む前
 |ColorScheme|		カラースキームを読み込んだ後
 
 |RemoteReply|		Vimサーバーからの返答を受け取ったとき
@@ -455,6 +479,10 @@ BufWinEnter			バッファがウィンドウ内に表示された後。これは
 				まま使われるためである。しかし、カレントバッファ
 				の名前を指定して ":split" をすると、そのバッファ
 				を再読み込みすることになるので、発生する。
+				端末ウィンドウでは発生しない。何故なら端末ジョ
+				ブモードで開始され、ノーマルモードコマンドは機
+				能しないからである。代わりに |TerminalOpen| を
+				使用すること。
 							*BufWinLeave*
 BufWinLeave			バッファがウィンドウから取り除かれる前。そのバッ
 				ファが別のウィンドウ内で表示中ならば発生しない。
@@ -505,6 +533,28 @@ CmdUndefined			ユーザー定義コマンドが使われたが、定義され�
 				マンドを常に定義するようにしてそのコマンドから
 				autoload 関数を呼び出すようにするという方法も
 				ある。|autoload| 参照。
+							*CmdlineChanged*
+CmdlineChanged			コマンドラインのテキストに変更が加えられた後。
+				Vim が固まってしまう可能性があるので、コマンド
+				ラインで間違いを起こさないよう注意すること。
+				<afile> はコマンドラインの種類を示す 1 文字に
+				設定される。
+				|cmdwin-char|
+							*CmdlineEnter*
+CmdlineEnter			ユーザーがコマンドを入力もしくは文字列を検索で
+				きるコマンドラインにカーソルが移動した後。
+				<afile> はコマンドラインの種類を示す 1 文字に
+				設定される。
+				|cmdwin-char|
+							*CmdlineLeave*
+CmdlineLeave			カーソルがコマンドラインを離れる前。CTRL-C も
+				しくは <Esc> の入力によってコマンドラインを放
+				棄する場合も同様。
+				コマンドの結果がエラーとなる場合は、コマンドラ
+				インは引き続き実行中となる。
+				<afile> はコマンドラインの種類を示す 1 文字に
+				設定される。
+				|cmdwin-char|
 							*CmdwinEnter*
 CmdwinEnter			Command-lineウィンドウに入った後。この特殊な
 				ウィンドウに対してのみオプションを設定するのに
@@ -524,6 +574,12 @@ ColorScheme			カラースキームを読み込んだ後。 |:colorscheme|
 				パターンはカラースキーム名にマッチする。
 				<afile> はこのオプションを設定したファイルの名
 				前になる。<amatch> はカラースキーム名になる。
+
+							*ColorSchemePre*
+ColorSchemePre			カラースキームを読み込む前。|:colorscheme|
+				あるカラースキームが読み込まれる前に、それ以前
+				に別のカラースキームによって追加されたものを取
+				り除くのに便利。
 
 							*CompleteDone*
 CompleteDone			挿入モード補完が完了したとき。補完が実行されて
@@ -608,14 +664,33 @@ FileChangedRO			読み込み専用ファイルに最初の変更を加える前�
 							*E881*
 				行数が変化した場合 undo のための保存は失敗し、
 				その変更は中止されるだろう。
+							*DirChanged*
+DirChanged			|:cd| もしくは |:lcd| コマンドによって、もしく
+				は 'autochdir' オプションの結果として作業ディ
+				レクトリが変更された後。
+				パターンは以下のようになる:
+					"window" `:lcd` により発生する
+					"global" `:cd` により発生する
+					"auto"   'autochdir' により発生する
+					"drop"   ファイルの編集により発生する
+				<afile> は新ディレクトリ名に設定される。
+							*ExitPre*
+ExitPre				Vim を終了させる `:quit`, `:wq` もしくは
+				`:qall` を使用したときで、|QuitPre| の直後。不
+				必要なウィンドウを閉じるのに使うことができる。
+				自動的に保存されない変更済みのバッファがある場
+				合には、終了はまだキャンセルされる可能性があ
+				る。本当に終了するときのためには |VimLeavePre|
+				を使用すること。
 							*FileChangedShell*
 FileChangedShell		ファイルのタイムスタンプが、ファイルの編集が始
 				まってから変更されたことを発見したとき。
 				ファイルの属性やファイルサイズが変更されたとき
 				にも使われる。|timestamp|
 				大抵はシェルコマンドの実行後に発生する。またコ
-				マンド |:checktime| の実行後や、Vimが入力フォー
-				カスを一度失い、再び得たときにも発生する。
+				マンド |:checktime| の実行後や、gvimが入力
+				フォーカスを一度失い、再び得たときにも発生す
+				る。
 				このイベントは変更されたファイルそれぞれに対し
 				て発生する。オプション 'autoread' がオンであり、
 				かつバッファが変更されていないときには使われな
@@ -656,7 +731,8 @@ FileType			オプション 'filetype' が設定されたとき。
 				パターンはファイルタイプに対して照合される。
 				<afile> は 'filetype' が設定されたファイルの名
 				前として使える。<amatch> は 'filetype' の新し
-				い値として使える。
+				い値として使える。他のウィンドウもしくはバッ
+				ファへの移動は許されていない。
 				|filetypes| を参照。
 							*FileWriteCmd*
 FileWriteCmd			バッファ全体を書き込まない場合の、ファイルに書
@@ -733,7 +809,8 @@ InsertCharPre			挿入モードで文字が入力されたとき、その文字�
 				ま (literally) 挿入される。
 				テキストを変更することはできない |textlock|。
 				このイベントは 'paste' がオンに設定されている
-				ときは発行されない。
+				ときは発行されない。{+eval 機能が有効な場合の
+				み}
 							*InsertEnter*
 InsertEnter			挿入モード・置換モード・仮想置換モードを開始す
 				る直前。変数|v:insertmode|がモードを示す。
@@ -804,6 +881,7 @@ QuitPre				`:quit`, `:wq`, `:qall` を使ったとき、カレント
 				定する前に発行される。例えば、普通のウィンドウ
 				がカレントウィンドウだけだったときに、他の余分
 				なウィンドウを閉じることができる。
+				|ExitPre| も参照。
 							*RemoteReply*
 RemoteReply			サーバーとして働くVimからの応答を受け取ったとき
 				|server2client()|。パターンは{serverid}に対し
@@ -875,7 +953,7 @@ SwapExists			ファイルの編集を始めようとしてスワップファイ�
 							*E812*
 				ここでは他のバッファに切り替えること、バッファ
 				名を変更すること、ディレクトリを変更することは
-				許可されていない。
+				許可されていない。{+eval 機能が有効な場合のみ}
 							*Syntax*
 Syntax				オプション 'syntax' が設定されたとき。
 				パターンは構文名に対して照合される。
@@ -900,6 +978,11 @@ TermChanged			オプション 'term' を変更した後。色やフォント等�
 				ターミナル依存の設定を更新するために構文定義ファ
 				イルを再読み込みするのに便利である。読み込まれ
 				たバッファ全てで発生する。
+							*TerminalOpen*
+TerminalOpen			`:terminal` もしくは |term_start()| により端末
+				バッファが生成された直後。このイベント
+				は、++hidden オプションによってウィンドウなし
+				にバッファが生成された場合でも発生する。
 							*TermResponse*
 TermResponse			|t_RV| に対する応答をターミナルから受け取った
 				とき。Vim変数 |v:termresponse| の値を使って、
@@ -922,10 +1005,36 @@ TextChangedI			挿入モードでカレントバッファのテキストが変�
 				ポップアップメニューが表示されているときは発生
 				しない。
 				他は TextChanged と同じ。
+							*TextChangedP*
+TextChangedP			挿入モードでカレントバッファのテキストに変更が
+				加えられた後で、ポップアップメニューが表示され
+				ている場合に限られる。そうでなければ
+				TextChanged と同じ。
+							*TextYankPost*
+TextYankPost			カレントバッファでテキストがヤンクもしくは削除
+				された後。|v:event| の以下の値は、この autocmd
+				を発生させた操作を特定するのに使用できる:
+				   operator	オペレーションが実行された。
+				   regcontents	行のリストとしてレジスタに格納
+						されたテキスト、例: >
+						getreg(r, 1, 1)
+<				   regname	レジスタの名前、もしくは無名レ
+						ジスタの場合は空文字列。
+				   regtype	レジスタの種類、|getregtype()|
+						を参照。
+				|quote_| が使用された場合、もしくは再帰的に呼
+				び出された場合には発生しない。
+				バッファのテキストを変更することは許されていな
+				い、|textlock| を参照。
+				{+eval 機能付きでコンパイルされた場合のみ有効}
 							*User*
 User				自動的に実行されることはない。コマンド
 				":doautocmd" によってのみ実行される
 				自動コマンドのために使用される。
+				Note: 該当する自動コマンドが存在しないときに
+				`:doautocmd User MyEvent` が使用された場合、エ
+				ラーが発生する。これを回避したい場合、ダミーの
+				自動コマンドを自身で定義すること。
 							*UserGettingBored*
 UserGettingBored		ユーザーが同じキーを 42 回押したとき。
 				ただの冗談！ :-)
@@ -969,9 +1078,10 @@ WinEnter			別のウィンドウに入った後。Vimの開始直後、1個目
 				ウの高さを設定するのに便利である。
 				そのウィンドウで他のバッファを開いていたときは、
 				イベント WinEnter の後に BufEnter が発生する。
-				Note: ":split fname" を実行したとき、WinEnter
-				が発生するのは、ウィンドウ分割の後だがファイル
-				"fname" が読み込まれる前の時点である。
+				Note: split と tabpage コマンドに関しては、
+				WinEnter イベントが発生するのは分割もしくはタ
+				ブコマンドの後だが、ファイルが読み込まれる前で
+				ある。
 							*WinLeave*
 WinLeave			ウィンドウを離れる前。次に入るウィンドウで他の
 				バッファを開いていたときは、イベント WinLeave

--- a/en/autocmd.txt
+++ b/en/autocmd.txt
@@ -1,10 +1,10 @@
-*autocmd.txt*   For Vim version 8.0.  Last change: 2017 Jan 14
+*autocmd.txt*   For Vim version 8.1.  Last change: 2018 May 03
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
 
 
-Automatic commands					*autocommand*
+Automatic commands				*autocommand* *autocommands*
 
 For a basic explanation, see section |40.3| in the user manual.
 
@@ -21,7 +21,6 @@ For a basic explanation, see section |40.3| in the user manual.
 11. Disabling autocommands	|autocmd-disable|
 
 {Vi does not have any of these commands}
-{only when the |+autocmd| feature has not been disabled at compile time}
 
 ==============================================================================
 1. Introduction						*autocmd-intro*
@@ -33,7 +32,7 @@ files matching *.c.  You can also use autocommands to implement advanced
 features, such as editing compressed files (see |gzip-example|).  The usual
 place to put autocommands is in your .vimrc or .exrc file.
 
-					*E203* *E204* *E143* *E855* *E937*
+				*E203* *E204* *E143* *E855* *E937* *E952*
 WARNING: Using autocommands is very powerful, and may lead to unexpected side
 effects.  Be careful not to destroy your text.
 - It's a good idea to do some testing on an expendable copy of a file first.
@@ -57,6 +56,8 @@ effects.  Be careful not to destroy your text.
 			Add {cmd} to the list of commands that Vim will
 			execute automatically on {event} for a file matching
 			{pat} |autocmd-patterns|.
+			Note: A quote character is seen as argument to the
+			:autocmd and won't start a comment.
 			Vim always adds the {cmd} after existing autocommands,
 			so that the autocommands execute in the order in which
 			they were given.  See |autocmd-nested| for [nested].
@@ -68,7 +69,14 @@ Note: The ":autocmd" command can only be followed by another command when the
 '|' appears before {cmd}.  This works: >
 	:augroup mine | au! BufRead | augroup END
 But this sees "augroup" as part of the defined command: >
+	:augroup mine | au! BufRead * | augroup END
 	:augroup mine | au BufRead * set tw=70 | augroup END
+Instead you can put the group name into the command: >
+	:au! mine BufRead *
+	:au mine BufRead * set tw=70
+Or use `:execute`: >
+	:augroup mine | exe "au! BufRead *" | augroup END
+	:augroup mine | exe "au BufRead * set tw=70" | augroup END
 
 Note that special characters (e.g., "%", "<cword>") in the ":autocmd"
 arguments are not expanded when the autocommand is defined.  These will be
@@ -85,7 +93,8 @@ will appear twice.  To avoid this, define your autocommands in a group, so
 that you can easily clear them: >
 
 	augroup vimrc
-	  autocmd!	" Remove all vimrc autocommands
+	  " Remove all vimrc autocommands
+	  autocmd!
 	  au BufNewFile,BufRead *.html so <sfile>:h/html.vim
 	augroup END
 
@@ -139,6 +148,8 @@ prompt.  When one command outputs two messages this can happen anyway.
 			plugins, syntax highlighting, etc.
 
 :au[tocmd]! [group]	Remove ALL autocommands.
+			Note: a quote will be seen as argument to the :autocmd
+			and won't start a comment.
 			Warning: You should normally not do this without a
 			group, it breaks plugins, syntax highlighting, etc.
 
@@ -251,6 +262,7 @@ Name			triggered by ~
 |BufCreate|		just after adding a buffer to the buffer list
 |BufDelete|		before deleting a buffer from the buffer list
 |BufWipeout|		before completely deleting a buffer
+|TerminalOpen|		after a terminal buffer was created
 
 |BufFilePre|		before changing the name of the current buffer
 |BufFilePost|		after changing the name of the current buffer
@@ -279,7 +291,8 @@ Name			triggered by ~
 |GUIFailed|		after starting the GUI failed
 |TermResponse|		after the terminal response to |t_RV| is received
 
-|QuitPre|		when using `:quit`, before deciding whether to quit
+|QuitPre|		when using `:quit`, before deciding whether to exit
+|ExitPre|		when using a command that may make Vim exit
 |VimLeavePre|		before exiting Vim, before writing the viminfo file
 |VimLeave|		before exiting Vim, after writing the viminfo file
 
@@ -287,6 +300,8 @@ Name			triggered by ~
 |FileChangedShell|	Vim notices that a file changed since editing started
 |FileChangedShellPost|	After handling a file changed since editing started
 |FileChangedRO|		before making the first change to a read-only file
+
+|DirChanged|		after the working directory has changed
 
 |ShellCmdPost|		after executing a shell command
 |ShellFilterPost|	after filtering with a shell command
@@ -315,6 +330,10 @@ Name			triggered by ~
 |CmdwinEnter|		after entering the command-line window
 |CmdwinLeave|		before leaving the command-line window
 
+|CmdlineChanged|	after a change was made to the command-line text
+|CmdlineEnter|		after the cursor moves to the command line
+|CmdlineLeave|		before the cursor leaves the command line
+
 |InsertEnter|		starting Insert mode
 |InsertChange|		when typing <Insert> while in Insert or Replace mode
 |InsertLeave|		when leaving Insert mode
@@ -323,7 +342,12 @@ Name			triggered by ~
 
 |TextChanged|		after a change was made to the text in Normal mode
 |TextChangedI|		after a change was made to the text in Insert mode
+			when popup menu is not visible
+|TextChangedP|		after a change was made to the text in Insert mode
+			when popup menu visible
+|TextYankPost|		after text is yanked or deleted
 
+|ColorSchemePre|	before loading a color scheme
 |ColorScheme|		after loading a color scheme
 
 |RemoteReply|		a reply from a server Vim was received
@@ -445,6 +469,9 @@ BufWinEnter			After a buffer is displayed in a window.  This
 				existing buffer.  But it does happen for a
 				":split" with the name of the current buffer,
 				since it reloads that buffer.
+				Does not happen for a terminal window, because
+				it starts in Terminal-Job mode and Normal mode
+				commands won't work. Use |TerminalOpen| instead.
 							*BufWinLeave*
 BufWinLeave			Before a buffer is removed from a window.
 				Not when it's still visible in another window.
@@ -492,6 +519,29 @@ CmdUndefined			When a user command is used but it isn't
 				command is defined.  An alternative is to
 				always define the user command and have it
 				invoke an autoloaded function.  See |autoload|.
+							*CmdlineChanged*
+CmdlineChanged			After a change was made to the text in the
+				command line.  Be careful not to mess up
+				the command line, it may cause Vim to lock up.
+				<afile> is set to a single character,
+				indicating the type of command-line.
+				|cmdwin-char|
+							*CmdlineEnter*
+CmdlineEnter			After moving the cursor to the command line,
+				where the user can type a command or search
+				string.
+				<afile> is set to a single character,
+				indicating the type of command-line.
+				|cmdwin-char|
+							*CmdlineLeave*
+CmdlineLeave			Before leaving the command line.
+				Also when abandoning the command line, after
+				typing CTRL-C or <Esc>.
+				When the commands result in an error the
+				command line is still executed.
+				<afile> is set to a single character,
+				indicating the type of command-line.
+				|cmdwin-char|
 							*CmdwinEnter*
 CmdwinEnter			After entering the command-line window.
 				Useful for setting options specifically for
@@ -516,6 +566,10 @@ ColorScheme			After loading a color scheme. |:colorscheme|
 				set, and <amatch> for the new colorscheme
 				name.
 
+							*ColorSchemePre*
+ColorSchemePre			Before loading a color scheme. |:colorscheme|
+				Useful to setup removing things added by a
+				color scheme, before another one is loaded.
 
 							*CompleteDone*
 CompleteDone			After Insert mode completion is done.  Either
@@ -602,6 +656,24 @@ FileChangedRO			Before making the first change to a read-only
 							*E881*
 				If the number of lines changes saving for undo
 				may fail and the change will be aborted.
+							*DirChanged*
+DirChanged			The working directory has changed in response
+				to the |:cd| or |:lcd| commands, or as a
+				result of the 'autochdir' option.
+				The pattern can be:
+					"window" to trigger on `:lcd
+					"global" to trigger on `:cd`
+					"auto"   to trigger on 'autochdir'.
+					"drop"	 to trigger on editing a file
+				<afile> is set to the new directory name.
+							*ExitPre*
+ExitPre				When using `:quit`, `:wq` in a way it makes
+				Vim exit, or using `:qall`, just after
+				|QuitPre|.  Can be used to close any
+				non-essential window.  Exiting may still be
+				cancelled if there is a modified buffer that
+				isn't automatically saved, use |VimLeavePre|
+				for really exiting.
 							*FileChangedShell*
 FileChangedShell		When Vim notices that the modification time of
 				a file has changed since editing started.
@@ -610,7 +682,7 @@ FileChangedShell		When Vim notices that the modification time of
 				|timestamp|
 				Mostly triggered after executing a shell
 				command, but also with a |:checktime| command
-				or when Gvim regains input focus.
+				or when gvim regains input focus.
 				This autocommand is triggered for each changed
 				file.  It is not used when 'autoread' is set
 				and the buffer was not changed.  If a
@@ -621,7 +693,7 @@ FileChangedShell		When Vim notices that the modification time of
 				to tell Vim what to do next.
 				NOTE: When this autocommand is executed, the
 				current buffer "%" may be different from the
-				buffer that was changed "<afile>".
+				buffer that was changed, which is in "<afile>".
 				NOTE: The commands must not change the current
 				buffer, jump to another buffer or delete a
 				buffer.  *E246* *E811*
@@ -651,7 +723,8 @@ FileType			When the 'filetype' option has been set.  The
 				pattern is matched against the filetype.
 				<afile> can be used for the name of the file
 				where this option was set, and <amatch> for
-				the new value of 'filetype'.
+				the new value of 'filetype'.  Navigating to
+				another window or buffer is not allowed.
 				See |filetypes|.
 							*FileWriteCmd*
 FileWriteCmd			Before writing to a file, when not writing the
@@ -738,7 +811,7 @@ InsertCharPre			When a character is typed in Insert mode,
 				inserted literally.
 				It is not allowed to change the text |textlock|.
 				The event is not triggered when 'paste' is
-				set.
+				set. {only with the +eval feature}
 							*InsertEnter*
 InsertEnter			Just before starting Insert mode.  Also for
 				Replace mode and Virtual Replace mode.  The
@@ -816,6 +889,7 @@ QuitPre				When using `:quit`, `:wq` or `:qall`, before
 				or quits Vim.  Can be used to close any
 				non-essential window if the current window is
 				the last ordinary window.
+				Also see |ExitPre|.
 							*RemoteReply*
 RemoteReply			When a reply from a Vim that functions as
 				server was received |server2client()|.  The
@@ -884,6 +958,7 @@ SwapExists			Detected an existing swap file when starting
 				It is not allowed to change to another buffer,
 				change a buffer name or change directory
 				here.
+				{only available with the +eval feature}
 							*Syntax*
 Syntax				When the 'syntax' option has been set.  The
 				pattern is matched against the syntax name.
@@ -910,6 +985,11 @@ TermChanged			After the value of 'term' has changed.  Useful
 				for re-loading the syntax file to update the
 				colors, fonts and other terminal-dependent
 				settings.  Executed for all loaded buffers.
+							*TerminalOpen*
+TerminalOpen			Just after a terminal buffer was created, with
+				`:terminal` or |term_start()|. This event is
+				triggered even if the buffer is created
+				without a window, with the ++hidden option.
 							*TermResponse*
 TermResponse			After the response to |t_RV| is received from
 				the terminal.  The value of |v:termresponse|
@@ -932,10 +1012,39 @@ TextChangedI			After a change was made to the text in the
 				current buffer in Insert mode.
 				Not triggered when the popup menu is visible.
 				Otherwise the same as TextChanged.
+							*TextChangedP*
+TextChangedP			After a change was made to the text in the
+				current buffer in Insert mode, only when the
+				popup menu is visible.  Otherwise the same as
+				TextChanged.
+							*TextYankPost*
+TextYankPost			After text has been yanked or deleted in the
+				current buffer.  The following values of
+				|v:event| can be used to determine the operation
+				that triggered this autocmd:
+				   operator    	The operation performed.
+				   regcontents 	Text that was stored in the
+						register, as a list of lines,
+						like with: >
+						getreg(r, 1, 1)
+<				   regname	Name of the |register| or
+						empty string for the unnamed
+						register.
+				   regtype	Type of the register, see
+						|getregtype()|.
+				Not triggered when |quote_| is used nor when
+				called recursively.
+				It is not allowed to change the buffer text,
+				see |textlock|.
+				{only when compiled with the +eval feature}
 							*User*
 User				Never executed automatically.  To be used for
 				autocommands that are only executed with
 				":doautocmd".
+				Note that when `:doautocmd User MyEvent` is
+				used while there are no matching autocommands,
+				you will get an error.  If you don't want
+				that, define a dummy autocommand yourself.
 							*UserGettingBored*
 UserGettingBored		When the user presses the same key 42 times.
 				Just kidding! :-)
@@ -980,9 +1089,10 @@ WinEnter			After entering another window.  Not done for
 				If the window is for another buffer, Vim
 				executes the BufEnter autocommands after the
 				WinEnter autocommands.
-				Note: When using ":split fname" the WinEnter
-				event is triggered after the split but before
-				the file "fname" is loaded.
+				Note: For split and tabpage commands the
+				WinEnter event is triggered after the split
+				or tab command but before the file is loaded.
+
 							*WinLeave*
 WinLeave			Before leaving a window.  If the window to be
 				entered next is for a different buffer, Vim
@@ -1292,7 +1402,7 @@ Careful: '[ and '] change when using commands that change the buffer.
 In commands which expect a file name, you can use "<afile>" for the file name
 that is being read |:<afile>| (you can also use "%" for the current file
 name).  "<abuf>" can be used for the buffer number of the currently effective
-buffer.  This also works for buffers that doesn't have a name.  But it doesn't
+buffer.  This also works for buffers that don't have a name.  But it doesn't
 work for files without a buffer (e.g., with ":r file").
 
 							*gzip-example*


### PR DESCRIPTION
For issue #207
autocmd.txt および autocmd.jax を Vim 8.1 用に更新しました。
ご確認お願いいたします。