### PR TITLE
help_ja: Highlight [...] w/o preceding space

### DIFF
--- a/syntax/help_ja.vim
+++ b/syntax/help_ja.vim
@@ -5,4 +5,5 @@ syn match helpVim "VIMリファレンス.*"
 syn region helpNotVi start="{Vim" start="{|++\?[A-Za-z0-9_/()]\+|" end="}" contains=helpLeadBlank,helpHyperTextJump
 syn match helpWarning "\<警告:"
 syn region helpTransNote start="{訳注:" end="}" contains=helpLeadBlank,helpHyperTextJump
+syn match helpSpecial "[。、]\zs\[[-a-z^A-Z0-9_]\{2,}]"
 hi def link helpTransNote Special


### PR DESCRIPTION
句読点の直後の `[...]` をハイライトするように変更。

例えば、以下の `[nested]` の前の余分なスペースが不要になります。
https://github.com/vim-jp/vimdoc-ja-working/blob/9ecb4685132783c1801e9001812e95074f2d8c45/doc/autocmd.jax#L61
