### PR TITLE
Update eval from Vim 8.0 to 8.1

### DIFF
--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -9161,16 +9161,16 @@ persistent_undo		永続アンドゥをサポート
 postscript		PostScriptファイルの印刷をサポート
 printer			|:hardcopy| をサポート
 profile			|:profile| をサポート
-python			Python 2.x インタフェースが使用可能。|has-python|
-python_compiled		Python 2.x インタフェース付きでコンパイルされ
-			た。|has-python|
-python_dynamic		Python 2.x インタフェースが動的にロードされ
-			た。|has-python|
-python3			Python 3.x インタフェースが使用可能。|has-python|
-python3_compiled	Python 3.x インタフェース付きでコンパイルされ
-			た。|has-python|
-python3_dynamic		Python 3.x インタフェースが動的にロードされ
-			た。|has-python|
+python			Python 2.x インターフェイスが使用可能。|has-python|
+python_compiled		Python 2.x インターフェイス付きでコンパイルされた。
+			|has-python|
+python_dynamic		Python 2.x インターフェイスが動的にロードされた。
+			|has-python|
+python3			Python 3.x インターフェイスが使用可能。|has-python|
+python3_compiled	Python 3.x インターフェイス付きでコンパイルされた。
+			|has-python|
+python3_dynamic		Python 3.x インターフェイスが動的にロードされた。
+			|has-python|
 pythonx			Compiled with |python_x| interface. |has-pythonx|
 qnx			QNXバージョン
 quickfix		|quickfix|をサポート

--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim バージョン 8.0.  Last change: 2017 Mar 09
+*eval.txt*	For Vim バージョン 8.1.  Last change: 2018 May 17
 
 
 		VIMリファレンスマニュアル    by Bram Moolenaar
@@ -113,9 +113,9 @@ Note 次のコマンドをみると >
 							*non-zero-arg*
 関数の引数は、|TRUE| とは少し異なる場合がある: 引数が存在し、それが非ゼロの
 Number、|v:true| または空でない String に評価される場合、値は TRUE と見なされ
-る。" " と "0" も空文字列ではないので、モードをクリアするのに注意すること。
-List、Dictionary、または Float は数値または文字列ではないため、FALSE と評価さ
-れる。
+る。
+Note: " " と "0" も空文字列ではないので、TRUE と見なされる。List、Dictionary、
+または Float は数値または文字列ではないため、FALSE と評価される。
 
 		*E745* *E728* *E703* *E729* *E730* *E731* *E908* *E910* *E913*
 リスト、辞書、Funcref、ジョブ、チャネルは自動的に変換されない。
@@ -922,12 +922,19 @@ expr7							*expr7*
 
 expr8							*expr8*
 -----
+この式は |expr9|、もしくは連続する以下の選択方式であり、どんな順番でもよい。
+例として、これらはすべて考えられる:
+	expr9[expr1].name
+	expr9.name[expr1]
+	expr9(expr1, ...)[expr1].name
+
+
 expr8[expr1]		文字列またはリストの要素	*expr-[]* *E111*
 							*E909* *subscript*
 expr8が数値か文字列ならば、この値は文字列 expr8 の第 expr1 番目のバイトからな
 る 1 バイトの文字列となる。expr8は文字列、expr1は数として扱われる。ただし
 expr8 がマルチバイト文字列である場合、この値は単なるバイトコードであり、1文字
-とはならないかもしれないことに注意。マルチバイト文字列に対する代替方法は
+とはならないかもしれないことに注意。マルチバイト文字列に対する選択方式は
 `byteidx()` を参照するか、`split()`を使って文字列を文字のリストに変換すれば良
 い。
 
@@ -1201,7 +1208,7 @@ function(expr1, ...)	関数呼出
 							*closure*
 ラムダ式は外側のスコープの変数と引数にアクセスできる。これはよくクロージャと呼
 ばれる。以下の例ではラムダの中で "i" と "a:arg" が使われているが、これらは関数
-のスコープに存在する。これらは関数から抜けても有効であり続ける: >
+のスコープに既に存在する。これらは関数から抜けても有効であり続ける: >
 	:function Foo(arg)
 	:  let i = 3
 	:  return {x -> x + i - a:arg}
@@ -1210,7 +1217,10 @@ function(expr1, ...)	関数呼出
 	:echo Bar(6)
 <	5
 
-|:func-closure|も参照。ラムダとクロージャのサポートは以下のように判定できる: >
+Note: これが正しく機能するためには、ラムダが定義される前の外側のスコープ内にそ
+れらの変数が存在していなければならない。|:func-closure|も参照。
+
+ラムダとクロージャのサポートは以下のように判定できる: >
 	if has('lambda')
 
 |sort()|, |map()|, |filter()|とともにラムダ式を使う例: >
@@ -1400,8 +1410,8 @@ v:beval_text	マウスポインタの下もしくは後ろにあるテキスト�
 		の下より前にあるドットと "->" は含まれる。マウスポインタが ']'
 		の上にあるときは、そこから対応する '[' とその前にあるテキスト
 		までが含まれる。マウスポインタが1行に収まるビジュアル領域の上
-		にあるときはその選択領域となる。オプション 'balloonexpr' を評
-		価している最中のみ有効。
+		にあるときはその選択領域となる。|<cexpr>| も参照。
+		オプション 'balloonexpr' を評価している最中のみ有効。
 
 					*v:beval_winnr* *beval_winnr-variable*
 v:beval_winnr	マウスポインタがあるウィンドウの番号。オプション 'balloonexpr'
@@ -1495,15 +1505,22 @@ v:errmsg	最後に表示されたエラーメッセージ。この変数は代�
 	:  ...
 <		また "errmsg" は、以前の版のVimとの互換性の為に動作する。
 
-					*v:errors* *errors-variable*
+				*v:errors* *errors-variable* *assert-return*
 v:errors	|assert_true()|のような、テスト用関数によって見つかったエラー。
 		これは文字列のリストである。
 		テスト用関数はテストに失敗した時にエラーを末尾に追加する。
+		戻り値が示すもの: 要素が v:errors に追加された場合 1 が返る。
+		それ以外では 0 が返る。
 		古い結果を削除する方法はこの変数を空にする: >
 	:let v:errors = []
 <		たとえ|v:errors| にリスト以外のいかなる値をセットしたとしても、
 		(次に実行される時に)テスト用関数によって空のリストが設定(上書
 		き)される。
+
+					*v:event* *event-variable*
+v:event		現在の |autocommand| に関する情報を含む辞書。この辞書は
+		|autocommand| が終了したときに空にされる。独立したコピーの取得
+		方法については |dict-identity| を参照。
 
 					*v:exception* *exception-variable*
 v:exception	最も直近に捕捉され、まだ終了していない例外の値。
@@ -1761,7 +1778,7 @@ v:scrollstart	画面のスクロールの原因となったスクリプトや関
 		ために便利。
 
 					*v:servername* *servername-variable*
-v:servername	|x11-clientserver|に登録されている名前。
+v:servername	|client-server-name| で登録された結果。
 		読出し専用。
 
 
@@ -1845,6 +1862,29 @@ v:termresponse	termcapのエントリ|t_RV|で端末から返されるエスケ�
 		 1ならvt220。Pvはパッチレベル(パッチ95で導入されたため常に95以
 		 上)。Pcは常に0。
 		{Vimが|+termresponse|機能付きでコンパイルされたときのみ有効}
+
+						*v:termblinkresp*
+v:termblinkresp	termcapのエントリ |t_RC| で端末から返されるエスケープシーケン
+		ス。端末カーソルが点滅しているかを調べるために使用される。
+		|term_getcursor()| で使用される。
+
+						*v:termstyleresp*
+v:termstyleresp	termcapのエントリ |t_RS| で端末から返されるエスケープシーケン
+		ス。カーソルの形状を調べるために使用される。|term_getcursor()|
+		で使用される。
+
+						*v:termrbgresp*
+v:termrbgresp	termcapのエントリ |t_RS| で端末から返されるエスケープシーケン
+		ス。端末の背景色を調べるために使用される。'background' を参照。
+
+						*v:termrfgresp*
+v:termrfgresp	termcapのエントリ |t_RF| で端末から返されるエスケープシーケン
+		ス。端末の文字色を調べるために使用される。
+
+						*v:termu7resp*
+v:termu7resp	termcapのエントリ |t_u7| で端末から返されるエスケープシーケン
+		ス。曖昧な幅の文字に対して端末が何をするか調べるのに使われる。
+		'ambiwidth' を参照。
 
 					*v:testing* *testing-variable*
 v:testing	`test_garbagecollect_now()` を使う前に設定する必要がある。
@@ -1931,29 +1971,37 @@ arglistid([{winnr} [, {tabnr}]])
 				数値	引数リストID
 argv({nr})			文字列	引数の第{nr}番目
 argv()				リスト	引数リスト
+assert_beeps({cmd})		数値	{cmd} がビープ音を鳴らすことをテストす
+					る
 assert_equal({exp}, {act} [, {msg}])
-				なし	{exp}と{act}が等しいかどうかテストする
+				数値	{exp}と{act}が等しいかどうかテストする
+assert_equalfile({fname-one}, {fname-two})
+				数値	ファイルコンテンツが等しいことをテスト
+					する
 assert_exception({error} [, {msg}])
-				なし	|v:exception|が{error}であるかテストする
+				数値	|v:exception|が{error}であるかテストする
 assert_fails({cmd} [, {error}])
-				なし	{cmd}が失敗するかどうかテストする
+				数値	{cmd}が失敗するかどうかテストする
 assert_false({actual} [, {msg}])
-				なし	{actual}がfalseかどうかテストする
+				数値	{actual}がfalseかどうかテストする
 assert_inrange({lower}, {upper}, {actual} [, {msg}])
-				なし	{actual}が範囲内にあるかテストする
-assert_match({pat}, {text} [, {msg}])    なし  {pat}が{text}にマッチするかテス
+				数値	{actual}が範囲内にあるかテストする
+assert_match({pat}, {text} [, {msg}])    数値  {pat}が{text}にマッチするかテス
 					トする
-assert_notequal({exp}, {act} [, {msg}])  なし  {exp}が{act}と等しくないことを
+assert_notequal({exp}, {act} [, {msg}])  数値  {exp}が{act}と等しくないことを
 					テストする
-assert_notmatch({pat}, {text} [, {msg}]) なし  {pat}が{text}とマッチしないこと
+assert_notmatch({pat}, {text} [, {msg}]) 数値  {pat}が{text}とマッチしないこと
 					をテストする
+assert_report({msg})		数値	テストの失敗を報告する
 assert_true({actual} [, {msg}])
-				なし	{actual}がtrueかどうかテストする
+				数値	{actual}がtrueかどうかテストする
 asin({expr})			浮動小数点数	{expr}のアークサイン
 atan({expr})			浮動小数点数	{expr}のアークタンジェント
 atan2({expr}, {expr})		浮動小数点数	{expr1} / {expr2} のアークタン
 						ジェント
-balloon_show({msg})		なし	{msg} をバルーン内に表示
+balloon_show({expr})		なし	{expr} をバルーン内に表示
+balloon_split({msg})		リスト	{msg} をバルーンで使われるように分割す
+					る
 browse({save}, {title}, {initdir}, {default})
 				文字列	ファイル選択ダイアログを表示
 browsedir({title}, {initdir})	文字列	ディレクトリ選択ダイアログを表示
@@ -2000,7 +2048,7 @@ ch_setoptions({handle}, {options})
 ch_status({handle} [, {options}])
 				文字列	チャネル{handle}の状態
 changenr()			数値	現在の変更番号
-char2nr({expr}[, {utf8}])	数値	{expr}の先頭文字のASCII/UTF8コード
+char2nr({expr} [, {utf8}])	数値	{expr}の先頭文字のASCII/UTF8コード
 cindent({lnum})			数値	{lnum}行目のCインデント量
 clearmatches()			なし	全マッチをクリアする
 col({expr})			数値	カーソルかマークのカラム番号
@@ -2019,8 +2067,11 @@ cscope_connection([{num} , {dbpath} [, {prepend}]])
 cursor({lnum}, {col} [, {off}])
 				数値	カーソルを{lnum}, {col}, {off}へ移動
 cursor({list})			数値	カーソルを{list}の位置へ移動
+debugbreak({pid})		数値	デバッグするプロセスへ割り込む
 deepcopy({expr} [, {noref}])	任意	{expr}の完全なコピーを作る
 delete({fname} [, {flags}])	数値	ファイルやディレクトリ{fname}を消す
+deletebufline({expr}, {first} [, {last}])
+				数値	バッファ {expr} から行を削除する
 did_filetype()			数値	FileTypeのautocommandが実行されたか?
 diff_filler({lnum})		数値	差分モードで{lnum}に挿入された行
 diff_hlID({lnum}, {col})	数値	差分モードで{lnum}/{col}位置の強調
@@ -2042,9 +2093,9 @@ filereadable({file})		数値	{file}が読み込み可能なら|TRUE|
 filewritable({file})		数値	{file}が書き込み可能なら|TRUE|
 filter({expr1}, {expr2})	リスト/辞書  {expr2}が0となる要素を{expr1}から
 					とり除く
-finddir({name}[, {path}[, {count}]])
+finddir({name} [, {path} [, {count}]])
 				文字列	{path}からディレクトリ{name}を探す
-findfile({name}[, {path}[, {count}]])
+findfile({name} [, {path} [, {count}]])
 				文字列	{path}からファイル{name}を探す
 float2nr({expr})		数値	浮動小数点数 {expr} を数値に変換する
 floor({expr})			浮動小数点数	{expr} を切り捨てる
@@ -2072,6 +2123,7 @@ getbufline({expr}, {lnum} [, {end}])
 				リスト	バッファ{expr}の{lnum}から{end}行目
 getbufvar({expr}, {varname} [, {def}])
 				任意	バッファ{expr}の変数 {varname}
+getchangelist({expr})		リスト	変更リスト要素のリスト
 getchar([expr])			数値	ユーザーから1文字を取得する
 getcharmod()			数値	修飾キーの状態を表す数値を取得
 getcharsearch()			辞書	最後の文字検索を取得
@@ -2088,9 +2140,11 @@ getfperm({fname})		文字列	ファイル{fname}の許可属性を取得
 getfsize({fname})		数値	ファイル{fname}のバイト数を取得
 getftime({fname})		数値	ファイルの最終更新時間
 getftype({fname})		文字列	ファイル{fname}の種類の説明
+getjumplist([{winnr} [, {tabnr}]])
+				リスト	ジャンプリスト要素のリスト
 getline({lnum})			文字列	現在のバッファから行の内容を取得
 getline({lnum}, {end})		リスト	カレントバッファの{lnum}から{end}行目
-getloclist({nr})		リスト	ロケーションリストの要素のリスト
+getloclist({nr} [, {what}])	リスト	ロケーションリストの要素のリスト
 getmatches()			リスト	現在のマッチのリスト
 getpid()			数値	Vim のプロセス ID
 getpos({expr})			リスト	カーソル・マークなどの位置を取得
@@ -2103,9 +2157,11 @@ gettabvar({nr}, {varname} [, {def}])
 				任意	タブ{nr}の変数{varname}または{def}
 gettabwinvar({tabnr}, {winnr}, {name} [, {def}])
 				任意	タブページ{tabnr}の{winnr}の{name}
-getwininfo([{winid}])		リスト	ウィンドウのリスト
-getwinposx()			数値	GUI vim windowのX座標
-getwinposy()			数値	GUI vim windowのY座標
+getwininfo([{winid}])		リスト	各ウィンドウに関する情報のリスト
+getwinpos([{timeout}])		リスト	Vim ウィンドウのピクセルでの X および
+					Y 座標
+getwinposx()			数値	Vim ウィンドウのピクセルでの X 座標
+getwinposy()			数値	Vim ウィンドウのピクセルでの Y 座標
 getwinvar({nr}, {varname} [, {def}])
 				文字列	ウィンドウ{nr}の変数{varname}
 glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])
@@ -2134,7 +2190,7 @@ index({list}, {expr} [, {start} [, {ic}]])
 				数値	{list}中に{expr}が現れる位置
 input({prompt} [, {text} [, {completion}]])
 				文字列	ユーザーからの入力を取得
-inputdialog({prompt} [, {text} [, {completion}]]])
+inputdialog({prompt} [, {text} [, {completion}]])
 				文字列	input()と同様。GUIのダイアログを使用
 inputlist({textlist})		数値	ユーザーに選択肢から選ばせる
 inputrestore()			数値	先行入力を復元する
@@ -2147,7 +2203,7 @@ islocked({expr})		数値	{expr}がロックされているなら|TRUE|
 isnan({expr})			数値	{expr}がNaNならば|TRUE|
 items({dict})			リスト	{dict}のキーと値のペアを取得
 job_getchannel({job})		チャネル  {job}のチャネルハンドルを取得
-job_info({job})			辞書	{job}についての情報を取得
+job_info([{job}])		辞書	{job}についての情報を取得
 job_setoptions({job}, {options}) なし	{job}のオプションを設定する
 job_start({command} [, {options}])
 				ジョブ	ジョブを開始する
@@ -2169,28 +2225,28 @@ localtime()			数値	現在時刻
 log({expr})			浮動小数点数	{expr}の自然対数(底e)
 log10({expr})			浮動小数点数	浮動小数点数 {expr} の 10 を底
 						とする対数
-luaeval({expr}[, {expr}])	任意	|Lua| の式を評価する
+luaeval({expr} [, {expr}])	任意	|Lua| の式を評価する
 map({expr1}, {expr2})		リスト/辞書  {expr1}の各要素を{expr2}に変える
-maparg({name}[, {mode} [, {abbr} [, {dict}]]])
+maparg({name} [, {mode} [, {abbr} [, {dict}]]])
 				文字列/辞書
 					モード{mode}でのマッピング{name}の値
-mapcheck({name}[, {mode} [, {abbr}]])
+mapcheck({name} [, {mode} [, {abbr}]])
 				文字列	{name}にマッチするマッピングを確認
-match({expr}, {pat}[, {start}[, {count}]])
+match({expr}, {pat} [, {start} [, {count}]])
 				数値	{expr}内で{pat}がマッチする位置
-matchadd({group}, {pattern}[, {priority}[, {id} [, {dict}]]])
+matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
 				数値	{pattern} を {group} で強調表示する
-matchaddpos({group}, {pos}[, {priority}[, {id}[, {dict}]]])
+matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])
 				数値	位置を {group} で強調表示する
 matcharg({nr})			リスト	|:match|の引数
 matchdelete({id})		数値	{id} で指定されるマッチを削除する
-matchend({expr}, {pat}[, {start}[, {count}]])
+matchend({expr}, {pat} [, {start} [, {count}]])
 				数値	{expr}内で{pat}が終了する位置
-matchlist({expr}, {pat}[, {start}[, {count}]])
+matchlist({expr}, {pat} [, {start} [, {count}]])
 				リスト	{expr}内の{pat}のマッチと部分マッチ
-matchstr({expr}, {pat}[, {start}[, {count}]])
+matchstr({expr}, {pat} [, {start} [, {count}]])
 				文字列	{expr}内の{count}番目の{pat}のマッチ
-matchstrpos({expr}, {pat}[, {start}[, {count}]])
+matchstrpos({expr}, {pat} [, {start} [, {count}]])
 				リスト	{expr}内の{count}番目の{pat}のマッチ
 max({expr})			数値	{expr}内の要素の最大値
 min({expr})			数値	{expr}内の要素の最小値
@@ -2199,13 +2255,17 @@ mkdir({name} [, {path} [, {prot}]])
 mode([expr])			文字列	現在の編集モード
 mzeval({expr})			任意	|MzScheme| の式を評価する
 nextnonblank({lnum})		数値	{lnum}行目以降で空行でない行の行番号
-nr2char({expr}[, {utf8}])	文字列	ASCII/UTF8コード{expr}で示される文字
+nr2char({expr} [, {utf8}])	文字列	ASCII/UTF8コード{expr}で示される文字
 or({expr}, {expr})		数値    ビット論理和
 pathshorten({expr})		文字列	path内の短縮したディレクトリ名
 perleval({expr})		任意	|Perl|の式を評価する
 pow({x}, {y})			浮動小数点数	{x} の {y} 乗
 prevnonblank({lnum})		数値	{lnum}行目以前の空行でない行の行番号
 printf({fmt}, {expr1}...)	文字列	文字列を組み立てる
+prompt_addtext({buf}, {expr})	なし	プロンプトバッファにテキストを追加する
+prompt_setcallback({buf}, {expr}) なし	プロンプトコールバック関数を設定する
+prompt_setinterrupt({buf}, {text}) なし	プロンプト割り込み関数を設定する
+prompt_setprompt({buf}, {text}) なし	プロンプトテキストを設定する
 pumvisible()			数値	ポップアップメニューが表示されているか
 pyeval({expr})			任意	|Python| の式を評価する
 py3eval({expr})			任意	|python3| の式を評価する
@@ -2214,16 +2274,21 @@ range({expr} [, {max} [, {stride}]])
 				リスト	{expr}から{max}までの要素のリスト
 readfile({fname} [, {binary} [, {max}]])
 				リスト	ファイル{fname}から行のリストを取得
+reg_executing()			文字列	実行中のレジスタ名を取得する
+reg_recording()			文字列	記録中のレジスタ名を取得する
 reltime([{start} [, {end}]])	リスト	時刻の値を取得
 reltimefloat({time})		浮動小数点数	時刻の値を浮動小数点に変換
 reltimestr({time})		文字列	時刻の値を文字列に変換
-remote_expr({server}, {string} [, {idvar}])
+remote_expr({server}, {string} [, {idvar} [, {timeout}]])
 				文字列	式を送信する
 remote_foreground({server})	数値	Vimサーバーを前面に出す
 remote_peek({serverid} [, {retvar}])
 				数値	返信文字列を確認する
-remote_read({serverid})		文字列	返信文字列を読み込む
+remote_read({serverid} [, {timeout}])
+				文字列	返信文字列を読み込む
 remote_send({server}, {string} [, {idvar}])
+				文字列	キーシーケンスを送信する
+remote_startserver({name})	なし	サーバー {name} になる
 				文字列	キーシーケンスを送信する
 remove({list}, {idx} [, {end}])	任意	{list}から{idx}と{end}間の要素を削除
 remove({dict}, {key})		任意	{dict}から要素{key}を削除
@@ -2249,6 +2314,9 @@ searchpos({pattern} [, {flags} [, {stopline} [, {timeout}]]])
 server2client({clientid}, {string})
 				数値	返信文字列を送信する
 serverlist()			文字列	利用可能なサーバーのリストを取得
+setbufline({expr}, {lnum}, {line})
+				数値	バッファ {expr} の {lnum} 行目に {line}
+					を設定する
 setbufvar({expr}, {varname}, {val})	バッファ{expr}内の変数{varname}に{val}
 					をセット
 setcharsearch({dict})		辞書	文字検索を{dict}に設定
@@ -2256,13 +2324,13 @@ setcmdpos({pos})		数値	コマンドライン内のカーソル位置を設定
 setfperm({fname}, {mode})	数値	ファイル {fname} のパーミッションを
 					{mode} に設定
 setline({lnum}, {line})		数値	行{lnum}に{line}(文字列)をセット
-setloclist({nr}, {list}[, {action}[, {what}]])
+setloclist({nr}, {list} [, {action} [, {what}]])
 				数値	{list}を使ってロケーションリストを変更
 setmatches({list})		数値	マッチのリストを復元する
 setpos({expr}, {list})		なし	{expr}の位置を{list}にする
-setqflist({list}[, {action}[, {what}]])
+setqflist({list} [, {action} [, {what}]])
 				数値	{list}を使ってQuickFixリストを変更
-setreg({n}, {v}[, {opt}])	数値	レジスタの値とタイプを設定
+setreg({n}, {v} [, {opt}])	数値	レジスタの値とタイプを設定
 settabvar({nr}, {varname}, {val}) なし	タブページ{nr}の変数{varname}を{val}に
 					設定する
 settabwinvar({tabnr}, {winnr}, {varname}, {val})
@@ -2290,28 +2358,29 @@ sqrt({expr})			浮動小数点数	{expr} の平方根
 str2float({expr})		浮動小数点数	文字列を浮動小数点数に変換する
 str2nr({expr} [, {base}])	数値	文字列を数値に変換する
 strchars({expr} [, {skipcc}])	数値	文字列{expr}の文字の数
-strcharpart({str}, {start}[, {len}])
+strcharpart({str}, {start} [, {len}])
 				文字列	{str} の {start} から長さ {len} の文字
 					列を得る
 strdisplaywidth({expr} [, {col}]) 数値	文字列{expr}の表示幅
-strftime({format}[, {time}])	文字列	指定されたフォーマットでの時刻
+strftime({format} [, {time}])	文字列	指定されたフォーマットでの時刻
 strgetchar({str}, {index})	数値	{str} から {index} 番目の文字インデッ
 					クスを得る
-stridx({haystack}, {needle}[, {start}])
+stridx({haystack}, {needle} [, {start}])
 				数値	{haystack}内の{needle}のインデックス
 string({expr})			文字列	{expr}の値の文字列表現
 strlen({expr})			数値	文字列{expr}の長さ
-strpart({src}, {start}[, {len}])
+strpart({str}, {start} [, {len}])
 				文字列	{src}内{start}から長さ{len}の部分
 strridx({haystack}, {needle} [, {start}])
 				数値	{haystack}内の最後の{needle}のインデッ
 					クス
 strtrans({expr})		文字列	文字列を表示可能に変更
 strwidth({expr})		数値	文字列{expr}の表示セル幅
-submatch({nr}[, {list}])	文字列/リスト
+submatch({nr} [, {list}])	文字列/リスト
 					":s" やsubstitute()における特定のマッチ
 substitute({expr}, {pat}, {sub}, {flags})
 				文字列	{expr}の{pat}を{sub}に置換え
+swapinfo({fname})		辞書	スワップファイル {fname} に関する情報
 synID({line}, {col}, {trans})	数値	{line}と{col}のsyntax IDを取得
 synIDattr({synID}, {what} [, {mode}])
 				文字列	syntax ID{synID}の属性{what}を取得
@@ -2323,17 +2392,50 @@ system({expr} [, {input}])	文字列	シェルコマンド{expr}の出力結果
 systemlist({expr} [, {input}])	リスト	シェルコマンド{expr}の出力結果
 tabpagebuflist([{arg}])		リスト	タブページ内のバッファ番号のリスト
 tabpagenr([{arg}])		数値	現在または最後のタブページの番号
-tabpagewinnr({tabarg}[, {arg}])
+tabpagewinnr({tabarg} [, {arg}])
 				数値	タブページ内の現在のウィンドウの番号
-taglist({expr})			リスト	{expr}にマッチするタグのリスト
+taglist({expr} [, {filename}])	リスト	{expr}にマッチするタグのリスト
 tagfiles()			リスト	使用しているタグファイルのリスト
 tan({expr})			浮動小数点数	{expr}のタンジェント
 tanh({expr})			浮動小数点数	{expr}のハイパボリックタンジェ
 						ント
 tempname()			文字列	テンポラリファイルの名前
+term_dumpdiff({filename}, {filename} [, {options}])
+				数値	2 つのダンプ間の差分を表示する
+term_dumpload({filename} [, {options}])
+				数値	スクリーンダンプの表示
+term_dumpwrite({buf}, {filename} [, {options}])
+				なし	端末ウィンドウの内容をダンプする
+term_getaltscreen({buf})	数値	代替スクリーンフラグを取得する
+term_getansicolors({buf})	リスト	GUI カラーモードでの ANSI パレットを取
+					得する
+term_getattr({attr}, {what})	数値	属性 {what} の値を取得する
+term_getcursor({buf})		リスト	端末のカーソル位置を取得する
+term_getjob({buf})		ジョブ	端末に関連付けられているジョブを取得す
+					る
+term_getline({buf}, {row})	文字列	端末から 1 行のテキストを取得する
+term_getscrolled({buf})		数値	端末のスクロール数を取得する
+term_getsize({buf})		リスト	端末のサイズを取得する
+term_getstatus({buf})		文字列	端末の状態を取得する
+term_gettitle({buf})		文字列	端末のタイトルを取得する
+term_gettty({buf}, [{input}])	文字列	端末の tty 名を取得する
+term_list()			リスト	端末バッファのリストを取得する
+term_scrape({buf}, {row})	リスト	端末スクリーンの行を取得する
+term_sendkeys({buf}, {keys})	なし	キー入力を端末に送信する
+term_setansicolors({buf}, {colors})
+				なし	GUI カラーモードでの ANSI パレットを設
+					定する
+term_setkill({buf}, {how})	なし	端末のジョブを停止するためのシグナルを
+					設定する
+term_setrestore({buf}, {command}) なし	端末を復元するためのコマンドを設定する
+term_setsize({buf}, {rows}, {cols})
+				なし	端末のサイズを設定する
+term_start({cmd}, {options})	ジョブ	端末ウィンドウを開きジョブを実行する
+term_wait({buf} [, {time}])	数値	スクリーンが更新されるのを待つ
 test_alloc_fail({id}, {countdown}, {repeat})
 				なし	メモリの確保を失敗にさせる
 test_autochdir()		なし	起動時に 'autochdir' を有効にする
+test_feedinput()		なし	キー入力を入力バッファに追加する
 test_garbagecollect_now()	なし	テスト用に直ちにメモリを解放する
 test_ignore_error({expr})	なし	特定のエラーを無視する
 test_null_channel()		チャネル	テスト用のnull値
@@ -2354,6 +2456,7 @@ tolower({expr})			文字列	文字列{expr}を小文字にする
 toupper({expr})			文字列	文字列{expr}を大文字にする
 tr({src}, {fromstr}, {tostr})	文字列	{src}中に現れる文字{fromstr}を{tostr}
 					に変換する
+trim({text} [, {mask}])		文字列	{text} から {mask} 内の文字を切り取る
 trunc({expr})			浮動小数点数	浮動小数点数{expr}を切り詰める
 type({name})			数値	変数{name}の型
 undofile({name})		文字列	{name}に対するアンドゥファイルの名前
@@ -2369,9 +2472,12 @@ win_getid([{win} [, {tab}]])	数値	{tab}の{win}のウィンドウIDを取得
 win_gotoid({expr})		数値	ID {expr}のウィンドウに行く
 win_id2tabwin({expr})		リスト	ウィンドウIDからタブとウィンドウnr取得
 win_id2win({expr})		数値	ウィンドウIDからウィンドウnr取得
+win_screenpos({nr})		リスト	ウィンドウ {nr} のスクリーン位置を取得
+					する
 winbufnr({nr})			数値	ウィンドウ{nr}のバッファ番号
 wincol()			数値	カーソル位置のウィンドウ桁
 winheight({nr})			数値	ウィンドウ{nr}の高さ
+winlayout([{tabnr}])		リスト	タブ {tabnr} 内のウィンドウの配置
 winline()			数値	カーソル位置のウィンドウ行
 winnr([{expr}])			数値	現在のウィンドウの番号
 winrestcmd()			文字列	ウィンドウサイズを復元するコマンド
@@ -2439,6 +2545,21 @@ append({lnum}, {expr})					*append()*
 		成功なら0を返す。例: >
 			:let failed = append(line('$'), "# THE END")
 			:let failed = append(0, ["Chapter 1", "the beginning"])
+
+appendbufline({expr}, {lnum}, {text})			*appendbufline()*
+		|append()| と同様、ただしバッファ {expr} にテキストを追加する。
+
+		{expr} の使い方については |bufname()| を参照。
+
+		{lnum} は |append()| と同様に扱われる。Note: |line()| の使用
+		は、追加対象のバッファではなくカレントバッファに適用される。
+		バッファの最後に追加するには "$" を使用する。
+
+		成功時には 0 が返り、失敗時には 1 が返る。
+
+		{expr} が有効なバッファでない、もしくは {lnum} が有効でない場
+		合、エラーメッセージが与えられる。例: >
+			:let failed = appendbufline(13, 0, "# THE START")
 <
 							*argc()*
 argc()		カレントウィンドウの引数リスト内の、ファイルの数を返す。
@@ -2473,10 +2594,16 @@ argv([{nr}])	結果は引数リスト内の、{nr}番目のファイル。|argli
 <		引数{nr}が指定されなかった場合は、引数リスト|arglist|全体を返
 		す。
 
+assert_beeps({cmd})					*assert_beeps()*
+		{cmd} を実行し、それがビープもしくはビジュアルベルを発生させな
+		かった場合、|v:errors| にエラーメッセージを追加する。
+		|assert_fails()| および |assert-return| も参照。
+
 							*assert_equal()*
 assert_equal({expected}, {actual} [, {msg}])
 		{expected}と{actual}が等しくない場合、|v:errors|にエラーメッセ
-		ージを追加する。
+		ージを追加し、1 が返る。そうでなければ 0 が返る。
+		|assert-return|
 		暗黙的な変換は行われないため、文字列 "4" は数値 4 とは異なる。
 		同様に、数値 4 は浮動小数点数 4.0 と異なる。ここでは
 		'ignorecase' の値は使われず、大文字小文字は常に区別される。
@@ -2487,9 +2614,18 @@ assert_equal({expected}, {actual} [, {msg}])
 <		以下の結果が|v:errors|に追加される:
 	test.vim line 12: Expected 'foo' but got 'bar' ~
 
+							*assert_equalfile()*
+assert_equalfile({fname-one}, {fname-two})
+		ファイル {fname-one} および {fname-two} がまったく同じテキスト
+		でない場合、|v:errors| にエラーメッセージが追加される。
+		|assert-return| も参照。
+		{fname-one} もしくは {fname-two} が存在しない場合、それに関連
+		したエラーとなる。
+		主に |terminal-diff| で役立つ。
+
 assert_exception({error} [, {msg}])			*assert_exception()*
 		v:exception に{error}が含まれていない時、|v:errors|にエラーメッ
-		セージを追加する。
+		セージを追加する。|assert-return| も参照。
 		これは例外を投げるコマンドのテストを行う場合に使うことができ
 		る。コロンが続くエラー番号を使えば、翻訳の問題を回避できる: >
 			try
@@ -2501,13 +2637,17 @@ assert_exception({error} [, {msg}])			*assert_exception()*
 
 assert_fails({cmd} [, {error}])					*assert_fails()*
 		{cmd}を実行しエラーを生成しなかった場合、|v:errors|にエラーメッ
-		セージを追加する。
+		セージを追加する。|assert-return| も参照。
 		{error}が渡された場合、|v:errmsg|の一部にマッチしなければなら
 		ない。
+		Note: ビープ音の発生はエラーとは見なされず、いくつかのコマンド
+		は失敗時にビープ音を鳴らすだけである。これらについては
+		|assert_beeps()| を使用すること。
 
 assert_false({actual} [, {msg}])				*assert_false()*
 		|assert_equal()|と同様に、{actual}がfalseでない場合、|v:errors|
 		にエラーメッセージを追加する。
+		|assert-return| も参照。
 		ゼロである時、その値はfalseである。{actual}が数値でない場合、
 		テストが失敗する。
 		{msg}が省略された場合、"Expected False but got {actual}" とい
@@ -2516,14 +2656,14 @@ assert_false({actual} [, {msg}])				*assert_false()*
 assert_inrange({lower}, {upper}, {actual} [, {msg}])	 *assert_inrange()*
 		これは数値の値かをテストする。{actual}が{lower}より低いか
 		{upper}より大きい場合、|v:errors|にエラーメッセージが追加され
-		る。
+		る。|assert-return| も参照。
 		{msg}を省略すると、"Expected range {lower} - {upper}, but
 		got {actual}" という形式のエラーが生成される。
 
 								*assert_match()*
 assert_match({pattern}, {actual} [, {msg}])
 		{pattern}が{actual}と一致しない場合、|v:errors|にエラーメッセー
-		ジが追加される。
+		ジが追加される。|assert-return| も参照。
 
 		|=~|と同じように{pattern}が使われる: マッチングは 'magic' や
 		'cpoptions' の実際の値に関係なく、'magic' が設定され、
@@ -2543,16 +2683,23 @@ assert_match({pattern}, {actual} [, {msg}])
 							*assert_notequal()*
 assert_notequal({expected}, {actual} [, {msg}])
 		`assert_equal()` の反対: {expected}と{actual}が等しいときにエ
-		ラーメッセージを |v:errors| に追加する。
+		ラーメッセージを |v:errors| に追加する。|assert-return| も参
+		照。
 
 							*assert_notmatch()*
 assert_notmatch({pattern}, {actual} [, {msg}])
 		`assert_match()` の反対: {pattern}が{actual}にマッチするときに
 		|v:errors| にエラーメッセージを追加する。
+		|assert-return| も参照。
 
-assert_true({actual} [, {msg}])					*assert_true()*
+assert_report({msg})					*assert_report()*
+		テストの失敗を {msg} を使って直接報告する。
+		常に 1 を返す。
+
+assert_true({actual} [, {msg}])				*assert_true()*
 		|assert_equal()|と同様に、{actual}がtrueでない場合、|v:errors|
 		にエラーメッセージを追加する。
+		|assert-return| も参照。
 		非ゼロである時、その値はTRUEである。{actual}が数値でない場合、
 		テストが失敗する。
 		{msg}が省略された場合、"Expected True but got {actual}" とい
@@ -2595,8 +2742,11 @@ atan2({expr1}, {expr2})					*atan2()*
 <			2.356194
 		{|+float| 機能を有効にしてコンパイルしたときのみ有効}
 
-balloon_show({msg})					*balloon_show()*
-		{msg} をバルーン内に表示する。
+balloon_show({expr})					*balloon_show()*
+		{expr} をバルーン内に表示する。GUI では {expr} は文字列として
+		扱われる。端末では {expr} をバルーンの行を含むリストとしてもよ
+		い。{expr} がリストでない場合、|balloon_split()| で分割される。
+
 		例: >
 			func GetBalloonContent()
 			   " 内容の取得を開始
@@ -2615,7 +2765,14 @@ balloon_show({msg})					*balloon_show()*
 
 		バルーンを表示できないときは何も起こらず、エラーメッセージも表
 		示されない。
-		{Vimが |+balloon_eval| 機能付きでコンパイルされたときのみ有効}
+		{Vimが |+balloon_eval| もしくは +balloon_eval_term 機能付きで
+		コンパイルされたときのみ有効}
+
+balloon_split({msg})					*balloon_split()*
+		{msg} をバルーン内で表示される行に分割する。カレントウィンドウ
+		サイズ用に分割され、デバッガ出力を表示するために最適化される。
+		分割された行の |List| を返す。
+		{+balloon_eval_term 機能付きでコンパイルされたときのみ有効}
 
 							*browse()*
 browse({save}, {title}, {initdir}, {default})
@@ -2646,7 +2803,9 @@ browsedir({title}, {initdir})
 bufexists({expr})
 		結果は数値で、{expr}と呼ばれるバッファが存在すれば|TRUE|とな
 		る。
-		{expr}が数値の場合、バッファ番号とみなされる。
+		{expr}が数値の場合、バッファ番号とみなされる。数値の 0 はカレ
+		ントウィンドウの代替バッファである。
+
 		{expr}が文字列の場合、バッファ名に正確にマッチしなければな
 		らない。名前として以下のものが許される:
 		- カレントディレクトリからの相対パス。
@@ -2854,6 +3013,9 @@ ch_evalraw({handle}, {string} [, {options}])		*ch_evalraw()*
 		したり応答をデコードしたりはしない。呼び出しは正しいコンテンツ
 		である事が保証される。また NL モードでは改行が行われるが、ここ
 		では改行が付与されない。NL は応答から削除される。
+		Note: Vim は Raw チャネル上で受け取るテキストがいつ完了するの
+		か分からない。最初の部分だけを返す可能性もあり、残りを取り出す
+		ために ch_readraw() を使う必要がある。
 		|channel-use| を参照。
 
 		{|+channel| 機能付きでコンパイルされたときのみ有効}
@@ -2917,6 +3079,11 @@ ch_logfile({fname} [, {mode}])					*ch_logfile()*
 		UNIX で "tail -f" にてリアルタイムで何が行われているかが見える
 		様に、ファイルはメッセージ毎にフラッシュされる。
 
+		この関数は |sandbox| 内では無効である。
+		Note: チャネルとの通信はファイルに格納される。これには、あなた
+		が端末ウィンドウ上でタイプしたパスワードのような、機密やプライ
+		バシーに関する情報を含むことがあることに注意すること。
+
 
 ch_open({address} [, {options}])				*ch_open()*
 		{address}へのチャネルを開く。|channel|を参照。
@@ -2934,12 +3101,16 @@ ch_open({address} [, {options}])				*ch_open()*
 ch_read({handle} [, {options}])					*ch_read()*
 		{handle} から読み込みメッセージを受信する。
 		{handle} はチャネルもしくはチャネルを持つジョブであっても良い。
+		NL チャネルの場合、何も読み込むものがない (チャネルが閉じられ
+		た) 場合を除いて NL を受信するまで待つ。
 		|channel-more| を参照。
 		{|+channel| 機能付きでコンパイルされたときのみ有効}
 
 ch_readraw({handle} [, {options}])			*ch_readraw()*
 		ch_read() と同様に動作するが JS や JSON の場合でもメッセージは
-		デコードされない。|channel-more| を参照。
+		デコードされない。NL チャネルの場合、NL を受信するまで待つこと
+		はないが、それ以外は ch_read() と同様に動作する。
+		|channel-more| を参照。
 		{|+channel| 機能付きでコンパイルされたときのみ有効}
 
 ch_sendexpr({handle}, {expr} [, {options}])			*ch_sendexpr()*
@@ -2998,7 +3169,7 @@ changenr()						*changenr()*
 		redoされた変更の番号となる。undoを行った直後はundoされた変更よ
 		り1小さい番号になる。
 
-char2nr({expr}[, {utf8}])					*char2nr()*
+char2nr({expr} [, {utf8}])					*char2nr()*
 		{expr}の最初の文字のASCIIコードを返す。例: >
 			char2nr(" ")		returns 32
 			char2nr("ABC")		returns 65
@@ -3184,12 +3355,16 @@ cosh({expr})						*cosh()*
 
 
 count({comp}, {expr} [, {ic} [, {start}]])			*count()*
-		リスト|List|または辞書|Dictionary| {comp}の中に値{expr}が何回
-		現れるかを返す。
-		{start}が指定されたときはそのインデックスの要素から検索を開始
-		する。{start}は{comp}がリストの場合のみ使用できる。
-		{ic}が指定され、|TRUE|の場合は大文字・小文字は区別されない。
+		文字列|String|、リスト|List|または辞書|Dictionary| {comp} の中
+		に値 {expr} が何回現れるかを返す。
 
+		{start} が指定されたときはそのインデックスの要素から検索を開始
+		する。{start} は {comp} がリストの場合のみ使用できる。
+
+		{ic} が指定され、|TRUE|の場合は大文字・小文字は区別されない。
+
+		{comp} が文字列の場合、オーバーラップしていない {expr} の回数
+		が返される。{expr} が空文字列の場合は 0 が返る。
 
 							*cscope_connection()*
 cscope_connection([{num} , {dbpath} [, {prepend}]])
@@ -3257,7 +3432,13 @@ cursor({list})
 		などへも移動できる。
 		カーソルを移動できたときは 0 を、できなかったときは-1 を返す。
 
-deepcopy({expr}[, {noref}])				*deepcopy()* *E698*
+debugbreak({pid})					*debugbreak()*
+		主にデバッグしているプログラムに割り込むために使用される。プロ
+		セス {pid} に対して SIGTRAP を発生させる。関係のないプロセスへ
+		の振る舞いは未定義である。|terminal-debugger| を参照。
+		{MS-Windows 上でのみ有効}
+
+deepcopy({expr} [, {noref}])				*deepcopy()* *E698*
 		{expr}のコピーを作る。数値と文字列の場合は、{expr}そのものとコ
 		ピーの間に違いはない。
 		{expr}がリスト|List|の場合は完全なコピーを作る。つまり元のリス
@@ -3294,13 +3475,25 @@ delete({fname} [, {flags}])					*delete()*
 		結果は数値であり、削除に成功すれば 0、削除に失敗すれば -1 であ
 		る。
 
-		バッファから行を削除するには|:delete|を使う。行番号が変数に入っ
-		ている場合は|:exe|を使う。
+		バッファから行を削除するには|:delete|もしくは|deletebufline()|
+		を使う。
+
+deletebufline({expr}, {first} [, {last}])		*deletebufline()*
+		{first} から {last} (を含む) までの行をバッファ {expr} から削
+		除する。{last} が省略されている場合、{first} 行だけを削除する。
+		成功時には 0 が返され、失敗時には 1 が返される。
+
+		{expr} の使い方は前述の |bufname()| を参照。
+
+		{first} および {last} は |setline()| と同様に扱われる。Note:
+		|line()| の使用はカレントバッファを参照する。バッファ {expr}
+		内の最後の行を参照するには "$" を使用する。
 
 							*did_filetype()*
 did_filetype()	autocommandが実行されFileTypeイベントが一度でも起こっていれば、
 		|TRUE|が返る。スクリプトのFileTypeイベントが、複数回呼び出され
 		るのを回避するのに使える。 |FileType|
+		`:setf FALLBACK` が使用されている場合は |FALSE| を返す。
 		他のファイルへ移動すると、このカウンタはリセットされる。よって
 		実際は、カレントバッファに対してFileTypeイベントが発生したかど
 		うかを判定する。他のバッファを開くオートコマンドの中でこの関数
@@ -3328,6 +3521,7 @@ empty({expr})						*empty()*
 		{expr}が空なら1を、そうでなければ0を返す。
 		- リスト|List|または辞書|Dictionary|は要素を1個も持たないとき
 		  空とみなされる。
+		- 文字列はその長さが0のとき空とみなされる。
 		- 数値と浮動小数点数は値が0のとき空とみなされる。
 		- |v:false|, |v:none|, |v:null| は空であり、|v:true| は空では
 		  ない。
@@ -3342,7 +3536,7 @@ escape({string}, {chars})				*escape()*
 			:echo escape('c:\program files\vim', ' \')
 <		結果: >
 			c:\\program\ files\\vim
-<		|shellescape()| も参照。
+<		|shellescape()| および |fnameescape()| も参照。
 
 							*eval()*
 eval({string})	{string}を評価し、値を返す。|string()|の戻り値を元の値に戻すの
@@ -3378,6 +3572,8 @@ executable({expr})					*executable()*
 			1	存在する
 			0	存在しない
 			-1	このシステム上では実装されていない
+		|exepath()| は、実行ファイルの絶対パスを取得するのに使用するこ
+		とができる。
 
 execute({command} [, {silent}])					*execute()*
 		単一あるいは複数のExコマンドを実行して、出力を文字列として返
@@ -3723,7 +3919,7 @@ filter({expr1}, {expr2})					*filter()*
 		される。
 
 
-finddir({name}[, {path}[, {count}]])				*finddir()*
+finddir({name} [, {path} [, {count}]])				*finddir()*
 		{path}から{name}という名前のディレクトリを探す。ディレクトリを
 		上方・下方のどちらにも再帰的に検索できる。{path}の記法について
 		は|file-searching|を参照。
@@ -3738,7 +3934,7 @@ finddir({name}[, {path}[, {count}]])				*finddir()*
 		を返す。これはexコマンド|:find|によく似ている。
 		{|+file_in_path| 機能付きでコンパイルされたときのみ利用可能}
 
-findfile({name}[, {path}[, {count}]])				*findfile()*
+findfile({name} [, {path} [, {count}]])				*findfile()*
 		|finddir()|と同様だが、ディレクトリでなくファイルを検索する。
 		'suffixesadd' が適用される。
 		例: >
@@ -3851,12 +4047,13 @@ foldtext()	閉じた折り畳みに表示する文字列を返す。これはオ
 		|v:foldend|, |v:folddashes|を使用する。
 		戻り値の文字列は次のようになる: >
 			+-- 45 lines: abcdef
-<		
-		ダッシュ(-)の数は折り畳みレベルによって決まる。"45" はその折り
-		畳みに含まれている行数である。"abcdef" はその折り畳みの中の最
-		初の空行でない行のテキストである。行頭の空白と、"//" や "/*"、
-		'foldmarker' と 'commentstring' に設定されている文字列は削除さ
-		れる。
+<		先導するダッシュ(-)の数は折り畳みレベルによって決まる。"45" は
+		その折り畳みに含まれている行数である。"abcdef" はその折り畳み
+		の中の最初の空行でない行のテキストである。行頭の空白と、"//"
+		や "/*"、'foldmarker' と'commentstring' に設定されている文字列
+		は削除される。
+		実際に折り畳みテキストを表示するときには、行の残りは
+		'fillchars' で設定した折り畳み用の文字で埋められる。
 		{|+folding|機能付きでコンパイルされたときのみ利用可能}
 
 foldtextresult({lnum})					*foldtextresult()*
@@ -3905,7 +4102,7 @@ function({name} [, {arglist}] [, {dict}])
 		{arglist}もしくは{dict}が与えられると、関数の部分適用が作られ
 		る。すなわち引数のリスト及び/または辞書はFuncrefに格納され、
 		そのFuncrefが呼ばれるときに使用される。
-		
+
 		格納された引数は他の引数よりも前に関数に渡される。例えば: >
 			func Callback(arg1, arg2, name)
 			...
@@ -4000,6 +4197,7 @@ getbufinfo([{dict}])
 		る。{dict}には以下のキーを指定できる：
 			buflisted	リストされたバッファのみを含む。
 			bufloaded	ロードされたバッファのみを含む。
+			bufmodified	修正されたバッファのみを含む。
 
 		それ以外の場合、{expr}は情報を返す特定のバッファを指定する。
 		{expr}の使用については、上記の|bufname()|を参照。バッファが見
@@ -4035,7 +4233,7 @@ getbufinfo([{dict}])
 			endfor
 <
 		バッファローカルオプションを取得するには: >
-			getbufvar({bufnr}, '&')
+			getbufvar({bufnr}, '&option_name')
 
 <
 							*getbufline()*
@@ -4082,6 +4280,20 @@ getbufvar({expr}, {varname} [, {def}])				*getbufvar()*
 			:let bufmodified = getbufvar(1, "&mod")
 			:echo "todo myvar = " . getbufvar("todo", "myvar")
 <
+getchangelist({expr})					*getchangelist()*
+		バッファ {expr} の |changelist| を返す。{expr} の使い方は前述
+		の |bufname()| を参照。バッファ {expr} が存在しない場合、空の
+		リストが返される。
+
+		返されるリストは 2 つのエントリを含む: 変更位置のリストと、リ
+		スト内の現在地。変更リスト内のそれぞれの項目は、以下の項目を含
+		む辞書になっている:
+			col		列番号
+			coladd		'virtualedit' 用の列のオフセット
+			lnum		行番号
+		バッファ {expr} がカレントバッファの場合、現在地はリスト内の位
+		置を指す。それ以外のバッファではリストの長さに設定される。
+
 getchar([expr])						*getchar()*
 		ユーザーまたは入力ストリームから1文字を取得する。
 		[expr] が省略されたときは1文字を取得できるまで待つ。
@@ -4091,12 +4303,12 @@ getchar([expr])						*getchar()*
 		い。取得できないときは0を返す。
 
 		[expr] が省略されたときや [expr] が0のときは、文字全体または特
-		殊キーを返す。それが8ビット文字なら戻り値は数値である。これを
-		文字列に戻すにはnr2char()を使う。8ビット文字でないならばエン
-		コードして文字列にして返す。
-		特殊キーとは0x80(10進数で128)で始まるバイト列である。これは
-		文字列 "\<Key>" と同じ値である(例: "\<Left>")。戻り値は文字列
-		であり、修飾キー(shift, control, alt)は含まれない。
+		殊キーを返す。それが1文字なら戻り値は数値である。これを文字列
+		に戻すにはnr2char()を使う。それ以外の場合にはエンコードして文
+		字列にして返す。
+		特殊キーとは0x80(10進数で128)で始まるバイト列からなる文字列で
+		ある。これは文字列 "\<Key>" と同じ値である(例: "\<Left>")。戻
+		り値は文字列であり、修飾キー(shift, control, alt)は含まれない。
 
 		[expr] が0や Esc が入力された場合は、これがエスケープシーケン
 		スの始まりであるかどうかをVimが知るために待つ間、短い遅延があ
@@ -4224,6 +4436,7 @@ getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
 		コマンドライン補完のマッチするリストを返す。{type}は何のための
 		ものかを指定する。 次の補完タイプがサポートされている:
 
+		arglist		引数リスト内のファイル名
 		augroup		自動コマンドグループ
 		buffer		バッファ名
 		behave		|:behave|サブオプション
@@ -4243,6 +4456,7 @@ getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
 		highlight	ハイライトグループ
 		history		|:history|サブオプション
 		locale		ロケール名 (locale -aの出力)
+		mapclear	バッファ引数
 		mapping		マッピング名
 		menu		メニュー
 		messages	|:messages|サブオプション
@@ -4273,22 +4487,27 @@ getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
 getcurpos()	カーソルの位置を返す。これは getpos('.') に似ているが、追加の
 		情報を含む:
 		    [bufnum, lnum, col, off, curswant] ~
-		"curswant" は縦方向移動の優先的列番号である。
+		"curswant" は縦方向移動の優先的列番号である。|getpos()| も参照。
+
 		次のようにしてカーソル位置の保存と復元ができる: >
 			let save_cursor = getcurpos()
 			MoveTheCursorAround
 			call setpos('.', save_cursor)
-<
+<		Note: これはウィンドウ内でのみ機能する。より多くの状態を復元す
+		る方法については |winrestview()| を参照。
 							*getcwd()*
 getcwd([{winnr} [, {tabnr}]])
 		結果は現在の作業ディレクトリ名の文字列である。
-		引数が指定されない場合、現在のウィンドウである。
+		引数が指定されない場合、現在のウィンドウに対する結果である。
 
-		{winnr}が指定された場合、現在のタブページ内の{winnr}のウィンド
-		ウのローカルカレントディレクトリを返す。
+		{winnr} が指定された場合、現在のタブページ内の {winnr} のウィ
+		ンドウのローカルカレントディレクトリを返す。{winnr} にはウィン
+		ドウ番号または|window-ID|が使える。
+		{winnr} が -1 の場合、グローバル作業ディレクトリ名を返す。
+		|haslocaldir()| も参照。
+
 		{winnr}と{tabnr}が指定された場合、{tabnr}のタブページ内の
 		{winnr}のウィンドウのローカルカレントディレクトリを返す。
-		{winnr} にはウィンドウ番号または|window-ID|が使える。
 		もし引数が不正の場合、空文字列を返す。
 
 getfsize({fname})					*getfsize()*
@@ -4353,12 +4572,30 @@ getftype({fname})					*getftype()*
 		MS-Windowsでは、ディレクトリへのシンボリックリンクは "link" の
 		代わりに "dir" を返す。
 
+getjumplist([{winnr} [, {tabnr}]])			*getjumplist()*
+		指定されたウィンドウの |jumplist| を返す。
+
+		引数なしの場合、カレントウィンドウを使用する。
+		{winnr} のみの場合、現在のタブページのこのウィンドウを使用す
+		る。{winnr} には |window-ID| も使用できる。
+		{winnr} と {tabnr} 両方の場合、指定されたタブページのウィンド
+		ウを使用する。
+
+		返されるリストは 2 つのエントリを含む: ジャンプ位置のリストと、
+		リスト内の最後に使われたジャンプ位置番号。ジャンプ位置リスト内
+		のそれぞれの項目は、以下の項目を含む辞書になっている:
+			bufnr		バッファ番号
+			col		列番号
+			coladd		'virtualedit' 用の列のオフセット
+			filename	利用可能ならばファイル名
+			lnum		行番号
+
 							*getline()*
 getline({lnum} [, {end}])
 		{end}が指定されない場合は、カレントバッファの{lnum}行目の内容
 		を文字列にして返す。例: >
 			getline(1)
-<		{lnum}が数字ではない文字で始まる文字列であった場合、line()に
+<		{lnum}が数字ではない文字で始まる文字列であった場合、|line()|に
 		よってその文字列が数字に変換される。よって、カーソルのある行の
 		文字列を取得するには: >
 			getline(".")
@@ -4377,7 +4614,7 @@ getline({lnum} [, {end}])
 
 <		他のバッファの行を取得するには|getbufline()|を参照。
 
-getloclist({nr}[, {what}])				*getloclist()*
+getloclist({nr} [, {what}])				*getloclist()*
 		ウィンドウ{nr}のロケーションリストの全項目からなるリストを返す。
 		{nr} にはウィンドウ番号または|window-ID|が使える。{nr}に0を指
 		定するとカレントウィンドウになる。
@@ -4389,6 +4626,10 @@ getloclist({nr}[, {what}])				*getloclist()*
 		オプションの{what}辞書引数が指定されている場合、{what}にリスト
 		されている項目を辞書として返す。{what}のサポートされている項目
 		については、|getqflist()|を参照。
+		{what} が 'filewinid' を含む場合、ロケーションリスト中のファイ
+		ルを表示するのに使われているウィンドウの ID を返す。このフィー
+		ルドはロケーションリストウィンドウから呼び出されたときのみ適用
+		される。
 
 getmatches()						*getmatches()*
 		|matchadd()| と |:match| により定義された全てのマッチの |List|
@@ -4442,6 +4683,7 @@ getqflist([{what}])					*getqflist()*
 		以下の要素を持つ:
 			bufnr	ファイル名を持つバッファの番号。その名前を取得
 				するにはbufname()を使う。
+			module	モジュール名
 			lnum	バッファ中の行番号(最初の行は1)
 			col	桁番号(最初の桁は1)
 			vcol	|TRUE|: "col" は画面上の桁
@@ -4466,25 +4708,65 @@ getqflist([{what}])					*getqflist()*
 		オプションの{what}辞書引数が指定されている場合は、{what}にリス
 		トされている項目のみを辞書として返す。{what}では、以下の文字列
 		項目がサポートされている:
+			changedtick	リストに行われた変更の総数を取得
+					|quickfix-changedtick|
+			context	|quickfix-context| を取得
+			efm	"lines" をパースするときに使われるエラーフォー
+				マット。存在しない場合はオプション
+				'errorformat' の値が使用される。
+			id	|quickfix-ID|に対応するquickfixリストの情報を
+				取得。0 は現在のリストもしくは "nr" で指定され
+				たリストのidを意味する
+			idx	リスト内の現在のエントリのインデックス
+			items	quickfixリストのエントリ
+			lines	'efm' を使用して行のリストをパースし、結果のエ
+				ントリを返す。|List| 型のみを受け付ける。現在
+				のquickfixリストは変更を受けない。
+				|quickfix-parse|を参照。
 			nr	このquickfixリストの情報を取得。0 は現在の
-				quickfixリストを意味する
-			title	リストタイトルを取得
-			winid	|window-ID|を取得 (もし開かれていれば)
+				quickfixリストを意味し、"$" は最後のquickfixリ
+				ストを意味する
+			size	quickfixリスト内のエントリの数
+			title	リストタイトルを取得 |quickfix-title|
+			winid	quickfixの|window-ID|を取得
 			all	上記のquickfixのすべてのプロパティ
-		{what}の文字列以外の項目は無視される。
-		"nr" が存在しない場合、現在のquickfixリストが使用される。{what}
-		の処理中にエラーとなった場合、空の辞書が返される。
+		{what} の文字列以外の項目は無視される。特定の項目の値を取得す
+		るには 0 を設定する。
+		"nr" が存在しない場合、現在のquickfixリストが使用される。"nr"
+		と 0 でない "id" が両方とも指定されていた場合、"id" で指定され
+		たリストが使用される。
+		quickfixスタック内のリストの数を取得するには、{what} 内で "nr"
+		に "$" を設定する。返される辞書内の "nr" の値がquickfixスタッ
+		クサイズである。
+		"lines" が指定された場合、"efm" を除くその他すべての項目は無視
+		される。返される辞書は、エントリのリストからなるエントリ
+		"items" を含む。
 
 		返される辞書には、次のエントリが含まれる:
-			nr	quickfixリスト番号
-			title	quickfixリストのタイトルテキスト
-			winid	quickfixの|window-ID| (もし開かれていれば)
+			changedtick	リストに行われた変更の総数
+					|quickfix-changedtick|
+			context	quickfixリストコンテキスト。|quickfix-context|
+				を参照。存在しない場合、"" に設定される。
+			id	quickfixリストID |quickfix-ID|。存在しない場
+				合、0 に設定される。
+			idx	リスト内の現在のエントリのインデックス。存在し
+				ない場合、0 に設定される。
+			items	quickfixリストのエントリ。存在しない場合、空リ
+				ストに設定される。
+			nr	quickfixリスト番号。存在しない場合、0 に設定さ
+				れる。
+			size	quickfixリスト内のエントリの数。存在しない場
+				合、0 に設定される。
+			title	quickfixリストのタイトルテキスト。存在しない場
+				合、"" に設定される。
+			winid	quickfixの|window-ID|。存在しない場合、0 に設
+				定される。
 
-		例: >
+		例 (|getqflist-examples|も参照): >
 			:echo getqflist({'all': 1})
 			:echo getqflist({'nr': 2, 'title': 1})
+			:echo getqflist({'lines' : ["F1:10:L10"]})
 <
-
 getreg([{regname} [, 1 [, {list}]]])			*getreg()*
 		レジスタ{regname}の中身を文字列にして返す。例: >
 			:let cliptext = getreg('*')
@@ -4557,14 +4839,8 @@ gettabwinvar({tabnr}, {winnr}, {varname} [, {def}])		*gettabwinvar()*
 			:let list_is_on = gettabwinvar(1, 2, '&list')
 			:echo "myvar = " . gettabwinvar(3, 1, 'myvar')
 <
-
-							*getwinposx()*
-getwinposx()	結果はGUIのVimウィンドウの左端の、デスクトップ上でのX座標値(数
-		値)。情報が存在しない(コンソールの)場合は-1となる。
-
-							*getwinposy()*
-getwinposy()	結果はGUIのVimウィンドウの上端の、デスクトップ上でのY座標値(数
-		値)。情報が存在しない(コンソールの)場合は-1となる。
+		すべてのウィンドウローカル変数を取得するには: >
+			gettabwinvar({tabnr}, {winnr}, '&')
 
 getwininfo([{winid}])					*getwininfo()*
 		ウィンドウに関する情報を、辞書のリストとして返す。
@@ -4577,7 +4853,7 @@ getwininfo([{winid}])					*getwininfo()*
 
 		各Listアイテムは次のエントリを持つ辞書である:
 			bufnr		ウィンドウ内のバッファ数
-			height		ウィンドウの高さ
+			height		ウィンドウの高さ (winbarを除く)
 			loclist		ロケーションリストを表示してる場合は1
 					{Vimが|+quickfix|機能付きでコンパイルさ
 					れたときのみ有効}
@@ -4585,14 +4861,49 @@ getwininfo([{winid}])					*getwininfo()*
 					ドウの場合は1
 					{Vimが|+quickfix|機能付きでコンパイルさ
 					れたときのみ有効}
+			terminal	端末ウィンドウの場合は 1
+					{only with the +terminal feature}
 			tabnr		タブページ番号
 			variables	ウィンドウローカル変数の辞書への参照
 			width		ウィンドウ幅
+			winbar		ウィンドウがツールバーを持っていれば
+					1、そうでなければ 0
+			wincol		ウィンドウの最も左のスクリーン列、
+					|win_screenpos()|の列
 			winid		|window-ID|
 			winnr		ウィンドウ番号
+			winrow		ウィンドウの最も上のスクリーン行、
+					|win_screenpos()|の行
 
-		すべてのウィンドウローカル変数を取得するには: >
-			gettabwinvar({tabnr}, {winnr}, '&')
+getwinpos([{timeout}])					*getwinpos()*
+		結果は、getwinposx() と getwinposy() の結果が組み合わされた 2
+		つの数字のリスト:
+			[x-pos, y-pos]
+		{timeout} は端末からの応答をどれくらい待つかを、ミリ秒単位で指
+		定するのに使われる。省略された場合は 100 ミリ秒が使用される。
+		リモート端末にはより長い時間を指定すること。
+		10 より小さい値が使用され、かつその時間内に応答を受け取らなかっ
+		た場合、利用可能であれば前に報告された位置が返される。これは位
+		置をポーリングし、同時に何かを行う場合に使用することができる: >
+			while 1
+			  let res = getwinpos(1)
+			  if res[0] >= 0
+			    break
+			  endif
+			  " Do some work here
+			endwhile
+<
+							*getwinposx()*
+getwinposx()	結果はGUIのVimウィンドウの左端の、デスクトップ上でのX座標値(数
+		値)。 xtermでも機能する (100 ミリ秒のタイムアウトを使用して)。
+		情報が存在しない(コンソールの)場合は-1となる。
+		この値は `:winpos` でも使用される。
+
+							*getwinposy()*
+getwinposy()	結果はGUIのVimウィンドウの上端の、デスクトップ上でのY座標値(数
+		値)。 xtermでも機能する (100 ミリ秒のタイムアウトを使用して)。
+		情報が存在しない(コンソールの)場合は-1となる。
+		この値は `:winpos` でも使用される。
 
 getwinvar({winnr}, {varname} [, {def}])				*getwinvar()*
 		カレントタブページに対する|gettabwinvar()|と同様。
@@ -4616,7 +4927,7 @@ glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])		*glob()*
 		があるときはそれらは文字 <NL> で区切られる。
 
 		展開が失敗した場合、空の文字列またはリストが返される。
-		
+
 		存在しないファイル名は結果に含まれない。シンボリックリンクは、
 		それが存在するファイルを指す場合のみ含まれる。
 		ただし、{alllinks} 引数が存在し、それが|TRUE|である場合はすべ
@@ -4629,7 +4940,7 @@ glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])		*glob()*
 			:let &tags = substitute(tagfiles, "\n", ",", "g")
 <		バッククォート内のプログラムの実行結果は、一行に一つずつの項目
 		が含まれてなければならない。項目内のスペースは許容される。
-		
+
 		特殊なVimの変数を展開するためには|expand()|を参照。外部コマン
 		ドの生の出力を得るためには|system()|を参照。
 
@@ -5018,13 +5329,20 @@ job_getchannel({job})					 *job_getchannel()*
 <
 		{Vimが|+job|機能付きでコンパイルされたときのみ有効}
 
-job_info({job})						*job_info()*
+job_info([{job}])					*job_info()*
 		{job}に関する情報を持つ辞書を返す:
 		   "status"	|job_status()|が返すもの
 		   "channel"	|job_getchannel()|が返すもの
+		   "cmd"	ジョブを開始するのに使われるコマンド引数のリス
+				ト
+		   "process"	プロセス ID
+		   "tty_in"	端末入力名、何もないときには空
+		   "tty_out"	端末出力名、何もないときには空
 		   "exitval"	"status" が "dead" のときのみ有効
 		   "exit_cb"	終了時に呼び出される関数
 		   "stoponexit"	|job-stoponexit|
+
+		引数なしの場合、すべてのジョブオブジェクトのリストを返す。
 
 job_setoptions({job}, {options})			*job_setoptions()*
 		{job}のオプションを変更する。サポートされているものは:
@@ -5034,6 +5352,8 @@ job_setoptions({job}, {options})			*job_setoptions()*
 job_start({command} [, {options}])			*job_start()*
 		ジョブを開始し、ジョブオブジェクトを返す。|system()|と|:!cmd|
 		とは異なり、これはジョブが終了するのを待つことはない。
+		端末ウィンドウ内でジョブを開始する方法については
+		|term_start()| を参照。
 
 		{command}は文字列にできる。これはMS-Windowsで最も効果的である。
 		Unixでは、それはexecvp()に渡すために空白で区切られたパーツに分
@@ -5066,6 +5386,20 @@ job_start({command} [, {options}])			*job_start()*
 		返されたジョブオブジェクトを使用して、|job_status()|でステータ
 		スを取得し、|job_stop()|でジョブを停止することができる。
 
+		Note: ジョブオブジェクトは、それを参照するものがない場合削除さ
+		れる。これは stdin および stdout を閉じ、エラーによるジョブの
+		失敗を引き起こす。これを回避するにはジョブへの参照を維持する。
+		したがって、以下の代わりに: >
+	call job_start('my-command')
+<		このようにし: >
+	let myjob = job_start('my-command')
+<		さらに、ジョブが必要なくなったとき、もしくは (開始時にメッセー
+		ジが表示されたときのように) ジョブが失敗した後に、"myjob" を
+		unlet する。関数のローカル変数は、関数が終了すると消滅すること
+		に注意すること。必要であればスクリプトローカルな変数を使用する
+		ことができる: >
+	let s:myjob = job_start('my-command')
+<
 		{options}は辞書でなければならない。多くのオプション項目を含め
 		ることができる。|job-options|参照。
 
@@ -5118,9 +5452,14 @@ job_stop({job} [, {how}])					*job_stop()*
 		結果は数値で、操作が実行できる場合は1、システムでは "how" がサ
 		ポートされていない場合は0。
 		ジョブが実際に停止したかどうかは、操作が実行された場合でも、
-		job_status()でチェックする必要があることに注意すること。
-		ジョブのステータスがチェックされていない場合、Vimがジョブが実
-		行されていないと判断した場合でも操作が実行される。
+		|job_status()|でチェックする必要があることに注意すること。
+
+		ジョブのステータスが "dead" の場合、シグナルは送られない。これ
+		は、(特にプロセス番号が再利用される Unix において) 間違ったジョ
+		ブを停止することを防ぐためである。
+
+		"kill" を使用したとき、Vim はジョブが死ぬと想定し、チャネルを
+		閉じる。
 
 		{Vimが|+job|機能付きでコンパイルされたときのみ有効}
 
@@ -5161,14 +5500,29 @@ json_decode({string})					*json_decode()*
 		これはJSONフォーマットの文字列を解析し、それと同等のVimの値を
 		返す。JSONとVimの値の関係は|json_encode()|を参照。
 		デコードは寛容である:
-		- 配列やオブジェクトの末尾コンマは無視される。
-		- 多くの浮動小数点数を認識する。例えば "1." は "1.0" として認
-		  識される。
-									*E938*
-		しかし、1つのオブジェクトに重複するキーを含むことはできない。
-		結果は必ずVimの型として有効になる:
-		- オブジェクトの空のメンバ名は許されない。
-		- オブジェクトのメンバ名の重複は許されない。
+		- 配列やオブジェクトの末尾コンマは無視される、例えば
+		  "[1, 2, ]" と "[1, 2]" は同じである。
+		- 多くの浮動小数点数を認識する。例えば "1." は "1.0" となり、
+		  "001.2" は "1.2" となる。特別な浮動小数点の値、"Infinity" お
+		  よび "NaN" (大文字は無視される) は受け付けられる。
+		- 整数値の先頭に付く 0 は無視される、例えば "012" は "12" とな
+		  り、"-012" は "-12" となる。
+		- null、true および false の大文字は無視される、例えば "NULL"
+		  は "null" となり、"True" は "true" となる。
+		- 文字列中でエスケープされない U+0000 から U+001F の制御文字は
+		  受け付けられる、例えば "	" (文字列中のタブ文字) は "\t"
+		  となる。
+		- 無効な 2 文字のシーケンスエスケープ中のバックスラッシュは無
+		  視される、例えば "\a" は "a" と解釈される。
+		- JSON 文字列中の正しいサロゲートペアは、通常 "\uD834\uDD1E"
+		  のような連続した 12 文字でなければならないが、json_decode()
+		  は、"\uD834" や "\uD834\u" のような途切れたサロゲートペアを
+		  黙って受け付ける。
+								*E938*
+		結果は Vim の有効な型でなければならないため、rfc7159 では有効
+		なオブジェクト内の重複キーは、json_decode() では受け付けられな
+		い、例えばこれは失敗する: {"a":"b", "a":"c"}
+
 
 json_encode({expr})					*json_encode()*
 		{expr}をJSONフォーマットの文字列にエンコードし、この文字列を返
@@ -5247,7 +5601,7 @@ libcall({libname}, {funcname}, {argument})
 		ときのみ利用可能}
 		例: >
 			:echo libcall("libc.so", "getenv", "HOME")
-< 
+<
 							*libcallnr()*
 libcallnr({libname}, {funcname}, {argument})
 		|libcall()|とほぼ同様だが、文字列でなくintを返す関数に使う。
@@ -5264,8 +5618,10 @@ line({expr})	結果は数値で、{expr}で与えられた位置のファイル�
 		    $	    現在のバッファの最後の位置
 		    'x	    マークxの位置(マークが設定されていない場合、0が返
 			    る)
-		    w0	    カレントウィンドウの最上行
-		    w$	    カレントウィンドウの最下行
+		    w0	    カレントウィンドウの最上行 (サイレント Ex モードの
+			    ように、画面が更新されない場合は 1)
+		    w$	    カレントウィンドウの最下行 (行が表示されていない場
+			    合は "w0" より 1 小さい)
 		    v	    ビジュアルモードでは: ビジュアル選択領域の開始行
 			    (カーソルがその端)。ビジュアルモード以外ではカーソ
 			    ル位置を返す。すぐに更新される点が |'<| と違う。
@@ -5281,7 +5637,10 @@ line({expr})	結果は数値で、{expr}で与えられた位置のファイル�
 		このオートコマンドはファイルを開いた時に、最後に開かれていた時
 		の行へ自動的にジャンプするものである。これは '" マークがセット
 		されている時にのみ有効である: >
-	:au BufReadPost * if line("'\"") > 1 && line("'\"") <= line("$") | exe "normal! g`\"" | endif
+     :au BufReadPost *
+	 \ if line("'\"") > 1 && line("'\"") <= line("$") && &ft !~# 'commit'
+	 \ |   exe "normal! g`\""
+	 \ | endif
 
 line2byte({lnum})					*line2byte()*
 		バッファの先頭から、{lnum}行目までのバイト数を返す。これには現
@@ -5333,8 +5692,8 @@ log10({expr})						*log10()*
 			:echo log10(0.01)
 <			-2.0
 		{|+float| 機能つきでコンパイルされたときのみ有効}
-		
-luaeval({expr}[, {expr}])					*luaeval()*
+
+luaeval({expr} [, {expr}])					*luaeval()*
 		Lua の式 {expr} を評価し、その結果を Vim のデータ構造に変換し
 		たものを返す。2番目の {expr} は、最初の {expr} の中では _A と
 		してアクセスできる追加の引数を保持する。
@@ -5389,16 +5748,17 @@ map({expr1}, {expr2})					*map()*
 		される。
 
 
-maparg({name}[, {mode} [, {abbr} [, {dict}]]])			*maparg()*
+maparg({name} [, {mode} [, {abbr} [, {dict}]]])			*maparg()*
 		{dict}が省略されたかゼロのとき: モード{mode}におけるキーマップ
 		{name}のrhsを返す。結果の文字列内の特殊文字は、":map" コマンド
 		でリスト表示した時のように変換される。
-		
-		{name}というキーマップが存在しない場合、空文字列が返される。
-		
+
+		{name} というキーマップが存在しない場合、空文字列が返される。
+		{name} というキーマップが空の場合、"<Nop>" が返される。
+
 		{name}には ":map" コマンドで使用可能な、特殊なキー名が指定でき
 		る。
-		
+
 		{mode}には次の文字が使用可能:
 			"n"	ノーマル
 			"v"	ビジュアル (選択含む)
@@ -5408,6 +5768,7 @@ maparg({name}[, {mode} [, {abbr} [, {dict}]]])			*maparg()*
 			"s"	選択
 			"x"	ビジュアル
 			"l"	langmap |language-mapping|
+			"t"	端末ジョブ
 			""	ノーマル、ビジュアル、及びオペレータ待機
 		{mode}が省略された場合、"" が使用される。
 
@@ -5436,7 +5797,7 @@ maparg({name}[, {mode} [, {abbr} [, {dict}]]])			*maparg()*
 		その動作を行いつつ、再マップすることができる。概要: >
 			exe 'nnoremap <Tab> ==' . maparg('<Tab>', 'n')
 
-mapcheck({name}[, {mode} [, {abbr}]])			*mapcheck()*
+mapcheck({name} [, {mode} [, {abbr}]])			*mapcheck()*
 		モード{mode}におけるキーマップ{name}が存在するかチェックする。
 		{name}に指定できる特殊文字は|maparg()|を参照。
 		{abbr}が指定され、|TRUE|の場合はマッピングでなく短縮入力を対象
@@ -5454,8 +5815,9 @@ mapcheck({name}[, {mode} [, {abbr}]])			*mapcheck()*
 		けるが、maparg()はぴったり{name}に一致するマッピングのみを見つ
 		ける。
 		{name}にマッチするキーマップが存在しない時には、空文字列が返さ
-		れる。結果が一つならばマップされたrhsが返される。複数見つかっ
-		た場合には、それらのうちどれか一つのrhsが返される。
+		れる。結果が一つならばマップされたRHSが返される。{name} で始ま
+		るマッピングが複数見つかった場合には、それらのうちどれか一つの
+		RHSが返される。RHS が空の場合は "<Nop>" となる。
 		まずカレントバッファにローカルなマッピングを探し、次のグローバ
 		ルマッピングを探す。
 		この関数はマッピングが曖昧にならないかチェックするために使うこ
@@ -5466,7 +5828,7 @@ mapcheck({name}[, {mode} [, {abbr}]])			*mapcheck()*
 <		これは、"_vv" というマッピングが "_v" とか "_vvv" といったマッ
 		ピングと衝突しないように事前にチェックしている。
 
-match({expr}, {pat}[, {start}[, {count}]])			*match()*
+match({expr}, {pat} [, {start} [, {count}]])			*match()*
 		{expr}がリストの場合は、{pat}にマッチする最初の要素のインデッ
 		クスを返す。各要素は文字列として扱われる。リストと辞書はechoし
 		たときと同じように文字列表現に変換される。
@@ -5522,8 +5884,8 @@ match({expr}, {pat}[, {start}[, {count}]])			*match()*
 		かを設定できる。'smartcase' は適用されない。マッチングは常に
 		'magic' をオン、'cpoptions' を空にした状態で行われる。
 
-					*matchadd()* *E798* *E799* *E801*
-matchadd({group}, {pattern}[, {priority}[, {id}[, {dict}]]])
+				*matchadd()* *E798* *E799* *E801* *E957*
+matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
 		カレントウィンドウで強調表示するパターンを定義する。このパター
 		ンのことを「マッチ」と呼ぶ。構文グループ {group}で強調する。戻
 		り値は、マッチを識別する ID である。|matchdelete()|でこの ID
@@ -5556,6 +5918,8 @@ matchadd({group}, {pattern}[, {priority}[, {id}[, {dict}]]])
 			conceal	    マッチ(|hl-Conceal|のためだけにハイライトさ
 				    れたマッチ、|:syn-cchar|を参照)の代わりに
 				    表示する特別な文字
+			window	    現在のウィンドウの代わりに、この番号もしく
+				    はウィンドウ ID のウィンドウを使用する
 
 		コマンド |:match| と異なり、マッチの個数に上限はない。
 
@@ -5570,7 +5934,7 @@ matchadd({group}, {pattern}[, {priority}[, {id}[, {dict}]]])
 		|clearmatches()| 一発でできる。
 
 							*matchaddpos()*
-matchaddpos({group}, {pos}[, {priority}[, {id}[, {dict}]]])
+matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])
 		|matchadd()| と同じだが、パターンを指定するのではなく、位置の
 		リスト {pos} を指定する。このコマンドは正規表現を扱う必要もな
 		く、画面更新のためにバッファ行の境界を設定するため、
@@ -5590,7 +5954,7 @@ matchaddpos({group}, {pos}[, {priority}[, {id}[, {dict}]]])
 		- 数値を 3 つ持ったリスト。例 [23, 11, 3]。数値 2 つの場合と同
 		  じだが、3 つ目に強調表示する文字の長さ (バイト単位) を指定す
 		  る。
-		
+
 		指定できる位置は最大で 8 個である。
 
 		例: >
@@ -5602,8 +5966,6 @@ matchaddpos({group}, {pos}[, {priority}[, {id}[, {dict}]]])
 <		|matchaddpos()| で追加されたマッチは |getmatches()| で取得する
 		際には "pos1"、"pos2"、... という項目を持つ。それぞれの値は
 		{pos} で指定された値である。
-		これらのマッチは |setmatches()| で設定することはできない。ただ
-		し、|clearmatches()| で削除することはできる。
 
 matcharg({nr})							*matcharg()*
 		|:match|、|:2match|、|:3match|によって設定されているマッチパター
@@ -5624,7 +5986,7 @@ matchdelete({id})			       *matchdelete()* *E802* *E803*
 		-1 を返す。|matchadd()| の例を参照。すべてのマッチを削除するの
 		は |clearmatches()| 一発でできる。
 
-matchend({expr}, {pat}[, {start}[, {count}]])			*matchend()*
+matchend({expr}, {pat} [, {start} [, {count}]])			*matchend()*
 		|match()|と同じだが、返されるのはマッチした部分文字列の終了後の
 		インデックスである。例: >
 			:echo matchend("testing", "ing")
@@ -5643,7 +6005,7 @@ matchend({expr}, {pat}[, {start}[, {count}]])			*matchend()*
 <		結果は "-1"。
 		{expr}がリストの場合、戻り値は |match()| と等しくなる。
 
-matchlist({expr}, {pat}[, {start}[, {count}]])			*matchlist()*
+matchlist({expr}, {pat} [, {start} [, {count}]])		*matchlist()*
 		|match()| と同じだがリストを返す。リストの最初の要素は、
 		matchstr()が返すのと同じマッチした文字列。それ以降の要素は
 		|:substitute|における "\1"、"\2" のようなサブマッチである。\1
@@ -5652,7 +6014,7 @@ matchlist({expr}, {pat}[, {start}[, {count}]])			*matchlist()*
 <		結果は['acd', 'a', '', 'c', 'd', '', '', '', '', '']となる。
 		マッチしなかったときは空リストを返す。
 
-matchstr({expr}, {pat}[, {start}[, {count}]])			*matchstr()*
+matchstr({expr}, {pat} [, {start} [, {count}]])			*matchstr()*
 		|match()| と同じだが、マッチした文字列を返す。例: >
 			:echo matchstr("testing", "ing")
 <		結果は "ing"。
@@ -5666,7 +6028,7 @@ matchstr({expr}, {pat}[, {start}[, {count}]])			*matchstr()*
 		その要素の型は変換されないため、必ずしも文字列であるとは限らな
 		い。
 
-matchstrpos({expr}, {pat}[, {start}[, {count}]])		*matchstrpos()*
+matchstrpos({expr}, {pat} [, {start} [, {count}]])		*matchstrpos()*
 		|matchstr()| と同じだがマッチした文字列とマッチした開始位置と
 		終了位置を返す。例: >
 			:echo matchstrpos("testing", "ing")
@@ -5712,41 +6074,51 @@ mkdir({name} [, {path} [, {prot}]])
 		例: >
 			:call mkdir($HOME . "/tmp/foo/bar", "p", 0700)
 <		|sandbox|の中ではこの関数は使用できない。
+		ディレクトリが既に存在して、かつフラグ "p" が渡された場合エラー
+		は発生しない (パッチ 8.0.1708 より。
 		システムによっては利用できない場合がある。これを確認するには次
 		のようにする: >
 			:if exists("*mkdir")
 <
 							*mode()*
-mode([expr])		現在のモードを示す文字列を返す。
-			[expr] に 0 でない数値か空でない文字列(|non-zero-arg|)
-			を指定した場合、フルモードが返される。それ以外の場合は
-			最初の一文字だけが返される。
+mode([expr])	現在のモードを示す文字列を返す。
+		[expr] に 0 でない数値か空でない文字列 (|non-zero-arg|) を指定
+		した場合、フルモードが返される。それ以外の場合は最初の一文字だ
+		けが返される。
 
-			n	ノーマル
-			no	オペレータ待機
-			v	文字単位ビジュアル
-			V	行単位ビジュアル
-			CTRL-V	矩形ビジュアル
-			s	文字単位選択
-			S	行単位選択
-			CTRL-S	矩形選択
-			i	挿入
-			ic	挿入モード補完 |compl-generic|
-			ix	挿入モード |i_CTRL-X| 補完
-			R	置換 |R|
-			Rc	置換モード補完 |compl-generic|
-			Rv	仮想置換 |gR|
-			Rx	置換モード |i_CTRL-X| 補完
-			c	コマンドライン編集
-			cv	Vim Ex モード |gQ|
-			ce	ノーマル Ex モード |Q|
-			r	Hit-enter プロンプト
-			rm	-- more -- プロンプト
-			r?	ある種の |:confirm| 問い合わせ
-			!	シェルまたは外部コマンド実行中
+		   n	    ノーマル、端末ノーマル
+		   no	    オペレータ待機
+		   niI	    |Insert-mode| で |i_CTRL-O| を使用したノーマル
+		   niR	    |Replace-mode| で |i_CTRL-O| を使用したノーマル
+		   niV	    |Virtual-Replace-mode| で |i_CTRL-O| を使用したノー
+			    マル
+		   v	    文字単位ビジュアル
+		   V	    行単位ビジュアル
+		   CTRL-V   矩形ビジュアル
+		   s	    文字単位選択
+		   S	    行単位選択
+		   CTRL-S   矩形選択
+		   i	    挿入
+		   ic	    挿入モード補完 |compl-generic|
+		   ix	    挿入モード |i_CTRL-X| 補完
+		   R	    置換 |R|
+		   Rc	    置換モード補完 |compl-generic|
+		   Rv	    仮想置換 |gR|
+		   Rx	    置換モード |i_CTRL-X| 補完
+		   c	    コマンドライン編集
+		   cv	    Vim Ex モード |gQ|
+		   ce	    ノーマル Ex モード |Q|
+		   r	    Hit-enter プロンプト
+		   rm	    -- more -- プロンプト
+		   r?	    ある種の |:confirm| 問い合わせ
+		   !	    シェルまたは外部コマンド実行中
+		   t	    端末ジョブモード: キー入力がジョブに行く
 		これらはオプション 'statusline' の中や、|remote_expr()| といっ
 		しょに使うと便利である。他のほとんどの場所では "c" または "n"
 		しか返さない。
+		Note: 将来的により多くのモードやより詳細なモードが追加される可
+		能性がある。文字列全体を比較するのではなく、先頭の文字だけを比
+		較したほうがよい。
 		|visualmode()| も参照。
 
 mzeval({expr})							*mzeval()*
@@ -5773,7 +6145,7 @@ nextnonblank({lnum})					*nextnonblank()*
 <		{lnum}が無効なときや、それ以降に非空行がないときは0を返す。
 		|prevnonblank()|も参照。
 
-nr2char({expr}[, {utf8}])				*nr2char()*
+nr2char({expr} [, {utf8}])				*nr2char()*
 		コード{expr}で表される1文字からなる文字列を返す。例: >
 			nr2char(64)		"@"を返す
 			nr2char(32)		" "を返す
@@ -5823,7 +6195,7 @@ pow({x}, {y})						*pow()*
 			:echo pow(32, 0.20)
 <			2.0
 		{|+float| 機能つきでコンパイルされたときのみ有効}
-		
+
 prevnonblank({lnum})					*prevnonblank()*
 		{lnum}行以前({lnum}行を含む)の最初の非空行の行番号を返す。
 		例: >
@@ -5921,7 +6293,7 @@ printf({fmt}, {expr1} ...)				*printf()*
 			:echo printf("%d: %.*s", nr, width, line)
 <		この例は、テキスト "line" の長さを "width" バイトに制限する。
 
-		変換指示子の意味は以下の通り: 
+		変換指示子の意味は以下の通り:
 
 				*printf-d* *printf-b* *printf-B* *printf-o*
 				*printf-x* *printf-X*
@@ -5999,6 +6371,52 @@ printf({fmt}, {expr1} ...)				*printf()*
 		{expr1}以降の引数の数と "%" 変換指示子の個数がちょうど一致しな
 		ければならない。そうでない場合はエラーとなる。引数は最大18個ま
 		で使える。
+
+
+prompt_setcallback({buf}, {expr})			*prompt_setcallback()*
+		バッファ {buf} のプロンプトコールバックを {expr} に設定する。
+		{expr} が空文字列の場合、コールバックは取り除かれる。これは
+		{buf} の 'buftype' が "prompt" に設定されている場合のみ有効で
+		ある。
+
+		このコールバックは Enter を押したときに呼び出される。カレント
+		バッファは必ずプロンプトバッファである。コールバックの呼び出し
+		の前に次のプロンプト用の新しい行が追加されるので、コールバック
+		が呼び出されたプロンプトは最後から 2 番目の行になる。
+		コールバックがバッファにテキストを追加する場合、最後の行は現在
+		のプロンプトであるため、その上に追加しなければならない。これは
+		非同期に行われる可能性がある。
+		コールバックは、プロンプトに入力されたテキストを唯一の引数とし
+		て呼び出される。ユーザーが Enter のみをタイプした場合は空文字
+		となる。
+		例: >
+		   call prompt_setcallback(bufnr(''), function('s:TextEntered'))
+		   func s:TextEntered(text)
+		     if a:text == 'exit' || a:text == 'quit'
+		       stopinsert
+		       close
+		     else
+		       call append(line('$') - 1, 'Entered: "' . a:text . '"')
+		       " Reset 'modified' to allow the buffer to be closed.
+		       set nomodified
+		     endif
+		   endfunc
+
+prompt_setinterrupt({buf}, {expr})			*prompt_setinterrupt()*
+		バッファ {buf} のコールバックを {expr} に設定する。{expr} が空
+		文字列の場合、コールバックは取り除かれる。これは {buf} の
+		'buftype' が "prompt" に設定されている場合のみ有効である。
+
+		このコールバックは、挿入モードにおいて CTRL-C を押したときに呼
+		び出される。コールバックを設定していない場合、Vim は他のバッ
+		ファと同様に挿入モードを終了する。
+
+prompt_setprompt({buf}, {text})				*prompt_setprompt()*
+		バッファ {buf} のプロンプトを {text} に設定する。大抵の場合、
+		{text} が空白で終わるようにしたいと考えるだろう。
+		{buf} の 'buftype' が "prompt" に設定されている場合のみ結果が
+		見える。例: >
+			call prompt_setprompt(bufnr(''), 'command: ')
 
 
 pumvisible()						*pumvisible()*
@@ -6084,6 +6502,14 @@ readfile({fname} [, {binary} [, {max}]])
 		す。
 		|writefile()|も参照。
 
+reg_executing()						*reg_executing()*
+		実行されているレジスタの名前を 1 文字で返す。レジスタが実行さ
+		れていない場合は空文字列を返す。|@| を参照。
+
+reg_recording()						*reg_recording()*
+		記録されているレジスタの名前を 1 文字で返す。記録が行われてい
+		ない場合は空文字列を返す。|q| を参照。
+
 reltime([{start} [, {end}]])				*reltime()*
 		時刻値を表す値を返す。値の形式はシステムに依存する。この値を
 		|reltimestr()|に渡すと文字列に変換でき、|reltimefloat()|に渡す
@@ -6120,19 +6546,26 @@ reltimestr({time})				*reltimestr()*
 		{|+reltime| 機能付きでコンパイルされたときのみ利用可能}
 
 							*remote_expr()* *E449*
-remote_expr({server}, {string} [, {idvar}])
+remote_expr({server}, {string} [, {idvar} [, {timeout}]])
 		{string}を{server}に送信する。{string}は式と見なされ、評価した
 		結果が返ってくる。
 		戻り値は文字列かリスト|List|でなければならない。リストの場合は
 		要素を連結して文字列に変換される。要素間の区切りは改行文字とな
 		る(join(expr, "\n")と同様)。
-		{idvar}には変数名を指定する。後でremote_read()で使われる
-		{serverid}がその変数に保存される。
+		空でない {idvar} が渡された場合は変数名と見なされ、後で
+		|remote_read()|で使われる {serverid} がその変数に保存される。
+		{timeout} が与えられた場合、読み込みはその数秒後にタイムアウト
+		する。それ以外ではタイムアウトとして 600 秒が使用される。
 		|clientserver|と|RemoteReply|も参照。
 		|sandbox|の中ではこの関数は利用できない。
 		{|+clientserver|機能付きでコンパイルされたときのみ利用可能}
 		Note: なんらかのエラーが発生した場合は、ローカルでエラーメッ
 		セージが表示され、戻り値は空文字列となる。
+
+		変数は、現在アクティブな関数とは無関係にグローバル名前空間で評
+		価される。デバッグモードを除いて、関数のローカル変数および引数
+		は評価されることができる。
+
 		例: >
 			:echo remote_expr("gvim", "2+2")
 			:echo remote_expr("gvim1", "b:current_syntax")
@@ -6142,8 +6575,7 @@ remote_foreground({server})				*remote_foreground()*
 		サーバー名{server}のVimをフォアグラウンドに移動させる。
 		次を実行するのと同様である: >
 			remote_expr({server}, "foreground()")
-<		
-		ただし、次の点が異なる: Win32では、OSが必ずしもサーバーが自分
+<		ただし、次の点が異なる: Win32では、OSが必ずしもサーバーが自分
 		自身をフォアグラウンドにすることを許可しないので、対応策として
 		クライアントが仕事を行う。
 		Note: foreground()と違い、最小化されていたウィンドウを復元しな
@@ -6166,10 +6598,11 @@ remote_peek({serverid} [, {retvar}])		*remote_peek()*
 			:let repl = ""
 			:echo "PEEK: ".remote_peek(id, "repl").": ".repl
 
-remote_read({serverid})				*remote_read()*
+remote_read({serverid}, [{timeout}])			*remote_read()*
 		{serverid}からの返信の中で最も古いものを取り出して返す。取り出
 		した返信はキューから取り除かれる。キューに返信が入っていないと
-		きは、返信を取り出せるようになるまで待機する。
+		きは、{timeout} (秒単位) が与えられていない限り返信を取り出せ
+		るようになるまで待機する。
 		|clientserver|も参照。
 		|sandbox|の中ではこの関数は利用できない。
 		{|+clientserver|機能付きでコンパイルされたときのみ利用可能}
@@ -6186,6 +6619,7 @@ remote_send({server}, {string} [, {idvar}])
 		|clientserver|と|RemoteReply|も参照。
 		|sandbox|の中ではこの関数は利用できない。
 		{|+clientserver|機能付きでコンパイルされたときのみ利用可能}
+
 		Note: なんらかのエラーが発生すると、サーバー側で報告され、表示
 		が乱れてしまうかもしれない。
 		例: >
@@ -6197,6 +6631,12 @@ remote_send({server}, {string} [, {idvar}])
 		:echo remote_send("gvim", ":sleep 10 | echo ".
 		 \ 'server2client(expand("<client>"), "HELLO")<CR>')
 <
+					*remote_startserver()* *E941* *E942*
+remote_startserver({name})
+		サーバー {name} になる。すでにサーバーとして起動してお
+		り、|v:servername| が空でない場合は失敗する。
+		{|+clientserver| 機能付きでコンパイルされたときのみ利用可能}
+
 remove({list}, {idx} [, {end}])				*remove()*
 		{end}を指定しなかった場合: リスト{list}から{idx}位置の要素を削
 		除し、その要素を返す。
@@ -6264,11 +6704,11 @@ round({expr})							*round()*
 <			-5.0
 		{|+float| 機能つきでコンパイルされたときのみ有効}
 
-screenattr(row, col)						*screenattr()*
+screenattr({row}, {col})					*screenattr()*
 		|screenchar()| と同様だが、属性を返す。これは他の位置の属性と
 		比較するのに利用できるだけの適当な数値である。
 
-screenchar(row, col)						*screenchar()*
+screenchar({row}, {col})					*screenchar()*
 		スクリーン上の位置 [row, col] の文字を数値で返す。これは全ての
 		スクリーン位置、ステータスライン、ウィンドウセパレータ、コマン
 		ドラインで機能する。左上の位置は行番号が1、列番号が1である。文
@@ -6434,6 +6874,8 @@ searchpair({start}, {middle}, {end} [, {flags} [, {skip}
 		{skip}を省略した、または空のときはどのマッチも無視しない。
 		{skip}を評価している最中にエラーが発生すると、検索は異常終了し
 		-1を返す。
+		{skip} は、文字列、ラムダ、関数参照もしくは部分適用のいずれか
+		である。それ以外の場合、関数は失敗する。
 
 		{stopline} と {timeout} については|search()|を参照。
 
@@ -6521,6 +6963,19 @@ serverlist()					*serverlist()*
 		例: >
 			:echo serverlist()
 <
+setbufline({expr}, {lnum}, {text})			*setbufline()*
+		バッファ {expr} の行 {lnum} を {text} に設定する。行を挿入する
+		場合には |append()| を使用する。
+
+		{expr} の使い方については前述の |bufname()| を参照。
+
+		{lnum} は |setline()| と同様に扱われる。
+		これは特定のバッファに対し、|setline()| のように機能する。
+		成功時には 0 が返され、失敗時には 1 が返される。
+
+		{expr} が有効なバッファでない、もしくは {lnum} が有効でない場
+		合、エラーメッセージが与えられる。
+
 setbufvar({expr}, {varname}, {val})			*setbufvar()*
 		バッファ{expr}のオプションまたはローカル変数{varname}に{val}を
 		代入する。
@@ -6584,12 +7039,18 @@ setfperm({fname}, {mode})				*setfperm()* *chmod*
 
 setline({lnum}, {text})					*setline()*
 		カレントバッファの{lnum}行目を{text}にする。行を挿入したい場合
-		は |append()| を使う。
+		は |append()| を使う。別のバッファの行を変更したい場合は
+		|setbufline()| を使う。
+
 		{lnum}は|getline()|のときと同じように解釈される。
 		{lnum}が最後の行の次の行の場合、新規行として{text}を追加する。
+
 		成功したら0を返す。失敗したら(大抵{lnum}が無効な値のとき)1を返
-		す。例: >
+		す。
+
+		例: >
 			:call setline(5, strftime("%c"))
+
 <		{text}がリスト|List|の場合、{lnum}行目とそれ以降の行にリストの
 		要素をセットする。例: >
 			:call setline(5, ['aaa', 'bbb', 'ccc'])
@@ -6597,9 +7058,10 @@ setline({lnum}, {text})					*setline()*
 			:for [n, l] in [[5, 'aaa'], [6, 'bbb'], [7, 'ccc']]
 			:  call setline(n, l)
 			:endfor
+
 <		Note: マーク '[ と '] はセットされない。
 
-setloclist({nr}, {list}[, {action}[, {what}]])		*setloclist()*
+setloclist({nr}, {list} [, {action} [, {what}]])		*setloclist()*
 		ウィンドウ{nr}のロケーションリストを作成・置き換え・追加する。
 		{nr} にはウィンドウ番号または|window-ID|が使える。
 		{nr}が0のときはカレントウィンドウを対象にする。
@@ -6665,15 +7127,19 @@ setpos({expr}, {list})
 		|cursor()| も参照。|winrestview()| の "curswant" キーも参照。
 
 
-setqflist({list} [, {action}[, {what}]])		*setqflist()*
-		{list}の要素によりQuickFixリストを作成・置き換え・追加する。
-		{list}の各要素は辞書であること。
-		辞書でない{list}の要素は無視される。各辞書は以下の要素を持つ:
+setqflist({list} [, {action} [, {what}]])		*setqflist()*
+		QuickFixリストを作成、置き換え、もしくはリストへの追加を行う。
+
+		{what} が存在しない場合、{list} 内の要素を使用する。各要素は辞
+		書であること。辞書でない {list} の要素は無視される。各辞書は以
+		下の要素を持つ:
 
 		    bufnr	バッファ番号。有効なバッファ番号でなければなら
 				ない。
 		    filename	ファイル名。"bufnr" がないとき、または無効であ
 				るときのみ使われる。
+		    module	モジュール名; 与えられた場合はファイル名の代わ
+				りに QuickFix エラーウィンドウ内で使用される。
 		    lnum	ファイル中の行番号
 		    pattern	エラーの位置を特定するための検索パターン
 		    col		桁番号
@@ -6682,6 +7148,7 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		    nr		エラー番号
 		    text	エラーの説明
 		    type	エラータイプを示す1文字。'E', 'W' など。
+		    valid	エラーメッセージが認識されている
 
 		辞書の要素 "col"、"vcol"、"nr"、"type"、"text" は省略可能であ
 		る。"lnum" か "pattern" のどちらか一方のみがエラー行を特定する
@@ -6689,39 +7156,66 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		は "lnum" と "pattern" の両方ともない場合、その要素はエラー行
 		として扱われない。"pattern" と "lnum" の両方があるときは
 		"pattern" が使われる。
+		要素 "valid" が与えられていない場合、"bufnr" が有効なバッファ
+		であるか、もしくは "filename" が存在するときには有効フラグが設
+		定される。
 		{list} に空のリストを指定すると QuickFix リストはクリアされ
 		る。
 		このリストは|getqflist()|が返すものと正確に同じではないことに
 		注意。
 
-							*E927*
-		{action}が 'a' ならば{list}の要素を既存のQuickFixリストに追加
-		する。QuickFixリストがまだ存在しない場合は新規に作成される。
+		{action} の値:					*E927*
+		'a'	{list} の要素を既存のQuickFixリストに追加する。
+			QuickFixリストがまだ存在しない場合は新規に作成される。
 
-		{action}が 'r' ならば{list}の要素で現在のQuickFixリストを置き
-		換える。これはリストをクリアするのにも使える: >
-			:call setqflist([], 'r')
+		'r'	{list} の要素で現在のQuickFixリストを置き換える。これ
+			はリストをクリアするのにも使える: >
+				:call setqflist([], 'r')
 <
+		'f'	QuickFix スタック内のすべての QuickFix リストが解放さ
+			れる。
+
 		{action}が指定されないとき、または ' ' のときは新しい QuickFix
-		リストを作成する。
+		リストを作成する。新しい QuickFix リストは、スタック内の現在の
+		QuickFix リストと、続くすべてのリストが解放された後に追加され
+		る。新しい QuickFix リストをスタックの最後に追加する場合には、
+		{what} 内の "nr" に "$" を設定する。
 
 		オプショナル引数の辞書 {what} が提供される場合、{what} で指定
 		されるアイテムのみが設定される。最初の {list} は無視される。
 		{what} では以下のアイテムを指定する事ができる:
-		    nr		quickfix スタックでのリスト番号
+		    context	quickfix リストコンテキスト。
+				|quickfix-context| を参照
+		    efm		"lines" からテキストをパースするときに使うエ
+				ラーフォーマット。存在しない場合はオプション
+				'errorformat' の値が使用される。
+		    id		quickfix リスト識別子 |quickfix-ID|
+		    items	quickfix エントリのリスト。引数 {list} と同じ。
+		    lines	行のリストをパースするのに 'errorformat' を使
+				用し、結果のエントリを quickfix リスト {nr} も
+				しくは {id} に加える。|List| 値だけがサポート
+				される。
+		    nr		quickfix スタックでのリスト番号; 0 は現在の
+				quickfix リストを意味し、"$" は最後の quickfix
+				リストを意味する
 		    title	quickfix リストのタイトルテキスト
 		{what} 内でのサポートされていないキーは無視される。
 		"nr" 番目のアイテムが提供されていない場合は現在の quickfix リ
-		ストが変更される。
+		ストが変更される。新しい quickfix リストを作成するときは、"nr"
+		に quickfix スタックサイズより 1 大きい値を設定することができ
+		る。quickfix リストを変更するときには、正しいリストが変更され
+		ることを保証するために、リストの指定には "nr" ではなく "id" が
+		使用されるべきである。
 
-		例: >
-			:call setqflist([], 'r', {'title': 'My search'})
-			:call setqflist([], 'r', {'nr': 2, 'title': 'Errors'})
+		例 (|setqflist-examples| も参照): >
+		   :call setqflist([], 'r', {'title': 'My search'})
+		   :call setqflist([], 'r', {'nr': 2, 'title': 'Errors'})
+		   :call setqflist([], 'a', {'id':qfid, 'lines':["F1:10:L10"]})
 <
 		成功なら0、失敗なら-1を返す。
 
 		この関数は 'errorformat' の設定とは無関係にQuickFixリストを作
-		るために使える。その最初のエラーへジャンプするには ":cc 1" な
+		るために使える。その最初のエラーへジャンプするには `:cc 1` な
 		どのコマンドを使う。
 
 
@@ -6756,16 +7250,16 @@ setreg({regname}, {value} [, {options}])
 			:call setreg('*', @%, 'ac')
 			:call setreg('a', "1\n2\n3", 'b5')
 
-<		次の例は、この関数を使ってレジスタを退避・復元する例である
-		(note: |getreg()| の 3 番目の引数を使用せずにレジスタの内容を
-		完全に復元することはできない。改行文字と Nul 文字がどちらも改
-		行文字として表現されてしまうため。|NL-used-for-Nul| 参照)。
+<		次の例は、この関数を使ってレジスタを退避・復元する例である: >
 			:let var_a = getreg('a', 1, 1)
 			:let var_amode = getregtype('a')
 			    ....
 			:call setreg('a', var_a, var_amode)
+<		Note: |getreg()| の 3 番目の引数を使用せずにレジスタの内容を完
+		全に復元することはできない。改行文字と Nul 文字がどちらも改行
+		文字として表現されてしまうため。|NL-used-for-Nul| 参照。
 
-<		空文字列を追加すると、レジスタの種類を変更することができる: >
+		空文字列を追加すると、レジスタの種類を変更することができる: >
 			:call setreg('a', '', 'al')
 
 settabvar({tabnr}, {varname}, {val})			*settabvar()*
@@ -6811,17 +7305,21 @@ shellescape({string} [, {special}])			*shellescape()*
 		全て二重にする。
 		そうでなければ、{string}をシングルクォートで囲み、"'" を
 		"'\''" で置き換える。
+
 		{special} が指定され、0 でない数値または空でない文字列の場合
 		(|non-zero-arg|)、"!", "%", "#", "<cword>" などの特殊なアイテ
 		ムの前にはバックスラッシュがつく。コマンド |:!| によってその
 		バックスラッシュは再び除かれる。
+
 		'shell' の値の末尾が "csh" である場合、{special} が
 		|non-zero-arg| ならば "!" の文字もエスケープされる。これは、
 		csh と tcsh は シングルクォートの中であっても "!" を履歴置換と
 		解釈するためである。
-		<NL> 文字もエスケープされる。{special} が |non-zero-arg| であ
-		り 'shell' の末尾が "csh" である場合、これは2回エスケープされ
-		る。
+
+		{special} が |non-zero-arg| である場合、<NL> 文字もエスケープ
+		される。'shell' の末尾が "csh" である場合、これは 2 回エスケー
+		プされる。
+
 		|:!| コマンドを使う場合の例: >
 		    :exe '!dir ' . shellescape(expand('<cfile>'), 1)
 <		これはカーソル下のファイルを dir コマンドで表示する。
@@ -6861,7 +7359,6 @@ sin({expr})						*sin()*
 			:echo sin(-4.01)
 <			0.763301
 		{|+float| 機能つきでコンパイルされたときのみ有効}
-		
 
 sinh({expr})						*sinh()*
 		{expr} の双曲線正弦 (ハイパボリックサイン) を返す。
@@ -6878,7 +7375,7 @@ sinh({expr})						*sinh()*
 
 sort({list} [, {func} [, {dict}]])			*sort()* *E702*
 		{list}の要素をその場で(in-place)ソートする。{list}を返す。
-		
+
 		リストを変更したくない場合は、最初にコピーを作っておくこと: >
 			:let sortedlist = sort(copy(mylist))
 <		{func} が省略されたか空かゼロの場合は、各項目の文字列表現を
@@ -7018,7 +7515,7 @@ sqrt({expr})						*sqrt()*
 		"nan" はシステムのライブラリに依存するので、異なるかもしれな
 		い。
 		{|+float| 機能つきでコンパイルされたときのみ有効}
-		
+
 
 str2float({expr})					*str2float()*
 		文字列 {expr} を浮動小数点数に変換する。これは式の中で浮動小数
@@ -7046,6 +7543,7 @@ str2nr({expr} [, {base}])				*str2nr()*
 		{base}が2のとき、文字列の先頭の "0b" と "0B" は無視される。
 		数値の後のテキストは暗黙に無視される。
 
+
 strchars({expr} [, {skipcc}])					*strchars()*
 		結果は数値で、文字列 {expr} の文字の数を返す。
 		{skipcc} を省略またはゼロを指定すると、合成文字は別々にカウン
@@ -7053,7 +7551,7 @@ strchars({expr} [, {skipcc}])					*strchars()*
 		{skipcc} に 1 を指定すると、合成文字は無視される。
 		{訳注: 基底文字と結合文字をまとめて1としてカウントする}
 		|strlen()|, |strdisplaywidth()|, |strwidth()| も参照。
-		
+
 		{skipcc}は7.4.755以降でのみ有効である。それ以前では、ラッパー
 		関数を定義すればよい: >
 		    if has("patch-7.4.755")
@@ -7070,7 +7568,7 @@ strchars({expr} [, {skipcc}])					*strchars()*
 		      endfunction
 		    endif
 <
-strcharpart({src}, {start}[, {len}])			*strcharpart()*
+strcharpart({src}, {start} [, {len}])			*strcharpart()*
 		|strpart()| と同様だがバイトのインデックスおよび長さではなく文
 		字のインデックスおよび長さを使用する。
 		文字インデックスが存在しない文字を指す場合、それは1文字である
@@ -7078,7 +7576,7 @@ strcharpart({src}, {start}[, {len}])			*strcharpart()*
 			strcharpart('abc', -1, 2)
 <		結果は "a" である。
 
-strdisplaywidth({expr}[, {col}])			*strdisplaywidth()*
+strdisplaywidth({expr} [, {col}])			*strdisplaywidth()*
 		結果は数値で、文字列 {expr} が {col} で始まる時のスクリーン上
 		での表示セル幅を返す。
 		{col} が省略されたときはゼロが使われる。{col} には計算を開始す
@@ -7160,7 +7658,7 @@ strlen({expr})	結果は数値で、文字列{expr}のバイト単位での長�
 		マルチバイト文字の数を数える場合は|strchars()|を使用する。
 		|len()|, |strdisplaywidth()|, |strwidth()| も参照。
 
-strpart({src}, {start}[, {len}])			*strpart()*
+strpart({src}, {start} [, {len}])			*strpart()*
 		結果は文字列で、{src}の{start}番目の文字から始まる、長さ{len}
 		の部分文字列。
 		バイト数ではなく文字数で数えるには |strcharpart()| を用いる。
@@ -7209,7 +7707,7 @@ strwidth({expr})					*strwidth()*
 		きは、文字幅は 'ambiwidth' の設定に依存する。
 		|strlen()|, |strdisplaywidth()|, |strchars()| も参照。
 
-submatch({nr}[, {list}])			*submatch()* *E935*
+submatch({nr} [, {list}])			*submatch()* *E935*
 		|:substitute| や substitute() 関数の中の式でのみ使われる。
 		マッチしたテキストの{nr} 番目の部分マッチを返す。{nr}が0のとき
 		はマッチしたテキスト全体を返す。
@@ -7229,6 +7727,7 @@ submatch({nr}[, {list}])			*submatch()* *E935*
 
 		例: >
 			:s/\d\+/\=submatch(0) + 1/
+			:echo substitute(text, '\d\+', '\=submatch(0) + 1', '')
 <		この例は、行の中で最初の数値を検索し、それに1を加える。改行は
 		改行文字として含まれる。
 
@@ -7273,12 +7772,31 @@ substitute({expr}, {pat}, {sub}, {flags})
 		以下の |submatch()| が返す様なリストである。例: >
 		   :echo substitute(s, '%\(\x\x\)', {m -> '0x' . m[1]}, 'g')
 
+swapinfo({fname})					*swapinfo()*
+		結果は、スワップファイル {fname} に関する情報を含む辞書。利用
+		可能なフィールドは以下のとおり:
+			version VIM バージョン
+			user	ユーザー名
+			host	ホスト名
+			fname	オリジナルファイルの名前
+			pid	スワップファイルを作成した VIM プロセスの PID
+			mtime	秒単位での最終修正時間
+			inode	オプショナル: ファイルの INODE 番号
+			dirty	ファイルが修正されていれば 1、そうでなければ 0
+		Note: "user" および "host" は最大で 39 バイトに切り詰められる。
+		失敗した場合、以下の理由と共に "error" 項目が追加される:
+			Cannot open file: ファイルが見つからない、もしくはアク
+					  セス不可
+			Cannot read file: 先頭ブロックが読めない
+			Not a swap file: 正しいブロック ID を含んでいない
+			Magic number mismatch: 先頭ブロックの情報が無効である
+
 synID({lnum}, {col}, {trans})				*synID()*
 		結果は数値で、現在のウィンドウ内での位置{lnum}と{col}の位置の
 		構文ID。
 		構文IDは|synIDattr()|と|synIDtrans()|に渡すことで、テキストに
 		ついての構文情報を取得するのに使用できる。
-		
+
 		最左のカラムを指定するには{col}に1を、最初の行を指定するには
 		{line}に1を指定する。'synmaxcol' が適用され、長すぎる行では0が
 		返ってくる。
@@ -7325,6 +7843,7 @@ synIDattr({synID}, {what} [, {mode}])
 		"standout"	強調 (standout) なら "1"
 		"underline"	下線付きなら "1"
 		"undercurl"	波線付きなら "1"
+		"strike"	取り消し線付きなら "1"
 
 		例(カーソルの下の構文アイテムのカラーを表示する): >
 	:echo synIDattr(synIDtrans(synID(line("."), col("."), 1)), "fg")
@@ -7337,15 +7856,28 @@ synIDtrans({synID})
 		従っている。
 
 synconcealed({lnum}, {col})				*synconcealed()*
-		リストを返す。リストの 1 番目のアイテムは、{lnum} と {col} が
-		指す位置の文字が Conceal 可能リージョン の中にあるなら 1、そう
-		でないなら 0。リストの 2 番目のアイテムは文字列で、最初のアイ
-		テムが 1 なら、代わりに表示される Conceal テキスト が入る (実
-		行時の 'conceallevel' の設定に依存)。リストの 3 番目のアイテム
-		は、どのシンタックスリージョンにマッチしたかを示すユニーク番
-		号。これは同じ置換文字を持つ二つのリージョンが連続していた場合
-		にその区切りを識別できるようにするため。
-		使用例は $VIMRUNTIME/syntax/2html.vim を参照。
+		結果は現状 3 つのアイテムを含むリストである。
+		1. リストの 1 番目のアイテムは、{lnum} と {col} が指す位置の文
+		   字が Conceal 可能リージョンの中にあるなら 1、そうでないなら
+		   0。
+		2. リストの 2 番目のアイテムは文字列で、最初のアイテムが 1 な
+		   ら、Conceal されたテキストの代わりに表示されるテキストが入
+		   る (実行時の'conceallevel' および 'listchars' の設定に依
+		   存)。
+		3. リストの 3 番目の最後のアイテムは、行内でどのシンタックス
+		   リージョンにマッチしたかを示す番号。その文字が Conceal され
+		   ていない場合、この値は 0 である。これは同じ置換文字を持つ 2
+		   つの Concela 可能リージョンが連続していた場合に、その区切り
+		   を識別できるようにするため。テキストが "123456"で、"23" と
+		   "45" の両方が Conceal されて文字 "X" に置き換えられていた場
+		   合の例:
+			call			returns ~
+			synconcealed(lnum, 1)   [0, '', 0]
+			synconcealed(lnum, 2)   [1, 'X', 1]
+			synconcealed(lnum, 3)   [1, 'X', 1]
+			synconcealed(lnum, 4)   [1, 'X', 2]
+			synconcealed(lnum, 5)   [1, 'X', 2]
+			synconcealed(lnum, 6)   [0, '', 0]
 
 
 synstack({lnum}, {col})					*synstack()*
@@ -7474,9 +8006,14 @@ tagfiles()	カレントバッファにおいて、タグを検索するときに
 		ある。
 
 
-taglist({expr})							*taglist()*
-		正規表現{expr}にマッチするタグのリストを返す。そのリストの各要
-		素は辞書であり、少なくとも次の要素を持つ:
+taglist({expr} [, {filename}])				*taglist()*
+		正規表現 {expr} にマッチするタグのリストを返す。
+
+		{filename} が渡された場合、|:tselect| と同じ方法で結果を優先順
+		位付けするために使われる。|tag-priority| を参照。
+		{filename} はファイルの絶対パスでなければならない。
+
+		そのリストの各要素は辞書であり、少なくとも次の要素を持つ:
 			name		タグの名前。
 			filename	タグの定義があるファイルの名前。カレン
 					トディレクトリからの相対パス、またはフ
@@ -7546,6 +8083,351 @@ tempname()
 		MS-Windowsでは、'shellslash' がオンのときか 'shellcmdflag' が
 		'-' で始まるときはスラッシュが使われる。
 
+							*term_dumpdiff()*
+term_dumpdiff({filename}, {filename} [, {options}])
+		2 つのファイルの差分を表示する新しいウィンドウを開く。これらの
+		ファイルは |term_dumpwrite()| で作られたものでなければならな
+		い。
+		差分の検出に失敗したときはバッファ番号もしくは 0 を返す。
+		|terminal-diff| も参照。
+		NOTE: これは 2 倍幅文字ではまだ機能しない。
+
+		バッファの先頭部分は 1 つ目のファイルの内容を含み、バッファの
+		末尾部分は 2 つ目のファイルの内容を含む。中央部分は差分を表示
+		する。
+		それぞれの部分はダッシュの行で分割される。
+
+		引数 {options} は辞書でなければらなず、以下のメンバを含むこと
+		ができる:
+		   "term_name"	     (1 つ目のファイル名の代わりに使用される)
+				     バッファ名
+		   "term_rows"	     ('termwinsize' の代わりに使用される) 端末
+				     の垂直サイズ
+		   "term_cols"	     ('termwinsize' の代わりに使用される) 端末
+				     の水平サイズ
+		   "vertical"	     ウィンドウを垂直に分割する
+		   "curwin"	     ウィンドウを分割せず現在のウィンドウを使
+				     用する、現在のバッファが放棄 (|abandon|)
+				     不可の場合は失敗する
+		   "norestore"	     端末ウィンドウをセッションファイルに加え
+				     ない
+
+		中央部分のそれぞれの文字は違いを表示している。複数の違いがあっ
+		た場合は以下のリスト内の最初のものだけが使用される:
+			X	異なる文字
+			w	異なる幅
+			f	異なる文字色
+			b	異なる背景色
+			a	異なる属性
+			+	1 つ目のファイル内に存在しない位置
+			-	2 つ目のファイル内に存在しない位置
+
+		"s" キーを押すと、先頭部分と末尾部分が入れ替わる。これにより差
+		分を簡単に確認することができる。
+
+							*term_dumpload()*
+term_dumpload({filename} [, {options}])
+		{filename} の内容を表示する新しいウィンドウを開く。このファイ
+		ルは |term_dumpwrite()| で作られたものでなければならない。
+		失敗したときはバッファ番号もしくは 0 を返す。
+		|terminal-diff| も参照。
+
+		{options} については |term_dumpdiff()| を参照。
+
+							*term_dumpwrite()*
+term_dumpwrite({buf}, {filename} [, {options}])
+		ファイル {filename} に、{buf} の端末画面の内容をダンプする。こ
+		れは |term_dumpload()| および |term_dumpdiff()| で使われる
+		フォーマットを使用する。
+		{filename} が既に存在する場合はエラーが発生する。	*E953*
+		|terminal-diff| も参照。
+
+		{options} は以下のオプショナルな要素を含む辞書である:
+			"rows"		ダンプする行の最大値
+			"columns"	ダンプする列の最大値
+
+term_getaltscreen({buf})				*term_getaltscreen()*
+		{buf} の端末が代替スクリーンを使用している場合 1 を返す。
+		{buf} の扱いについては |term_getsize()| と同じ。
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
+
+term_getansicolors({buf})				*term_getansicolors()*
+		端末 {buf} で使用されている ANSI カラーパレットを取得する。
+		長さ 16 のリストを返し、各要は色を 16 進数の "#rrggbb" フォー
+		マットで表す文字列である。
+		|term_setansicolors()| および |g:terminal_ansi_colors| も参照。
+		どちらも使用されていない場合、既定値を返す。
+
+		{buf} の扱いについては |term_getsize()| と同じ。バッファが存在
+		しない、もしくは端末ウィンドウでない場合は、空リストが返され
+		る。
+		{|+terminal| 機能付きで、GUI が有効もしくは |+termguicolors|
+		機能付きでコンパイルされたときのみ有効}
+
+term_getattr({attr}, {what})				*term_getattr()*
+		term_scrape() で返された項目 "attr" の値である {attr} につい
+		て、{what} がオンになっているかを返す。{what} は次のうちどれか
+		1 つである:
+			bold
+			italic
+			underline
+			strike
+			reverse
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
+
+term_getcursor({buf})					*term_getcursor()*
+		端末 {buf} のカーソル位置を取得する。2 つの数値と辞書から構成
+		されるリストを返す: [row, col, dict]。
+
+		"row" および "col" は 1 を基準とし、最初のスクリーンセルは
+		行 1、列 1 である。これは端末自身のカーソル位置であり、Vim
+		ウィンドウのものではない。
+
+		"dict" は以下 3 つのメンバを持つ:
+		   "visible"	カーソルが可視のときは 1、不可視のときは 0
+		   "blink"	カーソルが可視のときは 1、不可視のときは 0
+		   "shape"	ブロックカーソルは 1、下線は 2、垂直線は 3
+
+		{buf} は端末ウィンドウのバッファ番号でなければならない。バッ
+		ファが存在しない、もしくは端末ウィンドウでない場合は、空リスト
+		が返される。
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
+
+term_getjob({buf})					*term_getjob()*
+		端末ウィンドウ {buf} に関連付いたジョブを取得する。
+		{buf} の扱いについては |term_getsize()| と同じ。
+		ジョブが存在しないときには |v:null| を返す。
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
+
+term_getline({buf}, {row})				*term_getline()*
+		端末ウィンドウ {buf} から行のテキストを取得する。
+		{buf} の扱いについては |term_getsize()| と同じ。
+
+		先頭行の {row} は 1 である。{row} が "." のときはカーソル行が
+		使われる。{row} が無効のときは空文字列が返される。
+
+		各文字の属性を取得するには |term_scrape()| を使用する。
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
+
+term_getscrolled({buf})					*term_getscrolled()*
+		端末 {buf} の先頭から上方にスクロールされた行の数を返す。これ
+		は |term_getline()| および |getline()| で使われる行番号のオフ
+		セットとなるので: >
+			term_getline(buf, N)
+<		は以下と等しい: >
+			`getline(N + term_getscrolled(buf))
+<		(もしその行が存在していれば)。
+
+		{buf} の扱いについては |term_getsize()| と同じ。
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
+
+term_getsize({buf})					*term_getsize()*
+		端末 {buf} のサイズを取得する。2 つの数値を含むリストを返す:
+		[rows, cols]。これは端末のサイズであり、端末を含むウィンドウの
+		サイズではない。
+
+		{buf} は端末ウィンドウのバッファ番号でなければならない。現在の
+		バッファには空文字列を使用する。バッファが存在しない、もしくは
+		端末ウィンドウでない場合は、空リストが返される。
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
+
+term_getstatus({buf})					*term_getstatus()*
+		端末 {buf} のステータスを取得する。これらの項目をコンマで区切っ
+		たリストを返す:
+			running		ジョブが実行中である
+			finished	ジョブが完了した
+			normal		端末ノーマルモードである
+		"running" または "finished" のどちらかは常に存在する。
+
+		{buf} は端末ウィンドウのバッファ番号でなければならない。バッ
+		ファが存在しない、もしくは端末ウィンドウでない場合は、空リスト
+		が返される。
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
+
+term_gettitle({buf})					*term_gettitle()*
+		端末 {buf} のタイトルを取得する。これは端末内でジョブが設定し
+		たタイトルである。
+
+		{buf} は端末ウィンドウのバッファ番号でなければならない。バッ
+		ファが存在しない、もしくは端末ウィンドウでない場合は、空リスト
+		が返される。
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
+
+term_gettty({buf} [, {input}])				*term_gettty()*
+		端末ウィンドウ {buf} に関連付けられた制御端末の名前を取得する。
+		{buf} の扱いについては |term_getsize()| と同じ。
+
+		{input} が省略されたもしくは 0 のとき、書き込み (stdout) の名
+		前を返す。{input} が 1 のとき、読み込み (stdin) の名前を返す。
+		UNIX では両方で同じ名前が返る。
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
+
+term_list()						*term_list()*
+		すべての端末ウィンドウのバッファのバッファ番号のリストを返す。
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
+
+term_scrape({buf}, {row})				*term_scrape()*
+		端末スクリーン {buf} の {row} にある内容を取得する。
+		{buf} については |term_getsize()| を参照。
+
+		先頭行の {row} は 1 である。{row} が "." のときはカーソル行が
+		使用される。{row} が無効なときは空文字列が返される。
+
+		各スクリーンのセルに対する辞書を含んだリストを返す:
+		    "chars"	セルの文字
+		    "fg"	文字色 (#rrggbb)
+		    "bg"	背景色 (#rrggbb)
+		    "attr"	セルの属性、個々のフラグを取得するには
+				|term_getattr()| を使用する
+		    "width"	セルの幅: 1 もしくは 2
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
+
+term_sendkeys({buf}, {keys})				*term_sendkeys()*
+		端末 {buf} にキー入力 {keys} を送る。
+		{buf} の扱いについては |term_getsize()| と同じ。
+
+		{keys} はキーシーケンスとして解釈される。例えば、"\<c-x>" は
+		文字 CTRL-X を意味する。
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
+
+term_setansicolors({buf}, {colors})			*term_setansicolors()*
+		端末 {buf} で使用される ANSI カラーパレットを設定する。
+		{colors} は、|highlight-guifg| で受け付けられるような、有効な
+		カラー名もしくは 16 進数のカラーコードを 16 個含むリストでなけ
+		ればならない。
+		|term_getansicolors()| および |g:terminal_ansi_colors| も参照。
+
+		カラーは通常以下のとおり:
+			0    black
+			1    dark red
+			2    dark green
+			3    brown
+			4    dark blue
+			5    dark magenta
+			6    dark cyan
+			7    light grey
+			8    dark grey
+			9    red
+			10   green
+			11   yellow
+			12   blue
+			13   magenta
+			14   cyan
+			15   white
+
+		これらの色は、GUI 内および 'termguicolors' が設定されていると
+		きの端末内で使用される。GUI カラーを使用しないとき (GUI モード
+		もしくは 'termguicolors')、端末ウィンドウは、常に基となる端末
+		の 16 ANSI カラーを使用する。
+		{|+terminal| 機能付きで、GUI が有効もしくは |+termguicolors|
+		機能付きでコンパイルされたときのみ有効}
+
+term_setkill({buf}, {how})				*term_setkill()*
+		Vim が終了するもしくは何らかの方法で端末ウィンドウを閉じようと
+		しているとき、端末内のジョブを停止するかどうかを {how} で定義
+		する。
+		{how} が空 (既定値) のとき、ジョブは停止されない。終了しようと
+		すると |E947| となる。
+		それ以外では、{how} はジョブに何のシグナルを送るかを記述する。
+		値に関しては |job_stop()| を参照。
+
+		シグナルを送ったあと、Vim はジョブが実際に停止したか確認するた
+		めに 1 秒待つ。
+
+term_setrestore({buf}, {command})			*term_setrestore()*
+		この端末内のジョブを復元するためのセッションファイルを書き込む
+		コマンドを設定する。セッションファイル内に書き込まれる行は以下
+		の通り: >
+			terminal ++curwin ++cols=%d ++rows=%d {command}
+<		コマンドを適切にエスケープするよう気を付けること。
+
+		'shell' を実行するには空の {command} を使用する。
+		このウィンドウを復元しないためには "NONE" を使用する。
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
+
+term_setsize({buf}, {rows}, {cols})		*term_setsize()* *E955*
+		端末 {buf} のサイズを設定する。端末を含むウィンドウのサイズが
+		可能であれば調整される。{rows} もしくは {cols} が、0 もしくは
+		負である場合、大きさは変わらない。
+
+		{buf} は端末ウィンドウのバッファ番号でなければならない。現在の
+		バッファには空文字列を使用する。バッファが存在しない、もしくは
+		端末ウィンドウでない場合は、空リストが返される。
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
+
+term_start({cmd}, {options})				*term_start()*
+		端末ウィンドウを開き、その中で {cmd} を実行する。
+
+		{cmd} は |job_start()| と同じような文字列もしくはリストである。
+		ジョブを開始せずに端末ウィンドウを開くには、文字列 "NONE" を使
+		用することができ、端末の疑似端末は gdb のようなコマンドで使用
+		することができる。
+
+		端末ウィンドウのバッファ番号を返す。{cmd} が実行できない場合、
+		ウィンドウが開いてエラーメッセージを表示する。
+		ウィンドウを開くのに失敗すると 0 を返す。
+
+		{options} は |job_start()| で使用されるものと似ている。
+		|job-options| を参照。しかしながらすべてのオプションが使えるわ
+		けではない。サポートされているものは以下のとおり:
+		   すべての timeout オプション
+		   "stoponexit", "cwd", "env"
+		   "callback", "out_cb", "err_cb", "exit_cb", "close_cb"
+		   "in_io", "in_top", "in_bot", "in_name", "in_buf"
+		   "out_io", "out_name", "out_buf", "out_modifiable", "out_msg"
+		   "err_io", "err_name", "err_buf", "err_modifiable", "err_msg"
+		しなかしながら、少なくとも stdin、stdout もしくは stderr のう
+		ち 1 つは端末に接続されていなければならない。I/O が端末に接続
+		されているとき、その部分のコールバック機能は使用されない。
+
+		追加のオプションは以下のとおり:
+		   "term_name"	     (コマンド名の代わりに使用される)バッファ
+				     名に使用する名前
+		   "term_rows"	     ('termwinsize' の代わりに使用される) 端末
+				     の垂直サイズ
+		   "term_cols"	     ('termwinsize' の代わりに使用される) 端末
+				     の水平サイズ
+		   "vertical"	     ウィンドウを垂直に分割する。Note: 他のウィ
+				     ンドウの位置は、|:belowright| のようなコマ
+				     ンド修飾子によって決められる
+		   "curwin"	     ウィンドウを分割せず現在のウィンドウを使
+				     用する、現在のバッファが放棄 (|abandon|)
+				     不可の場合は失敗する
+		   "hidden"	     ウィンドウを開かない
+		   "norestore"	     端末ウィンドウをセッションファイルに加え
+				     ない
+		   "term_kill"	     端末ウィンドウを閉じようとしているときに
+				     何をするか、|term_setkill()| を参照
+		   "term_finish"     ジョブが終了したときに何をするか:
+					"close": ウィンドウを閉じる
+					"open": 必要ならばウィンドウを開く
+				     Note: "open" は割り込み的に発生する。
+				     |term++close| および |term++open|を参照。
+		   "term_opencmd"    "term_finish" が "open" のときにウィンド
+				     ウを開くために使用されるコマンド: バッファ
+				     番号が入る "%d" を含む必要がある、例
+				     "10split|buffer %d": 指定されていない場合
+				     は "botright sbuf %d" が使用される。
+		   "eof_chars"	     すべてのバッファ行が書き込まれた後に端末
+				     に送られるテキスト。設定されていないとき
+				     は MS-Windows では CTRL-D が使用される。
+				     Pythonでは CTRL-Z もしくは "exit()" を使
+				     用する。シェルでは "exit" を使用する。常
+				     に CR が追加される。
+				     "exit".  A CR is always added.
+		   "ansi_colors"     GUI カラーモードで使われる ANSI パレット
+				     を定義する 16 個のカラー名もしくは 16 進
+				     数コード。|g:terminal_ansi_colors| を参
+				     照。
+
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
+
+term_wait({buf} [, {time}])					*term_wait()*
+		{buf} で保留となっている更新が処理されるのを待つ。
+		{buf} の扱いについては |term_getsize()| と同じ。
+		{time} は更新が届くのを待つ、ミリ秒単位での長さ。設定されてい
+		ない場合は 10 ミリ秒が使用される。
+		{|+terminal| 機能付きでコンパイルされたときのみ有効}
 
 test_alloc_fail({id}, {countdown}, {repeat})		*test_alloc_fail()*
 		この関数はテストのために使われる: {id} のメモリ割り当てが行わ
@@ -7556,6 +8438,11 @@ test_alloc_fail({id}, {countdown}, {repeat})		*test_alloc_fail()*
 test_autochdir()					*test_autochdir()*
 		Vimの起動が完了する前に 'autochdir' の効果を有効にするためのフ
 		ラグをセットする。
+
+test_feedinput({string})				*test_feedinput()*
+		{string} の文字を、あたかもユーザーがタイプしたかのように処理
+		する。これは低レベル入力バッファを使用する。この関数は |+unix|
+		もしくは GUI で動作しているときに機能する。
 
 test_garbagecollect_now()			 *test_garbagecollect_now()*
 		garbagecollect() とほぼ同じであるが、この関数はガーベッジコレ
@@ -7601,8 +8488,22 @@ test_override({name}, {val})				*test_override()*
 
 		name	     {val} が非 0 のときの効果 ~
 		redraw       redrawing() 関数を無効化する
+		redraw_flag  RedrawingDisabled フラグを無視する
 		char_avail   char_avail() 関数を無効化する
+		starting     "starting" 変数を初期化する、以下を参照
+		nfa_fail     古い正規表現エンジンに戻すために、NFA regexp エン
+			     ジンを失敗させる
 		ALL	     すべての置き換えをクリアする ({val} は使われない)
+
+		"starting" は、起動が完了したようにテストが振る舞うべきときに
+		使われる。テストはスクリプトを読み込むことによって開始されるの
+		で、"starting" 変数は非ゼロである。これは通常はいいこと (テス
+		トが早く実行される) だが、テストが適切に動作しないという点では
+		動作を変えてしまっている。
+		次のようにしたとき: >
+			call test_override('starting', 1)
+<		"starting" の値が保存される。次のようにして復元される: >
+			call test_override('starting', 0)
 
 test_settime({expr})					*test_settime()*
 		Vim が内部的に用いる時間を設定する。現在は history のタイムス
@@ -7661,6 +8562,10 @@ timer_start({time}, {callback} [, {options}])
 		   "repeat"	コールバックを呼び出す繰り返し回数。-1 は無限
 				を意味する。指定されない場合はコールバックは一
 				度だけ呼び出される。
+				タイマーが 3 回連続してエラーを発生させた場合、
+				繰り返しはキャンセルされる。これは、すべてのエ
+				ラーメッセージによって Vim が使用不可になるの
+				を防ぐ。
 
 		例: >
 			func MyHandler(timer)
@@ -7708,6 +8613,22 @@ tr({src}, {fromstr}, {tostr})				*tr()*
 			echo tr("<blob>", "<>", "{}")
 <		戻り値は "{blob}" となる。
 
+trim({text} [, {mask}])						*trim()*
+		{text} の先頭と末尾から、{mask} 内のすべての文字を取り除いた文
+		字列を返す。
+		{mask} が与えられない場合、{mask} はタブ、空白、NL および CR
+		を含む 0x20 までのすべての文字と、ノーブレークスペース文字の
+		0xa0 となる。
+		このコードはマルチバイト文字を正しく扱える。
+
+		例: >
+			echo trim("   some text ")
+<		"some text" を返す >
+			echo trim("  \r\t\t\r RESERVE \t\n\x0B\xA0") . "_TAIL"
+<		"RESERVE_TAIL" を返す >
+			echo trim("rm<Xrm<>X>rrm", "rm<>")
+<		"Xrm<>X" を返す (中央部分の文字は取り除かれない)
+
 trunc({expr})							*trunc()*
 		{expr} をゼロ方向に切りつめた整数を |Float| で返す。
 		{expr} は |Float| または |Number| に評価されなければならない。
@@ -7719,7 +8640,7 @@ trunc({expr})							*trunc()*
 			echo trunc(4.0)
 <			4.0
 		{|+float| 機能つきでコンパイルされたときのみ有効}
-		
+
 							*type()*
 type({expr})	{expr}の型を示す数値を返す。
 		マジックナンバーを使わずに、v:t_ 変数を使う方が良い。それぞれ
@@ -7886,7 +8807,8 @@ win_getid([{win} [, {tab}]])				*win_getid()*
 		この {win} はウィンドウ番号である。トップウィンドウは番号 1 を
 		持つ。
 		{tab} が未指定の場合現在のタブが使用され、{tab} が番号で指定さ
-		れた場合はそのタブとなる。最初のタブ番号は 1 である。
+		れた場合はそのタブとなる。最初のタブ番号は 1 である。現在のウィ
+		ンドウを対象とする場合は `win_getid(winnr())` のようにする。
 		ウィンドウが見付からない場合には 0 を返す。
 
 win_gotoid({expr})					*win_gotoid()*
@@ -7903,6 +8825,14 @@ win_id2win({expr})					*win_id2win()*
 		{expr} の ID で示されるウィンドウのウィンドウ番号を返す。
 		現在のタブページ内でそのウィンドウが見付からなかった場合は 0
 		を返す。
+
+win_screenpos({nr})					*win_screenpos()*
+		ウィンドウ {nr} のスクリーン位置を 2 つの数値のリストで返す:
+		[row, col]。タブラインがない限り先頭のウィンドウは常に [1, 1]
+		の位置となり、タブラインがある場合は [2, 1] となる。
+		{nr} にはウィンドウ番号もしくは |window-ID| を指定する。
+		現在のタブページに対象のウィンドウが見つからない場合、[0, 0]を
+		返す。
 
 							*winbufnr()*
 winbufnr({nr})	結果は数値で、{nr}番目のウィンドウに関連付けられているバッファ
@@ -7924,10 +8854,38 @@ winheight({nr})						*winheight()*
 		{nr}が0ならば、現在のウィンドウの高さが返る。{nr}というウィン
 		ドウが存在しない場合、-1が返る。存在しているウィンドウは、絶対
 		に0かそれ以上の高さを持っている。
+		ウィンドウツールバーはすべて除く。
 		例: >
   :echo "The current window has " . winheight(0) . " lines."
 <
+winlayout([{tabnr}])					*winlayout()*
+		結果は、タブページ内のウィンドウの配置を含むネストしたリストで
+		ある。
 
+		{tabnr} が与えられない場合は現在のタブページを使い、それ以外は
+		番号 {tabnr} のタブページとなる。{tabnr} のタブページが見つか
+		らない場合、空リストを返す。
+
+		末端 (leaf) のウィンドウでは以下が返る:
+			['leaf', {winid}]
+		列を形成する水平に分割されたウィンドウでは以下が返る:
+			['col', [{ウィンドウのネストしたリスト}]]
+		行を形成する垂直に分割されたウィンドウではいかが返る:
+			['row', [{ウィンドウのネストしたリスト}]]
+
+		例: >
+			" タブページ内に一つのウィンドウのみ
+			:echo winlayout()
+			['leaf', 1000]
+			" 水平に分割された 2 つのウィンドウ
+			:echo winlayout()
+			['col', [['leaf', 1000], ['leaf', 1001]]]
+			" 水平に分割された 3 つのウィンドウで、かつ真ん中の
+			" ウィンドウが 2 つのウィンドウに垂直に分割されている
+			:echo winlayout(2)
+			['col', [['leaf', 1002], ['row', ['leaf', 1003],
+					     ['leaf', 1001]]], ['leaf', 1000]]
+<
 							*winline()*
 winline()	結果は数値で、ウィンドウの最上行から数えた行番号を返す。ウィン
 		ドウでの最上行が1となる。
@@ -8006,9 +8964,9 @@ winwidth({nr})						*winwidth()*
 		例: >
   :echo "The current window has " . winwidth(0) . " columns."
   :if winwidth(0) <= 50
-  :  exe "normal 50\<C-W>|"
+  :  50 wincmd |
   :endif
-<               端末または画面サイズを取得するには、'columns' オプション参照。
+<		端末または画面サイズを取得するには、'columns' オプション参照。
 
 
 wordcount()						*wordcount()*
@@ -8042,8 +9000,17 @@ writefile({list}, {fname} [, {flags}])
 		される。 >
 			:call writefile(["foo"], "event.log", "a")
 			:call writefile(["bar"], "event.log", "a")
->
-<		NL文字はNUL文字に置換される。
+<
+		{flags} が "s" を含むとき、ファイルを書き込んだあと fsync() が
+		呼び出される。これは、可能であればファイルをディスクに書き出
+		す。より時間がかかるが、システムがクラッシュした場合にファイル
+		が失われるのを防ぐ。
+		{flags} が "S" も "s" も含まないとき、オプション 'fsync' が設
+		定されていれば fsync() が呼び出される。
+		{flags} が "S" を含むとき、'fsync' が設定されていても fsync()
+		は呼び出されない。
+
+		NL文字はNUL文字に置換される。
 		CR文字を加えるには、{list}をwritefile()に渡す前に行わねばなら
 		ない。
 		既存のファイルは上書きされる(上書き可能ならば)。
@@ -8066,24 +9033,20 @@ xor({expr}, {expr})					*xor()*
 							*feature-list*
 機能は大別して 4 つの系統に分けられる:
 1.  コンパイル時に|+feature-list|とした時にだけサポートされる機能。例: >
-		:if has("cindent")
+	:if has("cindent")
 2.  ある状態の時にだけサポートされる機能。例: >
-		:if has("gui_running")
+	:if has("gui_running")
 <							*has-patch*
-3.  適用済みパッチ。"patch123" はパッチ 123 が適用されていることを示す。Note:
-    この形式は Vim のバージョンをチェックしない。あなたは |v:version| を解析す
-    る必要がある。
-    例 (6.2.148 以降かどうかを確認する): >
-	:if v:version > 602 || v:version == 602 && has("patch148")
-<    Note: 148 が適用されていても、147 が抜けていることもありうるので注意。
-
-4.  特定のバージョン以降であるか、またはバージョンが同じで特定のパッチが含まれ
-    ているかどうか。"patch-7.4.237" は、Vim のバージョンが 7.5 以降か、または
-    7.4 でパッチ 237 を含んでいるかどうかを示す。
-    Note: これはパッチ 7.4.237 以降でのみ機能する。それ以前では上述のように
-    v:version を確認する必要がある。例: >
+3.  あるバージョンより後か、あるバージョンで特定のパッチが適用されているか。機
+    能"patch-7.4.248" は、Vim のバージョンが 7.5 以降であるか、もしくはバージョ
+    ンが 7.4 でパッチ 248 が適用されているかを意味する。例: >
 	:if has("patch-7.4.248")
-<    Note: 148 が適用されていても、147 が抜けていることもありうるので注意。
+<    Note: 249 が適用されていても、248 が抜けている可能性もある。チェリーピッ
+    キングされたパッチでのみ発生する。
+    Note: この形式はパッチ 7.4.237 以降で機能し、それより前ではパッチと
+    v:version の両方を確認する必要がある。例 (バージョン 6.2.148 以降であるこ
+    とを確認する): >
+	:if v:version > 602 || (v:version == 602 && has("patch148"))
 
 ヒント: Vim がファイル名(MS-Windows)でバックスラッシュをサポートしているかどうか
 を調べるには `if exists('+shellslash')` を使用する。
@@ -8095,6 +9058,8 @@ amiga			AMIGAバージョン
 arabic			アラビア語をサポート |Arabic|
 arp			ARPをサポート (Amiga)
 autocmd			オートコマンドをサポート |autocommand|
+autochdir		'autochdir' をサポート
+autoservername		|clientserver| を自動的に有効化する
 balloon_eval		|balloon-eval| をサポート
 balloon_multiline	複数行バルーンをサポート
 beos			BeOSバージョン
@@ -8163,9 +9128,8 @@ listcmds		バッファリスト用のコマンド|:files|と引数リスト用�
 			ンド|arglist|をサポート
 localmap		ローカルなマッピングと短縮入力をサポート|:map-local|
 lua			Lua インターフェイスをサポート |Lua|
-mac			すべてのマッキントッシュ版Vim
-macunix			darwinつきのOS X
-osx			darwinなしのOS X
+mac			すべてのマッキントッシュ版Vim、osx を参照
+macunix			osxdarwin と同じ
 menu			|:menu|をサポート
 mksession		|:mksession|をサポート
 modify_fname		ファイル名変換子をサポート |filename-modifiers|
@@ -8188,6 +9152,8 @@ netbeans_enabled	|netbeans|をサポートし、現在接続している
 netbeans_intg		|netbeans|をサポート
 num64			64ビット数値をサポート |Number|
 ole			Win32にてOLEオートメーションをサポート
+osx			macOS 向けにコンパイル、mac を参照
+osxdarwin		|mac-darwin-feature| 付きで macOS 向けにコンパイル
 packages		|packages|をサポート
 path_extra		'path' と 'tags' の上方・下方検索をサポート
 perl			Perlインターフェイスをサポート
@@ -8195,9 +9161,17 @@ persistent_undo		永続アンドゥをサポート
 postscript		PostScriptファイルの印刷をサポート
 printer			|:hardcopy| をサポート
 profile			|:profile| をサポート
-python			Python 2.x インターフェイスをサポート |has-python|
-python3			Python 3.x インターフェイスをサポート |has-python|
-pythonx			|python_x| インターフェイスをサポート |has-pythonx|
+python			Python 2.x インタフェースが使用可能。|has-python|
+python_compiled		Python 2.x インタフェース付きでコンパイルされ
+			た。|has-python|
+python_dynamic		Python 2.x インタフェースが動的にロードされ
+			た。|has-python|
+python3			Python 3.x インタフェースが使用可能。|has-python|
+python3_compiled	Python 3.x インタフェース付きでコンパイルされ
+			た。|has-python|
+python3_dynamic		Python 3.x インタフェースが動的にロードされ
+			た。|has-python|
+pythonx			Compiled with |python_x| interface. |has-pythonx|
 qnx			QNXバージョン
 quickfix		|quickfix|をサポート
 reltime			|reltime()|をサポート
@@ -8220,6 +9194,7 @@ tag_old_static		旧式の静的tagsをサポート |tag-old-static|
 tag_any_white		タグファイル内の空白文字をサポート |tag-any-white|
 tcl			TCLインターフェイスをサポート
 termguicolors		端末でのtrueカラーをサポート
+terminal		|terminal| をサポート
 terminfo		termcapの代わりにterminfoをサポート
 termresponse		|t_RV|と|v:termresponse|をサポート
 textobjects		|text-objects|をサポート
@@ -8229,9 +9204,11 @@ title			ウィンドウタイトルをサポート |'title'|
 toolbar			|gui-toolbar|をサポート
 ttyin			入力が端末 (tty) である
 ttyout			出力が端末 (tty) である
-unix			UNIXバージョン
+unix			Vim の Unix バージョン。*+unix*
 unnamedplus		'clipboard' に "unnamedplus" をサポート
 user_commands		ユーザー定義コマンドをサポート
+vcon			Win32: 仮想コンソールサポートが機能していて、
+			'termguicolors' を使用することができる。|+vtp| も参照。
 vertsplit		ウィンドウの垂直分割をサポート |:vsplit|
 vim_starting		Vimの初期化プロセス中は真となる。|startup|
 			*vim_starting*
@@ -8241,12 +9218,15 @@ visual			ビジュアルモードをサポート
 visualextra		拡張ビジュアルモードをサポート |blockwise-operators|
 vms			VMSバージョン
 vreplace		コマンド|gR|と|gr|をサポート
+vtp			vcon をサポート |+vtp| (現在のコンソール内で機能するか
+			どうかを調べるには vcon を確認する)
 wildignore		オプション 'wildignore' をサポート
 wildmenu		オプション 'wildmenu' を指定してコンパイル
+win16			MS-Windows 3.1 用の古いバージョン (常に False)
 win32			Win32バージョン(MS-Windows 95 以上の 32 or 64 ビット)
 win32unix		Win32バージョン。Unixファイルを使用 (Cygwin)
 win64			Win64バージョン(MS-Windows 64 bit)
-win95			Win32バージョン。MS-Windows 95/98/ME用。
+win95			Win32バージョン。MS-Windows 95/98/ME用 (常に False)
 winaltkeys		オプション 'winaltkeys' を指定してコンパイル
 windows			複数ウィンドウをサポート
 writebackup		オプション 'writebackup' が起動時にonになる
@@ -8328,13 +9308,15 @@ x11			X11をサポート
 
 						*E124* *E125* *E853* *E884*
 :fu[nction][!] {name}([arguments]) [range] [abort] [dict] [closure]
-			{name}という名前で新しい関数を定義する。関数名はアル
-			ファベットと数字と '_' からなり、通常の関数はアルファ
-			ベットの大文字、スクリプトローカル関数は "s:" で始まら
-			なければならない。Note: "b:" や "g:" は使用できない
-			(7.4.260 からは関数名にコロンが含まれる場合は E884 エ
-			ラーが発生する。例 "foo:bar()"。このパッチ以前はエラー
-			にはならない)。
+			{name} という名前で新しい関数を定義する。関数の本体は、
+			次の行から |:endfunction| と一致するまで続く。
+
+			関数名はアルファベットと数字と '_' からなり、通常の関
+			数はアルファベットの大文字、スクリプトローカル関数は
+			"s:" で始まらなければならない。Note: "b:" や "g:" は
+			使用できない (7.4.260 からは関数名にコロンが含まれる場
+			合は E884 エラーが発生する。例 "foo:bar()"。このパッチ
+			以前はエラーにはならない)。
 
 			{name}は辞書|Dictionary|の要素の|Funcref|であってもよ
 			い: >
@@ -8350,6 +9332,9 @@ x11			X11をサポート
 			れなかった場合、エラーとなる。[!] が使用されていれば、
 			それまで存在していた関数は、速やかに新しいものへ置換え
 			られる。
+			NOTE: ! は十分に注意して使用すること。注意せずに使用し
+			た場合は既存の関数を期待せず置き換える可能性があり、デ
+			バッグが難しくなる。
 
 			引数{arguments}については|function-argument|を参照。
 
@@ -8398,17 +9383,34 @@ x11			X11をサポート
 			関数内で|:nohlsearch| を行っても、関数から戻ると検索結
 			果のハイライトが元に戻ることになる。
 
-					*:endf* *:endfunction* *E126* *E193*
-:endf[unction]		関数定義の終了。このコマンド1つで1行とすること。他のコ
-			マンドをいっしょに書いてはならない。
+				*:endf* *:endfunction* *E126* *E193* *W22*
+:endf[unction] [argument]
+			関数定義の終了。最も良いのは、[argument] 無しに行内に
+			これ自身のみを書くこと。
 
+			[argument] として可能なものは以下のとおり:
+				| コマンド	次に実行するコマンド
+				\n コマンド	次に実行するコマンド
+				" コメント	常に無視される
+				その他		無視される、'verbose' が非ゼロ
+						のときは警告が表示される
+			後ろに続くコマンドのサポートは Vim 8.0.0654 で追加され
+			ており、それ以前ではいかなる引数も黙って無視される。
+
+			コマンド `:execute` の内部で関数の定義を可能にするに
+			は、|:bar| の代わりに改行を使用する: >
+				:exe "func Foo()\necho 'foo'\nendfunc"
+<
 				*:delf* *:delfunction* *E130* *E131* *E933*
-:delf[unction] {name}	関数{name}を削除する。
+:delf[unction][!] {name}
+			関数{name}を削除する。
 			{name}は辞書|Dictionary|の要素の|Funcref|であってもよ
 			い: >
 				:delfunc dict.init
 <			この例は "dict" から要素 "init" を削除する。この関数へ
 			の参照がなくなると、関数は削除される。
+			! が付いていると、関数が存在していなくてもエラーが発生
+			しない。
 							*:retu* *:return* *E133*
 :retu[rn] [expr]	関数から戻る。"[expr]" が与えられた場合、それは評価さ
 			れ関数の戻り値として呼出し側に渡される。"[expr]" が与
@@ -8442,8 +9444,8 @@ a: のスコープとこの変数は固定されており、変更できない�
 致していなければならない。"..." を使った時には引数の数は大きくなるだろう。
 
 関数を引数無しで定義することも可能である。その時でも()は付けなければならない。
-関数の本体は、宣言の次の行から始まり、対応する|:endfunction|までになる。関数の
-中で別の関数を定義することも可能である。
+
+関数の中で別の関数を定義することも可能である。
 
 
 							*local-variables*
@@ -8808,10 +9810,18 @@ Vimはこれを見つけると、まず波括弧の中の式を評価し、そ�
 <			辞書からは一度に1個の要素を削除することができる: >
 				:unlet dict['two']
 				:unlet dict.two
-			グローバル変数とスクリプトローカル変数をクリーンアップ
+<			グローバル変数とスクリプトローカル変数をクリーンアップ
 			するために特に便利である(これらはスクリプト終了時に検
 			出されない)。関数ローカルな関数は、その関数から抜ける
 			ときに自動的に削除される。
+
+:unl[et] ${env-name} ...			*:unlet-environment* *:unlet-$*
+			環境変数 {env-name} を削除する。
+			一つの :unlet コマンドの中に {name} と ${env-name} を
+			混ぜることができる。! が付いていない場合でも、存在しな
+			い変数に対してエラーメッセージは表示されない。
+			システムが環境変数の削除をサポートしていない場合は空に
+			する。
 
 :lockv[ar][!] [depth] {name} ...			*:lockvar* *:lockv*
 			内部変数{name}をロックする。ロックすると、それ以降変更
@@ -10219,7 +11229,7 @@ matchstr()やsubstitute()を使えば実現できる。以下の例は、"foobar
     redir => scriptnames_output
     silent scriptnames
     redir END
-    
+
     " 出力を行のリストに分割し、各行をパースする。辞書 "scripts" に要素を追加
     " する。
     let scripts = {}
@@ -10254,6 +11264,17 @@ matchstr()やsubstitute()を使えば実現できる。以下の例は、"foobar
 	:  echo "You will _never_ see this message"
 	:endif
 
+|+eval|機能が無効になっているときだけにコマンドを実行するには、この例のような
+トリックが必要である: >
+
+	silent! while 0
+	  set history=111
+	silent! endwhile
+
+|+eval| 機能が有効なとき、"while 0" のためにコマンドはスキップされる。|+eval|
+機能がない場合、"while 0" はエラーとなり黙って無視されるため、コマンドが実行さ
+れる。
+
 ==============================================================================
 11. サンドボックス				*eval-sandbox* *sandbox* *E48*
 
@@ -10267,7 +11288,7 @@ matchstr()やsubstitute()を使えば実現できる。以下の例は、"foobar
 
 サンドボックス内では以下の事が禁止される:
 	- バッファの変更
-	- マッピング、オートコマンド、関数、ユーザー定義コマンドの定義・変更
+	- マッピング、オートコマンド、ユーザー定義コマンドの定義・変更
 	- ある種のオプションの設定 (|option-summary|を参照)
 	- ある種のVim定義済変数(v:)の設定 (|v:var|を参照)  *E794*
 	- シェルコマンドの実行
@@ -10290,6 +11311,7 @@ matchstr()やsubstitute()を使えば実現できる。以下の例は、"foobar
 - カレントディレクトリの .vimrc や .exrc を source するとき
 - サンドボックス内で実行している最中
 - モードラインから設定された値
+- サンドボックス内で定義された関数の実行
 
 Note サンドボックス内でオプションの値を退避し、それから復元した場合、そのオプ
 ションはやはりサンドボックス内で設定されたものとマークされる。

--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -923,7 +923,7 @@ expr7							*expr7*
 expr8							*expr8*
 -----
 この式は |expr9|、もしくは連続する以下の選択方式であり、どんな順番でもよい。
-例として、これらはすべて考えられる:
+例として、これらはすべて可能である:
 	expr9[expr1].name
 	expr9.name[expr1]
 	expr9(expr1, ...)[expr1].name

--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -934,7 +934,7 @@ expr8[expr1]		文字列またはリストの要素	*expr-[]* *E111*
 expr8が数値か文字列ならば、この値は文字列 expr8 の第 expr1 番目のバイトからな
 る 1 バイトの文字列となる。expr8は文字列、expr1は数として扱われる。ただし
 expr8 がマルチバイト文字列である場合、この値は単なるバイトコードであり、1文字
-とはならないかもしれないことに注意。マルチバイト文字列に対する選択方式は
+とはならないかもしれないことに注意。マルチバイト文字列に対する代わりの方法は
 `byteidx()` を参照するか、`split()`を使って文字列を文字のリストに変換すれば良
 い。
 
@@ -1976,8 +1976,7 @@ assert_beeps({cmd})		数値	{cmd} がビープ音を鳴らすことをテスト�
 assert_equal({exp}, {act} [, {msg}])
 				数値	{exp}と{act}が等しいかどうかテストする
 assert_equalfile({fname-one}, {fname-two})
-				数値	ファイルコンテンツが等しいことをテスト
-					する
+				数値	ファイルの内容が等しいことをテストする
 assert_exception({error} [, {msg}])
 				数値	|v:exception|が{error}であるかテストする
 assert_fails({cmd} [, {error}])
@@ -2370,7 +2369,7 @@ stridx({haystack}, {needle} [, {start}])
 string({expr})			文字列	{expr}の値の文字列表現
 strlen({expr})			数値	文字列{expr}の長さ
 strpart({str}, {start} [, {len}])
-				文字列	{src}内{start}から長さ{len}の部分
+				文字列	{str}内{start}から長さ{len}の部分
 strridx({haystack}, {needle} [, {start}])
 				数値	{haystack}内の最後の{needle}のインデッ
 					クス
@@ -2765,14 +2764,14 @@ balloon_show({expr})					*balloon_show()*
 
 		バルーンを表示できないときは何も起こらず、エラーメッセージも表
 		示されない。
-		{Vimが |+balloon_eval| もしくは +balloon_eval_term 機能付きで
-		コンパイルされたときのみ有効}
+		{Vimが |+balloon_eval| もしくは |+balloon_eval_term| 機能付き
+		でコンパイルされたときのみ有効}
 
 balloon_split({msg})					*balloon_split()*
 		{msg} をバルーン内で表示される行に分割する。カレントウィンドウ
 		サイズ用に分割され、デバッガ出力を表示するために最適化される。
 		分割された行の |List| を返す。
-		{+balloon_eval_term 機能付きでコンパイルされたときのみ有効}
+		{|+balloon_eval_term| 機能付きでコンパイルされたときのみ有効}
 
 							*browse()*
 browse({save}, {title}, {initdir}, {default})
@@ -6075,7 +6074,7 @@ mkdir({name} [, {path} [, {prot}]])
 			:call mkdir($HOME . "/tmp/foo/bar", "p", 0700)
 <		|sandbox|の中ではこの関数は使用できない。
 		ディレクトリが既に存在して、かつフラグ "p" が渡された場合エラー
-		は発生しない (パッチ 8.0.1708 より。
+		は発生しない (パッチ 8.0.1708 より)。
 		システムによっては利用できない場合がある。これを確認するには次
 		のようにする: >
 			:if exists("*mkdir")

--- a/en/eval.txt
+++ b/en/eval.txt
@@ -3045,8 +3045,8 @@ char2nr({expr}[, {utf8}])					*char2nr()*
 			char2nr("ABC")		returns 65
 <		When {utf8} is omitted or zero, the current 'encoding' is used.
 		Example for "utf-8": >
-			char2nr("แ")		returns 225
-			char2nr("แ"[0])		returns 195
+			char2nr("รก")		returns 225
+			char2nr("รก"[0])		returns 195
 <		With {utf8} set to 1, always treat as utf-8 characters.
 		A combining character is a separate character.
 		|nr2char()| does the opposite.

--- a/en/eval.txt
+++ b/en/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim version 8.0.  Last change: 2017 Mar 09
+*eval.txt*	For Vim version 8.1.  Last change: 2018 May 17
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -120,9 +120,8 @@ To test for a non-empty string, use empty(): >
 Function arguments often behave slightly different from |TRUE|: If the
 argument is present and it evaluates to a non-zero Number, |v:true| or a
 non-empty String, then the value is considered to be TRUE.
-Note that " " and "0" are also non-empty strings, thus cause the mode to be
-cleared.  A List, Dictionary or Float is not a Number or String, thus
-evaluates to FALSE.
+Note that " " and "0" are also non-empty strings, thus considered to be TRUE.
+A List, Dictionary or Float is not a Number or String, thus evaluate to FALSE.
 
 		*E745* *E728* *E703* *E729* *E730* *E731* *E908* *E910* *E913*
 List, Dictionary, Funcref, Job and Channel types are not automatically
@@ -815,14 +814,15 @@ Examples:
 "abc" == "Abc"	  evaluates to 1 if 'ignorecase' is set, 0 otherwise
 
 							*E691* *E692*
-A |List| can only be compared with a |List| and only "equal", "not equal" and
-"is" can be used.  This compares the values of the list, recursively.
-Ignoring case means case is ignored when comparing item values.
+A |List| can only be compared with a |List| and only "equal", "not equal",
+"is" and "isnot" can be used.  This compares the values of the list,
+recursively.  Ignoring case means case is ignored when comparing item values.
 
 							*E735* *E736*
 A |Dictionary| can only be compared with a |Dictionary| and only "equal", "not
-equal" and "is" can be used.  This compares the key/values of the |Dictionary|
-recursively.  Ignoring case means case is ignored when comparing item values.
+equal", "is" and "isnot" can be used.  This compares the key/values of the
+|Dictionary| recursively.  Ignoring case means case is ignored when comparing
+item values.
 
 							*E694*
 A |Funcref| can only be compared with a |Funcref| and only "equal", "not
@@ -954,6 +954,13 @@ These three can be repeated and mixed.  Examples:
 
 expr8							*expr8*
 -----
+This expression is either |expr9| or a sequence of the alternatives below,
+in any order.  E.g., these are all possible:
+	expr9[expr1].name
+	expr9.name[expr1]
+	expr9(expr1, ...)[expr1].name
+
+
 expr8[expr1]		item of String or |List|	*expr-[]* *E111*
 							*E909* *subscript*
 If expr8 is a Number or String this results in a String that contains the
@@ -1048,7 +1055,7 @@ When expr8 is a |Funcref| type variable, invoke the function it refers to.
 							*expr9*
 number
 ------
-number			number constant			*expr-number* 
+number			number constant			*expr-number*
 				*hex-number* *octal-number* *binary-number*
 
 Decimal, Hexadecimal (starting with 0x or 0X), Binary (starting with 0b or 0B)
@@ -1246,8 +1253,8 @@ The arguments are optional.  Example: >
 							*closure*
 Lambda expressions can access outer scope variables and arguments.  This is
 often called a closure.  Example where "i" and "a:arg" are used in a lambda
-while they exist in the function scope.  They remain valid even after the
-function returns: >
+while they already exist in the function scope.  They remain valid even after
+the function returns: >
 	:function Foo(arg)
 	:  let i = 3
 	:  return {x -> x + i - a:arg}
@@ -1256,7 +1263,10 @@ function returns: >
 	:echo Bar(6)
 <	5
 
-See also |:func-closure|.  Lambda and closure support can be checked with: >
+Note that the variables must exist in the outer scope before the lamba is
+defined for this to work.  See also |:func-closure|.
+
+Lambda and closure support can be checked with: >
 	if has('lambda')
 
 Examples for using a lambda expression with |sort()|, |map()| and |filter()|: >
@@ -1449,7 +1459,7 @@ v:beval_text	The text under or after the mouse pointer.  Usually a word as
 		but a dot and "->" before the position is included.  When on a
 		']' the text before it is used, including the matching '[' and
 		word before it.  When on a Visual area within one line the
-		highlighted text is used.
+		highlighted text is used.  Also see |<cexpr>|.
 		Only valid while evaluating the 'balloonexpr' option.
 
 					*v:beval_winnr* *beval_winnr-variable*
@@ -1545,14 +1555,22 @@ v:errmsg	Last given error message.  It's allowed to set this variable.
 	:  ... handle error
 <		"errmsg" also works, for backwards compatibility.
 
-					*v:errors* *errors-variable*
+				*v:errors* *errors-variable* *assert-return*
 v:errors	Errors found by assert functions, such as |assert_true()|.
 		This is a list of strings.
 		The assert functions append an item when an assert fails.
+		The return value indicates this: a one is returned if an item
+		was added to v:errors, otherwise zero is returned.
 		To remove old results make it empty: >
 	:let v:errors = []
 <		If v:errors is set to anything but a list it is made an empty
 		list by the assert function.
+
+					*v:event* *event-variable*
+v:event		Dictionary containing information about the current
+		|autocommand|.  The dictionary is emptied when the |autocommand|
+		finishes, please refer to |dict-identity| for how to get an
+		independent copy of it.
 
 					*v:exception* *exception-variable*
 v:exception	The value of the exception most recently caught and not
@@ -1647,7 +1665,7 @@ v:foldstart	Used for 'foldtext': first line of closed fold.
 		Read-only in the |sandbox|. |fold-foldtext|
 
 					*v:hlsearch* *hlsearch-variable*
-v:hlsearch	Variable that indicates whether search highlighting is on. 
+v:hlsearch	Variable that indicates whether search highlighting is on.
 		Setting it makes sense only if 'hlsearch' is enabled which
 		requires |+extra_search|. Setting this variable to zero acts
 		like the |:nohlsearch| command, setting it to one acts like >
@@ -1815,10 +1833,10 @@ v:scrollstart	String describing the script or function that caused the
 		hit-enter prompt.
 
 					*v:servername* *servername-variable*
-v:servername	The resulting registered |x11-clientserver| name if any.
+v:servername	The resulting registered |client-server-name| if any.
 		Read-only.
 
-		
+
 v:searchforward			*v:searchforward* *searchforward-variable*
 		Search direction:  1 after a forward search, 0 after a
 		backward search.  It is reset to forward when directly setting
@@ -1902,10 +1920,35 @@ v:termresponse	The escape sequence returned by the terminal for the |t_RV|
 		always 95 or bigger).  Pc is always zero.
 		{only when compiled with |+termresponse| feature}
 
+						*v:termblinkresp*
+v:termblinkresp	The escape sequence returned by the terminal for the |t_RC|
+		termcap entry.  This is used to find out whether the terminal
+		cursor is blinking. This is used by |term_getcursor()|.
+
+						*v:termstyleresp*
+v:termstyleresp	The escape sequence returned by the terminal for the |t_RS|
+		termcap entry.  This is used to find out what the shape of the
+		cursor is.  This is used by |term_getcursor()|.
+
+						*v:termrbgresp*
+v:termrbgresp	The escape sequence returned by the terminal for the |t_RB|
+		termcap entry.  This is used to find out what the terminal
+		background color is, see 'background'.
+
+						*v:termrfgresp*
+v:termrfgresp	The escape sequence returned by the terminal for the |t_RF|
+		termcap entry.  This is used to find out what the terminal
+		foreground color is.
+
+						*v:termu7resp*
+v:termu7resp	The escape sequence returned by the terminal for the |t_u7|
+		termcap entry.  This is used to find out what the terminal
+		does with ambiguous width characters, see 'ambiwidth'.
+
 					*v:testing* *testing-variable*
 v:testing	Must be set before using `test_garbagecollect_now()`.
 		Also, when set certain error messages won't be shown for 2
-		seconds. (e.g. "'dictionary' option is empty") 
+		seconds. (e.g. "'dictionary' option is empty")
 
 				*v:this_session* *this_session-variable*
 v:this_session	Full filename of the last loaded or saved session file.  See
@@ -1986,20 +2029,31 @@ argidx()			Number	current index in the argument list
 arglistid([{winnr} [, {tabnr}]]) Number	argument list id
 argv({nr})			String	{nr} entry of the argument list
 argv()				List	the argument list
-assert_equal({exp}, {act} [, {msg}])  none  assert {exp} is equal to {act}
-assert_exception({error} [, {msg}])   none  assert {error} is in v:exception
-assert_fails({cmd} [, {error}])	      none  assert {cmd} fails
-assert_false({actual} [, {msg}])      none  assert {actual} is false
+assert_beeps({cmd})		Number	assert {cmd} causes a beep
+assert_equal({exp}, {act} [, {msg}])
+				Number	assert {exp} is equal to {act}
+assert_equalfile({fname-one}, {fname-two})
+				Number	assert file contents is equal
+assert_exception({error} [, {msg}])
+				Number	assert {error} is in v:exception
+assert_fails({cmd} [, {error}])	Number	assert {cmd} fails
+assert_false({actual} [, {msg}])
+				Number	assert {actual} is false
 assert_inrange({lower}, {upper}, {actual} [, {msg}])
-				none	assert {actual} is inside the range
-assert_match({pat}, {text} [, {msg}])	 none  assert {pat} matches {text}
-assert_notequal({exp}, {act} [, {msg}])  none  assert {exp} is not equal {act}
-assert_notmatch({pat}, {text} [, {msg}]) none  assert {pat} not matches {text}
-assert_true({actual} [, {msg}])		 none  assert {actual} is true
+				Number	assert {actual} is inside the range
+assert_match({pat}, {text} [, {msg}])
+				Number	assert {pat} matches {text}
+assert_notequal({exp}, {act} [, {msg}])
+				Number	assert {exp} is not equal {act}
+assert_notmatch({pat}, {text} [, {msg}])
+				Number	assert {pat} not matches {text}
+assert_report({msg})		Number	report a test failure
+assert_true({actual} [, {msg}])	Number	assert {actual} is true
 asin({expr})			Float	arc sine of {expr}
 atan({expr})			Float	arc tangent of {expr}
 atan2({expr1}, {expr2})		Float	arc tangent of {expr1} / {expr2}
-balloon_show({msg})		none	show {msg} inside the balloon
+balloon_show({expr})		none	show {expr} inside the balloon
+balloon_split({msg})		List	split {msg} as used for a balloon
 browse({save}, {title}, {initdir}, {default})
 				String	put up a file requester
 browsedir({title}, {initdir})	String	put up a directory requester
@@ -2042,7 +2096,7 @@ ch_setoptions({handle}, {options})
 ch_status({handle} [, {options}])
 				String	status of channel {handle}
 changenr()			Number	current change number
-char2nr({expr}[, {utf8}])	Number	ASCII/UTF8 value of first char in {expr}
+char2nr({expr} [, {utf8}])	Number	ASCII/UTF8 value of first char in {expr}
 cindent({lnum})			Number	C indent for line {lnum}
 clearmatches()			none	clear all matches
 col({expr})			Number	column nr of cursor or mark
@@ -2061,8 +2115,11 @@ cscope_connection([{num}, {dbpath} [, {prepend}]])
 cursor({lnum}, {col} [, {off}])
 				Number	move cursor to {lnum}, {col}, {off}
 cursor({list})			Number	move cursor to position in {list}
+debugbreak({pid})		Number  interrupt process being debugged
 deepcopy({expr} [, {noref}])	any	make a full copy of {expr}
 delete({fname} [, {flags}])	Number	delete the file or directory {fname}
+deletebufline({expr}, {first} [, {last}])
+				Number	delete lines from buffer {expr}
 did_filetype()			Number	|TRUE| if FileType autocmd event used
 diff_filler({lnum})		Number	diff filler lines about {lnum}
 diff_hlID({lnum}, {col})	Number	diff highlighting at {lnum}/{col}
@@ -2084,9 +2141,9 @@ filereadable({file})		Number	|TRUE| if {file} is a readable file
 filewritable({file})		Number	|TRUE| if {file} is a writable file
 filter({expr1}, {expr2})	List/Dict  remove items from {expr1} where
 					{expr2} is 0
-finddir({name}[, {path}[, {count}]])
+finddir({name} [, {path} [, {count}]])
 				String	find directory {name} in {path}
-findfile({name}[, {path}[, {count}]])
+findfile({name} [, {path} [, {count}]])
 				String	find file {name} in {path}
 float2nr({expr})		Number	convert Float {expr} to a Number
 floor({expr})			Float	round {expr} down
@@ -2112,6 +2169,7 @@ getbufline({expr}, {lnum} [, {end}])
 				List	lines {lnum} to {end} of buffer {expr}
 getbufvar({expr}, {varname} [, {def}])
 				any	variable {varname} in buffer {expr}
+getchangelist({expr})		List	list of change list items
 getchar([expr])			Number	get one character from the user
 getcharmod()			Number	modifiers for the last typed character
 getcharsearch()			Dict	last character search
@@ -2128,9 +2186,11 @@ getfperm({fname})		String	file permissions of file {fname}
 getfsize({fname})		Number	size in bytes of file {fname}
 getftime({fname})		Number	last modification time of file
 getftype({fname})		String	description of type of file {fname}
+getjumplist([{winnr} [, {tabnr}]])
+				List	list of jump list items
 getline({lnum})			String	line {lnum} of current buffer
 getline({lnum}, {end})		List	lines {lnum} to {end} of current buffer
-getloclist({nr}[, {what}])	List	list of location list items
+getloclist({nr} [, {what}])	List	list of location list items
 getmatches()			List	list of current matches
 getpid()			Number	process ID of Vim
 getpos({expr})			List	position of cursor, mark, etc.
@@ -2143,9 +2203,10 @@ gettabvar({nr}, {varname} [, {def}])
 				any	variable {varname} in tab {nr} or {def}
 gettabwinvar({tabnr}, {winnr}, {name} [, {def}])
 				any	{name} in {winnr} in tab page {tabnr}
-getwininfo([{winid}])		List	list of windows
-getwinposx()			Number	X coord in pixels of GUI Vim window
-getwinposy()			Number	Y coord in pixels of GUI Vim window
+getwininfo([{winid}])		List	list of info about each window
+getwinpos([{timeout}])		List	X and Y coord in pixels of the Vim window
+getwinposx()			Number	X coord in pixels of the Vim window
+getwinposy()			Number	Y coord in pixels of the Vim window
 getwinvar({nr}, {varname} [, {def}])
 				any	variable {varname} in window {nr}
 glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])
@@ -2172,7 +2233,7 @@ index({list}, {expr} [, {start} [, {ic}]])
 				Number	index in {list} where {expr} appears
 input({prompt} [, {text} [, {completion}]])
 				String	get input from the user
-inputdialog({prompt} [, {text} [, {completion}]]])
+inputdialog({prompt} [, {text} [, {completion}]])
 				String	like input() but in a GUI dialog
 inputlist({textlist})		Number	let the user pick from a choice list
 inputrestore()			Number	restore typeahead
@@ -2185,7 +2246,7 @@ islocked({expr})		Number	|TRUE| if {expr} is locked
 isnan({expr})			Number	|TRUE| if {expr} is NaN
 items({dict})			List	key-value pairs in {dict}
 job_getchannel({job})		Channel	get the channel handle for {job}
-job_info({job})			Dict	get information about {job}
+job_info([{job}])		Dict	get information about {job}
 job_setoptions({job}, {options}) none	set options for {job}
 job_start({command} [, {options}])
 				Job	start a job
@@ -2206,28 +2267,28 @@ lispindent({lnum})		Number	Lisp indent for line {lnum}
 localtime()			Number	current time
 log({expr})			Float	natural logarithm (base e) of {expr}
 log10({expr})			Float	logarithm of Float {expr} to base 10
-luaeval({expr}[, {expr}])	any	evaluate |Lua| expression
+luaeval({expr} [, {expr}])	any	evaluate |Lua| expression
 map({expr1}, {expr2})		List/Dict  change each item in {expr1} to {expr}
-maparg({name}[, {mode} [, {abbr} [, {dict}]]])
+maparg({name} [, {mode} [, {abbr} [, {dict}]]])
 				String or Dict
 					rhs of mapping {name} in mode {mode}
-mapcheck({name}[, {mode} [, {abbr}]])
+mapcheck({name} [, {mode} [, {abbr}]])
 				String	check for mappings matching {name}
-match({expr}, {pat}[, {start}[, {count}]])
+match({expr}, {pat} [, {start} [, {count}]])
 				Number	position where {pat} matches in {expr}
-matchadd({group}, {pattern}[, {priority}[, {id} [, {dict}]]])
+matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
 				Number	highlight {pattern} with {group}
-matchaddpos({group}, {pos}[, {priority}[, {id}[, {dict}]]])
+matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])
 				Number	highlight positions with {group}
 matcharg({nr})			List	arguments of |:match|
 matchdelete({id})		Number	delete match identified by {id}
-matchend({expr}, {pat}[, {start}[, {count}]])
+matchend({expr}, {pat} [, {start} [, {count}]])
 				Number	position where {pat} ends in {expr}
-matchlist({expr}, {pat}[, {start}[, {count}]])
+matchlist({expr}, {pat} [, {start} [, {count}]])
 				List	match and submatches of {pat} in {expr}
-matchstr({expr}, {pat}[, {start}[, {count}]])
+matchstr({expr}, {pat} [, {start} [, {count}]])
 				String	{count}'th match of {pat} in {expr}
-matchstrpos({expr}, {pat}[, {start}[, {count}]])
+matchstrpos({expr}, {pat} [, {start} [, {count}]])
 				List	{count}'th match of {pat} in {expr}
 max({expr})			Number	maximum value of items in {expr}
 min({expr})			Number	minimum value of items in {expr}
@@ -2236,13 +2297,17 @@ mkdir({name} [, {path} [, {prot}]])
 mode([expr])			String	current editing mode
 mzeval({expr})			any	evaluate |MzScheme| expression
 nextnonblank({lnum})		Number	line nr of non-blank line >= {lnum}
-nr2char({expr}[, {utf8}])	String	single char with ASCII/UTF8 value {expr}
+nr2char({expr} [, {utf8}])	String	single char with ASCII/UTF8 value {expr}
 or({expr}, {expr})		Number	bitwise OR
 pathshorten({expr})		String	shorten directory names in a path
 perleval({expr})		any	evaluate |Perl| expression
 pow({x}, {y})			Float	{x} to the power of {y}
 prevnonblank({lnum})		Number	line nr of non-blank line <= {lnum}
 printf({fmt}, {expr1}...)	String	format text
+prompt_addtext({buf}, {expr})	none	add text to a prompt buffer
+prompt_setcallback({buf}, {expr}) none	set prompt callback function
+prompt_setinterrupt({buf}, {text}) none	set prompt interrupt function
+prompt_setprompt({buf}, {text}) none	set prompt text
 pumvisible()			Number	whether popup menu is visible
 pyeval({expr})			any	evaluate |Python| expression
 py3eval({expr})			any	evaluate |python3| expression
@@ -2251,16 +2316,21 @@ range({expr} [, {max} [, {stride}]])
 				List	items from {expr} to {max}
 readfile({fname} [, {binary} [, {max}]])
 				List	get list of lines from file {fname}
+reg_executing()			String	get the executing register name
+reg_recording()			String	get the recording register name
 reltime([{start} [, {end}]])	List	get time value
 reltimefloat({time})		Float	turn the time value into a Float
 reltimestr({time})		String	turn time value into a String
-remote_expr({server}, {string} [, {idvar}])
+remote_expr({server}, {string} [, {idvar} [, {timeout}]])
 				String	send expression
 remote_foreground({server})	Number	bring Vim server to the foreground
 remote_peek({serverid} [, {retvar}])
 				Number	check for reply string
-remote_read({serverid})		String	read reply string
+remote_read({serverid} [, {timeout}])
+				String	read reply string
 remote_send({server}, {string} [, {idvar}])
+				String	send key sequence
+remote_startserver({name})	none	become server {name}
 				String	send key sequence
 remove({list}, {idx} [, {end}])	any	remove items {idx}-{end} from {list}
 remove({dict}, {key})		any	remove entry {key} from {dict}
@@ -2286,19 +2356,22 @@ searchpos({pattern} [, {flags} [, {stopline} [, {timeout}]]])
 server2client({clientid}, {string})
 				Number	send reply string
 serverlist()			String	get a list of available servers
+setbufline({expr}, {lnum}, {line})
+				Number	set line {lnum} to {line} in buffer
+					{expr}
 setbufvar({expr}, {varname}, {val})
 				none	set {varname} in buffer {expr} to {val}
 setcharsearch({dict})		Dict	set character search from {dict}
 setcmdpos({pos})		Number	set cursor position in command-line
 setfperm({fname}, {mode})	Number	set {fname} file permissions to {mode}
 setline({lnum}, {line})		Number	set line {lnum} to {line}
-setloclist({nr}, {list}[, {action}[, {what}]])
+setloclist({nr}, {list} [, {action} [, {what}]])
 				Number	modify location list using {list}
 setmatches({list})		Number	restore a list of matches
 setpos({expr}, {list})		Number	set the {expr} position to {list}
-setqflist({list}[, {action}[, {what}]])
+setqflist({list} [, {action} [, {what}]])
 				Number	modify quickfix list using {list}
-setreg({n}, {v}[, {opt}])	Number	set register to value and type
+setreg({n}, {v} [, {opt}])	Number	set register to value and type
 settabvar({nr}, {varname}, {val}) none	set {varname} in tab page {nr} to {val}
 settabwinvar({tabnr}, {winnr}, {varname}, {val})
 				none	set {varname} in window {winnr} in tab
@@ -2324,25 +2397,26 @@ sqrt({expr})			Float	square root of {expr}
 str2float({expr})		Float	convert String to Float
 str2nr({expr} [, {base}])	Number	convert String to Number
 strchars({expr} [, {skipcc}])	Number	character length of the String {expr}
-strcharpart({str}, {start}[, {len}])
+strcharpart({str}, {start} [, {len}])
 				String	{len} characters of {str} at {start}
 strdisplaywidth({expr} [, {col}]) Number display length of the String {expr}
-strftime({format}[, {time}])	String	time in specified format
+strftime({format} [, {time}])	String	time in specified format
 strgetchar({str}, {index})	Number	get char {index} from {str}
-stridx({haystack}, {needle}[, {start}])
+stridx({haystack}, {needle} [, {start}])
 				Number	index of {needle} in {haystack}
 string({expr})			String	String representation of {expr} value
 strlen({expr})			Number	length of the String {expr}
-strpart({str}, {start}[, {len}])
+strpart({str}, {start} [, {len}])
 				String	{len} characters of {str} at {start}
 strridx({haystack}, {needle} [, {start}])
 				Number	last index of {needle} in {haystack}
 strtrans({expr})		String	translate string to make it printable
 strwidth({expr})		Number	display cell length of the String {expr}
-submatch({nr}[, {list}])	String or List
+submatch({nr} [, {list}])	String or List
 					specific match in ":s" or substitute()
 substitute({expr}, {pat}, {sub}, {flags})
 				String	all {pat} in {expr} replaced with {sub}
+swapinfo({fname})		Dict	information about swap file {fname}
 synID({lnum}, {col}, {trans})	Number	syntax ID at {lnum} and {col}
 synIDattr({synID}, {what} [, {mode}])
 				String	attribute {what} of syntax ID {synID}
@@ -2353,15 +2427,44 @@ system({expr} [, {input}])	String	output of shell command/filter {expr}
 systemlist({expr} [, {input}])	List	output of shell command/filter {expr}
 tabpagebuflist([{arg}])		List	list of buffer numbers in tab page
 tabpagenr([{arg}])		Number	number of current or last tab page
-tabpagewinnr({tabarg}[, {arg}]) Number	number of current window in tab page
-taglist({expr})			List	list of tags matching {expr}
+tabpagewinnr({tabarg} [, {arg}]) Number	number of current window in tab page
+taglist({expr} [, {filename}])	List	list of tags matching {expr}
 tagfiles()			List	tags files used
 tan({expr})			Float	tangent of {expr}
 tanh({expr})			Float	hyperbolic tangent of {expr}
 tempname()			String	name for a temporary file
+term_dumpdiff({filename}, {filename} [, {options}])
+				Number  display difference between two dumps
+term_dumpload({filename} [, {options}])
+				Number	displaying a screen dump
+term_dumpwrite({buf}, {filename} [, {options}])
+				none	dump terminal window contents
+term_getaltscreen({buf})	Number	get the alternate screen flag
+term_getansicolors({buf})	List	get ANSI palette in GUI color mode
+term_getattr({attr}, {what})	Number	get the value of attribute {what}
+term_getcursor({buf})		List	get the cursor position of a terminal
+term_getjob({buf})		Job	get the job associated with a terminal
+term_getline({buf}, {row})	String	get a line of text from a terminal
+term_getscrolled({buf})		Number	get the scroll count of a terminal
+term_getsize({buf})		List	get the size of a terminal
+term_getstatus({buf})		String	get the status of a terminal
+term_gettitle({buf})		String	get the title of a terminal
+term_gettty({buf}, [{input}])	String	get the tty name of a terminal
+term_list()			List	get the list of terminal buffers
+term_scrape({buf}, {row})	List	get row of a terminal screen
+term_sendkeys({buf}, {keys})	none	send keystrokes to a terminal
+term_setansicolors({buf}, {colors})
+				none	set ANSI palette in GUI color mode
+term_setkill({buf}, {how})	none	set signal to stop job in terminal
+term_setrestore({buf}, {command}) none	set command to restore terminal
+term_setsize({buf}, {rows}, {cols})
+				none	set the size of a terminal
+term_start({cmd}, {options})	Job	open a terminal window and run a job
+term_wait({buf} [, {time}])	Number  wait for screen to be updated
 test_alloc_fail({id}, {countdown}, {repeat})
 				none	make memory allocation fail
 test_autochdir()		none	enable 'autochdir' during startup
+test_feedinput()		none	add key sequence to input buffer
 test_garbagecollect_now()	none	free memory right now for testing
 test_ignore_error({expr})	none	ignore a specific error
 test_null_channel()		Channel	null value for testing
@@ -2382,6 +2485,7 @@ tolower({expr})			String	the String {expr} switched to lowercase
 toupper({expr})			String	the String {expr} switched to uppercase
 tr({src}, {fromstr}, {tostr})	String	translate chars of {src} in {fromstr}
 					to chars in {tostr}
+trim({text} [, {mask}])		String	trim characters in {mask} from {text}
 trunc({expr})			Float	truncate Float {expr}
 type({name})			Number	type of variable {name}
 undofile({name})		String	undo file name for {name}
@@ -2397,9 +2501,11 @@ win_getid([{win} [, {tab}]])	Number	get window ID for {win} in {tab}
 win_gotoid({expr})		Number	go to window with ID {expr}
 win_id2tabwin({expr})		List	get tab and window nr from window ID
 win_id2win({expr})		Number	get window nr from window ID
+win_screenpos({nr})		List	get screen position of window {nr}
 winbufnr({nr})			Number	buffer number of window {nr}
 wincol()			Number	window column of the cursor
 winheight({nr})			Number	height of window {nr}
+winlayout([{tabnr}])		List	layout of windows in tab {tabnr}
 winline()			Number	window line of the cursor
 winnr([{expr}])			Number	number of current window
 winrestcmd()			String	returns command to restore window sizes
@@ -2467,6 +2573,21 @@ append({lnum}, {expr})					*append()*
 		0 for success.  Example: >
 			:let failed = append(line('$'), "# THE END")
 			:let failed = append(0, ["Chapter 1", "the beginning"])
+
+appendbufline({expr}, {lnum}, {text})			*appendbufline()*
+		Like |append()| but append the text in buffer {expr}.
+
+		For the use of {expr}, see |bufname()|.
+
+		{lnum} is used like with |append()|.  Note that using |line()|
+		would use the current buffer, not the one appending to.
+		Use "$" to append at the end of the buffer.
+
+		On success 0 is returned, on failure 1 is returned.
+
+		If {expr} is not a valid buffer or {lnum} is not valid, an
+		error message is given. Example: >
+			:let failed = appendbufline(13, 0, "# THE START")
 <
 							*argc()*
 argc()		The result is the number of files in the argument list of the
@@ -2502,10 +2623,16 @@ argv([{nr}])	The result is the {nr}th file in the argument list of the
 <		Without the {nr} argument a |List| with the whole |arglist| is
 		returned.
 
+assert_beeps({cmd})					*assert_beeps()*
+		Run {cmd} and add an error message to |v:errors| if it does
+		NOT produce a beep or visual bell.
+		Also see |assert_fails()| and |assert-return|.
+
 							*assert_equal()*
 assert_equal({expected}, {actual} [, {msg}])
 		When {expected} and {actual} are not equal an error message is
-		added to |v:errors|.
+		added to |v:errors| and 1 is returned.  Otherwise zero is
+		returned |assert-return|.
 		There is no automatic conversion, the String "4" is different
 		from the Number 4.  And the number 4 is different from the
 		Float 4.0.  The value of 'ignorecase' is not used here, case
@@ -2517,9 +2644,18 @@ assert_equal({expected}, {actual} [, {msg}])
 <		Will result in a string to be added to |v:errors|:
 	test.vim line 12: Expected 'foo' but got 'bar' ~
 
+							*assert_equalfile()*
+assert_equalfile({fname-one}, {fname-two})
+		When the files {fname-one} and {fname-two} do not contain
+		exactly the same text an error message is added to |v:errors|.
+		Also see |assert-return|.
+		When {fname-one} or {fname-two} does not exist the error will
+		mention that.
+		Mainly useful with |terminal-diff|.
+
 assert_exception({error} [, {msg}])			*assert_exception()*
 		When v:exception does not contain the string {error} an error
-		message is added to |v:errors|.
+		message is added to |v:errors|.  Also see |assert-return|.
 		This can be used to assert that a command throws an exception.
 		Using the error number, followed by a colon, avoids problems
 		with translations: >
@@ -2532,12 +2668,15 @@ assert_exception({error} [, {msg}])			*assert_exception()*
 
 assert_fails({cmd} [, {error}])					*assert_fails()*
 		Run {cmd} and add an error message to |v:errors| if it does
-		NOT produce an error.
+		NOT produce an error.  Also see |assert-return|.
 		When {error} is given it must match in |v:errmsg|.
+		Note that beeping is not considered an error, and some failing
+		commands only beep.  Use |assert_beeps()| for those.
 
 assert_false({actual} [, {msg}])				*assert_false()*
 		When {actual} is not false an error message is added to
-		|v:errors|, like with |assert_equal()|.
+		|v:errors|, like with |assert_equal()|. 
+		Also see |assert-return|.
 		A value is false when it is zero. When {actual} is not a
 		number the assert fails.
 		When {msg} is omitted an error in the form
@@ -2546,7 +2685,7 @@ assert_false({actual} [, {msg}])				*assert_false()*
 assert_inrange({lower}, {upper}, {actual} [, {msg}])	 *assert_inrange()*
 		This asserts number values.  When {actual}  is lower than
 		{lower} or higher than {upper} an error message is added to
-		|v:errors|.
+		|v:errors|.  Also see |assert-return|.
 		When {msg} is omitted an error in the form
 		"Expected range {lower} - {upper}, but got {actual}" is
 		produced.
@@ -2554,7 +2693,7 @@ assert_inrange({lower}, {upper}, {actual} [, {msg}])	 *assert_inrange()*
 								*assert_match()*
 assert_match({pattern}, {actual} [, {msg}])
 		When {pattern} does not match {actual} an error message is
-		added to |v:errors|.
+		added to |v:errors|.  Also see |assert-return|.
 
 		{pattern} is used as with |=~|: The matching is always done
 		like 'magic' was set and 'cpoptions' is empty, no matter what
@@ -2575,15 +2714,22 @@ assert_match({pattern}, {actual} [, {msg}])
 assert_notequal({expected}, {actual} [, {msg}])
 		The opposite of `assert_equal()`: add an error message to
 		|v:errors| when {expected} and {actual} are equal.
+		Also see |assert-return|.
 
 							*assert_notmatch()*
 assert_notmatch({pattern}, {actual} [, {msg}])
 		The opposite of `assert_match()`: add an error message to
 		|v:errors| when {pattern} matches {actual}.
+		Also see |assert-return|.
 
-assert_true({actual} [, {msg}])					*assert_true()*
+assert_report({msg})					*assert_report()*
+		Report a test failure directly, using {msg}.
+		Always returns one.
+
+assert_true({actual} [, {msg}])				*assert_true()*
 		When {actual} is not true an error message is added to
 		|v:errors|, like with |assert_equal()|.
+		Also see |assert-return|.
 		A value is TRUE when it is a non-zero number.  When {actual}
 		is not a number the assert fails.
 		When {msg} is omitted an error in the form "Expected True but
@@ -2625,8 +2771,12 @@ atan2({expr1}, {expr2})					*atan2()*
 <			2.356194
 		{only available when compiled with the |+float| feature}
 
-balloon_show({msg})					*balloon_show()*
-		Show {msg} inside the balloon.
+balloon_show({expr})					*balloon_show()*
+		Show {expr} inside the balloon.  For the GUI {expr} is used as
+		a string.  For a terminal {expr} can be a list, which contains
+		the lines of the balloon.  If {expr} is not a list it will be
+		split with |balloon_split()|.
+
 		Example: >
 			func GetBalloonContent()
 			   " initiate getting the content
@@ -2646,7 +2796,16 @@ balloon_show({msg})					*balloon_show()*
 
 		When showing a balloon is not possible nothing happens, no
 		error message.
-		{only available when compiled with the +balloon_eval feature}
+		{only available when compiled with the +balloon_eval or
+		+balloon_eval_term feature}
+
+balloon_split({msg})					*balloon_split()*
+		Split {msg} into lines to be displayed in a balloon.  The
+		splits are made for the current window size and optimize to
+		show debugger output.
+		Returns a |List| with the split lines.
+		{only available when compiled with the +balloon_eval_term
+		feature}
 
 							*browse()*
 browse({save}, {title}, {initdir}, {default})
@@ -2677,6 +2836,8 @@ bufexists({expr})					*bufexists()*
 		The result is a Number, which is |TRUE| if a buffer called
 		{expr} exists.
 		If the {expr} argument is a number, buffer numbers are used.
+		Number zero is the alternate buffer for the current window.
+
 		If the {expr} argument is a string it must match a buffer name
 		exactly.  The name can be:
 		- Relative to the current directory.
@@ -2893,6 +3054,9 @@ ch_evalraw({handle}, {string} [, {options}])		*ch_evalraw()*
 		correct contents.  Also does not add a newline for a channel
 		in NL mode, the caller must do that.  The NL in the response
 		is removed.
+		Note that Vim does not know when the text received on a raw
+		channel is complete, it may only return the first part and you
+		need to use ch_readraw() to fetch the rest.
 		See |channel-use|.
 
 		{only available when compiled with the |+channel| feature}
@@ -2958,6 +3122,11 @@ ch_logfile({fname} [, {mode}])					*ch_logfile()*
 		The file is flushed after every message, on Unix you can use
 		"tail -f" to see what is going on in real time.
 
+		This function is not available in the |sandbox|.
+		NOTE: the channel communication is stored in the file, be
+		aware that this may contain confidential and privacy sensitive
+		information, e.g. a password you type in a terminal window.
+
 
 ch_open({address} [, {options}])				*ch_open()*
 		Open a channel to {address}.  See |channel|.
@@ -2974,12 +3143,16 @@ ch_open({address} [, {options}])				*ch_open()*
 ch_read({handle} [, {options}])					*ch_read()*
 		Read from {handle} and return the received message.
 		{handle} can be a Channel or a Job that has a Channel.
+		For a NL channel this waits for a NL to arrive, except when
+		there is nothing more to read (channel was closed).
 		See |channel-more|.
 		{only available when compiled with the |+channel| feature}
 
 ch_readraw({handle} [, {options}])			*ch_readraw()*
 		Like ch_read() but for a JS and JSON channel does not decode
-		the message.  See |channel-more|.
+		the message.  For a NL channel it does not block waiting for
+		the NL to arrive, but otherwise works like ch_read().
+		See |channel-more|.
 		{only available when compiled with the |+channel| feature}
 
 ch_sendexpr({handle}, {expr} [, {options}])			*ch_sendexpr()*
@@ -3039,7 +3212,7 @@ changenr()						*changenr()*
 		redo it is the number of the redone change.  After undo it is
 		one less than the number of the undone change.
 
-char2nr({expr}[, {utf8}])					*char2nr()*
+char2nr({expr} [, {utf8}])					*char2nr()*
 		Return number value of the first char in {expr}.  Examples: >
 			char2nr(" ")		returns 32
 			char2nr("ABC")		returns 65
@@ -3233,14 +3406,19 @@ cosh({expr})						*cosh()*
 <			-1.127626
 		{only available when compiled with the |+float| feature}
 
-		
+
 count({comp}, {expr} [, {ic} [, {start}]])			*count()*
 		Return the number of times an item with value {expr} appears
-		in |List| or |Dictionary| {comp}.
+		in |String|, |List| or |Dictionary| {comp}.
+
 		If {start} is given then start with the item with this index.
 		{start} can only be used with a |List|.
+
 		When {ic} is given and it's |TRUE| then case is ignored.
 
+		When {comp} is a string then the number of not overlapping
+		occurrences of {expr} is returned. Zero is returned when
+		{expr} is an empty string.
 
 							*cscope_connection()*
 cscope_connection([{num} , {dbpath} [, {prepend}]])
@@ -3312,8 +3490,13 @@ cursor({list})
 		position within a <Tab> or after the last character.
 		Returns 0 when the position could be set, -1 otherwise.
 
+debugbreak({pid})					*debugbreak()*
+		Specifically used to interrupt a program being debugged.  It
+		will cause process {pid} to get a SIGTRAP.  Behavior for other
+		processes is undefined. See |terminal-debugger|.
+		{only available on MS-Windows}
 
-deepcopy({expr}[, {noref}])				*deepcopy()* *E698*
+deepcopy({expr} [, {noref}])				*deepcopy()* *E698*
 		Make a copy of {expr}.  For Numbers and Strings this isn't
 		different from using {expr} directly.
 		When {expr} is a |List| a full copy is created.  This means
@@ -3340,26 +3523,38 @@ delete({fname} [, {flags}])					*delete()*
 
 		When {flags} is "d": Deletes the directory by the name
 		{fname}.  This fails when directory {fname} is not empty.
-		
+
 		When {flags} is "rf": Deletes the directory by the name
 		{fname} and everything in it, recursively.  BE CAREFUL!
 		Note: on MS-Windows it is not possible to delete a directory
 		that is being used.
 
 		A symbolic link itself is deleted, not what it points to.
-		
+
 		The result is a Number, which is 0 if the delete operation was
 		successful and -1 when the deletion failed or partly failed.
 
 		Use |remove()| to delete an item from a |List|.
-		To delete a line from the buffer use |:delete|.  Use |:exe|
-		when the line number is in a variable.
+		To delete a line from the buffer use |:delete| or
+		|deletebufline()|.
+
+deletebufline({expr}, {first} [, {last}])		*deletebufline()*
+		Delete lines {first} to {last} (inclusive) from buffer {expr}.
+		If {last} is omitted then delete line {first} only.
+		On success 0 is returned, on failure 1 is returned.
+
+		For the use of {expr}, see |bufname()| above.
+
+		{first} and {last} are used like with |setline()|. Note that
+		when using |line()| this refers to the current buffer. Use "$"
+		to refer to the last line in buffer {expr}.
 
 							*did_filetype()*
 did_filetype()	Returns |TRUE| when autocommands are being executed and the
 		FileType event has been triggered at least once.  Can be used
 		to avoid triggering the FileType event again in the scripts
 		that detect the file type. |FileType|
+		Returns |FALSE| when `:setf FALLBACK` was used.
 		When editing another file, the counter is reset, thus this
 		really checks if the FileType event has been triggered for the
 		current buffer.  This allows an autocommand that starts
@@ -3390,6 +3585,7 @@ empty({expr})						*empty()*
 		Return the Number 1 if {expr} is empty, zero otherwise.
 		- A |List| or |Dictionary| is empty when it does not have any
 		  items.
+		- A String is empty when its length is zero.
 		- A Number and Float is empty when its value is zero.
 		- |v:false|, |v:none| and |v:null| are empty, |v:true| is not.
 		- A Job is empty when it failed to start.
@@ -3404,7 +3600,7 @@ escape({string}, {chars})				*escape()*
 			:echo escape('c:\program files\vim', ' \')
 <		results in: >
 			c:\\program\ files\\vim
-<		Also see |shellescape()|.
+<		Also see |shellescape()| and |fnameescape()|.
 
 							*eval()*
 eval({string})	Evaluate {string} and return the result.  Especially useful to
@@ -3442,6 +3638,7 @@ executable({expr})					*executable()*
 			1	exists
 			0	does not exist
 			-1	not implemented on this system
+		|exepath()| can be used to get the full path of an executable.
 
 execute({command} [, {silent}])					*execute()*
 		Execute an Ex command or commands and return the output as a
@@ -3752,7 +3949,7 @@ filter({expr1}, {expr2})				*filter()*
 		For each item in {expr1} evaluate {expr2} and when the result
 		is zero remove the item from the |List| or |Dictionary|.
 		{expr2} must be a |string| or |Funcref|.
-		
+
 		If {expr2} is a |string|, inside {expr2} |v:val| has the value
 		of the current item.  For a |Dictionary| |v:key| has the key
 		of the current item and for a |List| |v:key| has the index of
@@ -3794,7 +3991,7 @@ filter({expr1}, {expr2})				*filter()*
 		defined with the "abort" flag.
 
 
-finddir({name}[, {path}[, {count}]])				*finddir()*
+finddir({name} [, {path} [, {count}]])				*finddir()*
 		Find directory {name} in {path}.  Supports both downwards and
 		upwards recursive directory searches.  See |file-searching|
 		for the syntax of {path}.
@@ -3809,7 +4006,7 @@ finddir({name}[, {path}[, {count}]])				*finddir()*
 		{only available when compiled with the |+file_in_path|
 		feature}
 
-findfile({name}[, {path}[, {count}]])				*findfile()*
+findfile({name} [, {path} [, {count}]])				*findfile()*
 		Just like |finddir()|, but find a file instead of a directory.
 		Uses 'suffixesadd'.
 		Example: >
@@ -3824,7 +4021,7 @@ float2nr({expr})					*float2nr()*
 		When the value of {expr} is out of range for a |Number| the
 		result is truncated to 0x7fffffff or -0x7fffffff (or when
 		64-bit Number support is enabled, 0x7fffffffffffffff or
-		-0x7fffffffffffffff.  NaN results in -0x80000000 (or when
+		-0x7fffffffffffffff).  NaN results in -0x80000000 (or when
 		64-bit Number support is enabled, -0x8000000000000000).
 		Examples: >
 			echo float2nr(3.95)
@@ -3852,7 +4049,7 @@ floor({expr})							*floor()*
 			echo floor(4.0)
 <			4.0
 		{only available when compiled with the |+float| feature}
-		
+
 
 fmod({expr1}, {expr2})					*fmod()*
 		Return the remainder of {expr1} / {expr2}, even if the
@@ -3923,11 +4120,14 @@ foldtext()	Returns a String, to be displayed for a closed fold.  This is
 		|v:foldstart|, |v:foldend| and |v:folddashes| variables.
 		The returned string looks like this: >
 			+-- 45 lines: abcdef
-<		The number of dashes depends on the foldlevel.  The "45" is
-		the number of lines in the fold.  "abcdef" is the text in the
-		first non-blank line of the fold.  Leading white space, "//"
-		or "/*" and the text from the 'foldmarker' and 'commentstring'
-		options is removed.
+<		The number of leading dashes depends on the foldlevel.  The
+		"45" is the number of lines in the fold.  "abcdef" is the text
+		in the first non-blank line of the fold.  Leading white space,
+		"//" or "/*" and the text from the 'foldmarker' and
+		'commentstring' options is removed.
+		When used to draw the actual foldtext, the rest of the line
+		will be filled with the fold char from the 'fillchars'
+		setting.
 		{not available when compiled without the |+folding| feature}
 
 foldtextresult({lnum})					*foldtextresult()*
@@ -3978,7 +4178,7 @@ function({name} [, {arglist}] [, {dict}])
 		When {arglist} or {dict} is present this creates a partial.
 		That means the argument list and/or the dictionary is stored in
 		the Funcref and will be used when the Funcref is called.
-		
+
 		The arguments are passed to the function in front of other
 		arguments.  Example: >
 			func Callback(arg1, arg2, name)
@@ -4030,7 +4230,7 @@ function({name} [, {arglist}] [, {dict}])
 garbagecollect([{atexit}])				*garbagecollect()*
 		Cleanup unused |Lists|, |Dictionaries|, |Channels| and |Jobs|
 		that have circular references.
-		
+
 		There is hardly ever a need to invoke this function, as it is
 		automatically done when Vim runs out of memory or is waiting
 		for the user to press a key after 'updatetime'.  Items without
@@ -4077,6 +4277,7 @@ getbufinfo([{dict}])
 		be specified in {dict}:
 			buflisted	include only listed buffers.
 			bufloaded	include only loaded buffers.
+			bufmodified	include only modified buffers.
 
 		Otherwise, {expr} specifies a particular buffer to return
 		information for.  For the use of {expr}, see |bufname()|
@@ -4115,7 +4316,7 @@ getbufinfo([{dict}])
 			endfor
 <
 		To get buffer-local options use: >
-			getbufvar({bufnr}, '&')
+			getbufvar({bufnr}, '&option_name')
 
 <
 							*getbufline()*
@@ -4163,6 +4364,22 @@ getbufvar({expr}, {varname} [, {def}])				*getbufvar()*
 			:let bufmodified = getbufvar(1, "&mod")
 			:echo "todo myvar = " . getbufvar("todo", "myvar")
 <
+getchangelist({expr})					*getchangelist()*
+		Returns the |changelist| for the buffer {expr}. For the use
+		of {expr}, see |bufname()| above. If buffer {expr} doesn't
+		exist, an empty list is returned.
+
+		The returned list contains two entries: a list with the change
+		locations and the current position in the list.  Each
+		entry in the change list is a dictionary with the following
+		entries:
+			col		column number
+			coladd		column offset for 'virtualedit'
+			lnum		line number
+		If buffer {expr} is the current buffer, then the current
+		position refers to the position in the list. For other
+		buffers, it is set to the length of the list.
+
 getchar([expr])						*getchar()*
 		Get a single character from the user or input stream.
 		If [expr] is omitted, wait until a character is available.
@@ -4172,14 +4389,14 @@ getchar([expr])						*getchar()*
 			not consumed.  Return zero if no character available.
 
 		Without [expr] and when [expr] is 0 a whole character or
-		special key is returned.  If it is an 8-bit character, the
+		special key is returned.  If it is a single character, the
 		result is a number.  Use nr2char() to convert it to a String.
 		Otherwise a String is returned with the encoded character.
-		For a special key it's a sequence of bytes starting with 0x80
-		(decimal: 128).  This is the same value as the string
-		"\<Key>", e.g., "\<Left>".  The returned value is also a
-		String when a modifier (shift, control, alt) was used that is
-		not included in the character.
+		For a special key it's a String with a sequence of bytes
+		starting with 0x80 (decimal: 128).  This is the same value as
+		the String "\<Key>", e.g., "\<Left>".  The returned value is
+		also a String when a modifier (shift, control, alt) was used
+		that is not included in the character.
 
 		When [expr] is 0 and Esc is typed, there will be a short delay
 		while Vim waits to see if this is the start of an escape
@@ -4314,6 +4531,7 @@ getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
 		specifies what for.  The following completion types are
 		supported:
 
+		arglist		file names in argument list
 		augroup		autocmd groups
 		buffer		buffer names
 		behave		:behave suboptions
@@ -4333,6 +4551,7 @@ getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
 		highlight	highlight groups
 		history		:history suboptions
 		locale		locale names (as output of locale -a)
+		mapclear        buffer argument
 		mapping		mapping name
 		menu		menus
 		messages	|:messages| suboptions
@@ -4363,12 +4582,14 @@ getcurpos()	Get the position of the cursor.  This is like getpos('.'), but
 		includes an extra item in the list:
 		    [bufnum, lnum, col, off, curswant] ~
 		The "curswant" number is the preferred column when moving the
-		cursor vertically.
+		cursor vertically.  Also see |getpos()|.
+
 		This can be used to save and restore the cursor position: >
 			let save_cursor = getcurpos()
 			MoveTheCursorAround
 			call setpos('.', save_cursor)
-<
+<		Note that this only works within the window.  See
+		|winrestview()| for restoring more state.
 							*getcwd()*
 getcwd([{winnr} [, {tabnr}]])
 		The result is a String, which is the name of the current
@@ -4376,10 +4597,13 @@ getcwd([{winnr} [, {tabnr}]])
 		Without arguments, for the current window.
 
 		With {winnr} return the local current directory of this window
-		in the current tab page.
+		in the current tab page.  {winnr} can be the window number or
+		the |window-ID|.
+		If {winnr} is -1 return the name of the global working
+		directory.  See also |haslocaldir()|.
+
 		With {winnr} and {tabnr} return the local current directory of
 		the window in the specified tab page.
-		{winnr} can be the window number or the |window-ID|.
 		Return an empty string if the arguments are invalid.
 
 getfsize({fname})					*getfsize()*
@@ -4449,13 +4673,32 @@ getftype({fname})					*getftype()*
 		"file" are returned.  On MS-Windows a symbolic link to a
 		directory returns "dir" instead of "link".
 
+getjumplist([{winnr} [, {tabnr}]])			*getjumplist()*
+		Returns the |jumplist| for the specified window.
+
+		Without arguments use the current window.
+		With {winnr} only use this window in the current tab page.
+		{winnr} can also be a |window-ID|.
+		With {winnr} and {tabnr} use the window in the specified tab
+		page.
+
+		The returned list contains two entries: a list with the jump
+		locations and the last used jump position number in the list.
+		Each entry in the jump location list is a dictionary with
+		the following entries:
+			bufnr		buffer number
+			col		column number
+			coladd		column offset for 'virtualedit'
+			filename	filename if available
+			lnum		line number
+
 							*getline()*
 getline({lnum} [, {end}])
 		Without {end} the result is a String, which is line {lnum}
 		from the current buffer.  Example: >
 			getline(1)
 <		When {lnum} is a String that doesn't start with a
-		digit, line() is called to translate the String into a Number.
+		digit, |line()| is called to translate the String into a Number.
 		To get the line under the cursor: >
 			getline(".")
 <		When {lnum} is smaller than 1 or bigger than the number of
@@ -4474,7 +4717,7 @@ getline({lnum} [, {end}])
 
 <		To get lines from another buffer see |getbufline()|
 
-getloclist({nr}[, {what}])				*getloclist()*
+getloclist({nr} [, {what}])				*getloclist()*
 		Returns a list with all the entries in the location list for
 		window {nr}.  {nr} can be the window number or the |window-ID|.
 		When {nr} is zero the current window is used.
@@ -4486,6 +4729,10 @@ getloclist({nr}[, {what}])				*getloclist()*
 		If the optional {what} dictionary argument is supplied, then
 		returns the items listed in {what} as a dictionary. Refer to
 		|getqflist()| for the supported items in {what}.
+		If {what} contains 'filewinid', then returns the id of the
+		window used to display files from the location list. This
+		field is applicable only when called from a location list
+		window.
 
 getmatches()						*getmatches()*
 		Returns a |List| with all matches previously defined by
@@ -4542,6 +4789,7 @@ getqflist([{what}])					*getqflist()*
 		list item is a dictionary with these entries:
 			bufnr	number of buffer that has the file name, use
 				bufname() to get the name
+			module	module name
 			lnum	line number in the buffer (first line is 1)
 			col	column number (first column is 1)
 			vcol	|TRUE|: "col" is visual column
@@ -4566,26 +4814,63 @@ getqflist([{what}])					*getqflist()*
 		If the optional {what} dictionary argument is supplied, then
 		returns only the items listed in {what} as a dictionary. The
 		following string items are supported in {what}:
+			changedtick	get the total number of changes made
+					to the list |quickfix-changedtick|
+			context	get the |quickfix-context|
+			efm	errorformat to use when parsing "lines". If
+				not present, then the 'errorformat' option
+				value is used.
+			id	get information for the quickfix list with
+				|quickfix-ID|; zero means the id for the
+				current list or the list specified by "nr"
+			idx	index of the current entry in the list
+			items	quickfix list entries
+			lines	parse a list of lines using 'efm' and return
+				the resulting entries.  Only a |List| type is
+				accepted.  The current quickfix list is not
+				modified. See |quickfix-parse|.
 			nr	get information for this quickfix list; zero
-				means the current quickfix list
-			title	get the list title
-			winid	get the |window-ID| (if opened)
+				means the current quickfix list and "$" means
+				the last quickfix list
+			size	number of entries in the quickfix list
+			title	get the list title |quickfix-title|
+			winid	get the quickfix |window-ID|
 			all	all of the above quickfix properties
-		Non-string items in {what} are ignored.
+		Non-string items in {what} are ignored. To get the value of a
+		particular item, set it to zero.
 		If "nr" is not present then the current quickfix list is used.
-		In case of error processing {what}, an empty dictionary is
-		returned.
+		If both "nr" and a non-zero "id" are specified, then the list
+		specified by "id" is used.
+		To get the number of lists in the quickfix stack, set "nr" to
+		"$" in {what}. The "nr" value in the returned dictionary
+		contains the quickfix stack size.
+		When "lines" is specified, all the other items except "efm"
+		are ignored.  The returned dictionary contains the entry
+		"items" with the list of entries.
 
 		The returned dictionary contains the following entries:
-			nr	quickfix list number
-			title	quickfix list title text
-			winid	quickfix |window-ID| (if opened)
+			changedtick	total number of changes made to the
+					list |quickfix-changedtick|
+			context	quickfix list context. See |quickfix-context|
+				If not present, set to "".
+			id	quickfix list ID |quickfix-ID|. If not
+				present, set to 0.
+			idx	index of the current entry in the list. If not
+				present, set to 0.
+			items	quickfix list entries. If not present, set to
+				an empty list.
+			nr	quickfix list number. If not present, set to 0
+			size	number of entries in the quickfix list. If not
+				present, set to 0.
+			title	quickfix list title text. If not present, set
+				to "".
+			winid	quickfix |window-ID|. If not present, set to 0
 
-		Examples: >
+		Examples (See also |getqflist-examples|): >
 			:echo getqflist({'all': 1})
 			:echo getqflist({'nr': 2, 'title': 1})
+			:echo getqflist({'lines' : ["F1:10:L10"]})
 <
-
 getreg([{regname} [, 1 [, {list}]]])			*getreg()*
 		The result is a String, which is the contents of register
 		{regname}.  Example: >
@@ -4664,15 +4949,8 @@ gettabwinvar({tabnr}, {winnr}, {varname} [, {def}])		*gettabwinvar()*
 			:let list_is_on = gettabwinvar(1, 2, '&list')
 			:echo "myvar = " . gettabwinvar(3, 1, 'myvar')
 <
-							*getwinposx()*
-getwinposx()	The result is a Number, which is the X coordinate in pixels of
-		the left hand side of the GUI Vim window.  The result will be
-		-1 if the information is not available.
-
-							*getwinposy()*
-getwinposy()	The result is a Number, which is the Y coordinate in pixels of
-		the top of the GUI Vim window.  The result will be -1 if the
-		information is not available.
+		To obtain all window-local variables use: >
+			gettabwinvar({tabnr}, {winnr}, '&')
 
 getwininfo([{winid}])					*getwininfo()*
 		Returns information about windows as a List with Dictionaries.
@@ -4686,20 +4964,58 @@ getwininfo([{winid}])					*getwininfo()*
 
 		Each List item is a Dictionary with the following entries:
 			bufnr		number of buffer in the window
-			height		window height
+			height		window height (excluding winbar)
 			loclist		1 if showing a location list
 					{only with the +quickfix feature}
 			quickfix	1 if quickfix or location list window
 					{only with the +quickfix feature}
+			terminal	1 if a terminal window
+					{only with the +terminal feature}
 			tabnr		tab page number
 			variables	a reference to the dictionary with
 					window-local variables
 			width		window width
+			winbar		1 if the window has a toolbar, 0
+					otherwise
+			wincol		leftmost screen column of the window,
+					col from |win_screenpos()|
 			winid		|window-ID|
 			winnr		window number
+			winrow		topmost screen column of the window,
+					row from |win_screenpos()|
 
-		To obtain all window-local variables use: >
-			gettabwinvar({tabnr}, {winnr}, '&')
+getwinpos([{timeout}])					*getwinpos()*
+		The result is a list with two numbers, the result of
+		getwinposx() and getwinposy() combined: 
+			[x-pos, y-pos]
+		{timeout} can be used to specify how long to wait in msec for
+		a response from the terminal.  When omitted 100 msec is used.
+		Use a longer time for a remote terminal.
+		When using a value less than 10 and no response is received
+		within that time, a previously reported position is returned,
+		if available.  This can be used to poll for the position and
+		do some work in the mean time: >
+			while 1
+			  let res = getwinpos(1)
+			  if res[0] >= 0
+			    break
+			  endif
+			  " Do some work here
+			endwhile
+<
+							*getwinposx()*
+getwinposx()	The result is a Number, which is the X coordinate in pixels of
+		the left hand side of the GUI Vim window. Also works for an
+		xterm (uses a timeout of 100 msec).
+		The result will be -1 if the information is not available.
+		The value can be used with `:winpos`.
+
+							*getwinposy()*
+getwinposy()	The result is a Number, which is the Y coordinate in pixels of
+		the top of the GUI Vim window.  Also works for an xterm (uses
+		a timeout of 100 msec).
+		The result will be -1 if the information is not available.
+		The value can be used with `:winpos`.
 
 getwinvar({winnr}, {varname} [, {def}])				*getwinvar()*
 		Like |gettabwinvar()| for the current tabpage.
@@ -5141,13 +5457,19 @@ job_getchannel({job})					 *job_getchannel()*
 <
 		{only available when compiled with the |+job| feature}
 
-job_info({job})						*job_info()*
+job_info([{job}])					*job_info()*
 		Returns a Dictionary with information about {job}:
 		   "status"	what |job_status()| returns
 		   "channel"	what |job_getchannel()| returns
+		   "cmd"	List of command arguments used to start the job
+		   "process"	process ID
+		   "tty_in"	terminal input name, empty when none
+		   "tty_out"	terminal output name, empty when none
 		   "exitval"	only valid when "status" is "dead"
 		   "exit_cb"	function to be called on exit
 		   "stoponexit"	|job-stoponexit|
+
+		Without any arguments, returns a List with all Job objects.
 
 job_setoptions({job}, {options})			*job_setoptions()*
 		Change options for {job}.  Supported are:
@@ -5157,6 +5479,7 @@ job_setoptions({job}, {options})			*job_setoptions()*
 job_start({command} [, {options}])			*job_start()*
 		Start a job and return a Job object.  Unlike |system()| and
 		|:!cmd| this does not wait for the job to finish.
+		To start a job in a terminal window see |term_start()|.
 
 		{command} can be a String.  This works best on MS-Windows.  On
 		Unix it is split up in white-separated parts to be passed to
@@ -5189,6 +5512,20 @@ job_start({command} [, {options}])			*job_start()*
 		The returned Job object can be used to get the status with
 		|job_status()| and stop the job with |job_stop()|.
 
+		Note that the job object will be deleted if there are no
+		references to it.  This closes the stdin and stderr, which may
+		cause the job to fail with an error.  To avoid this keep a
+		reference to the job.  Thus instead of: >
+	call job_start('my-command')
+<		use: >
+	let myjob = job_start('my-command')
+<		and unlet "myjob" once the job is not needed or is past the
+		point where it would fail (e.g. when it prints a message on
+		startup).  Keep in mind that variables local to a function
+		will cease to exist if the function returns.  Use a
+		script-local variable if needed: >
+	let s:myjob = job_start('my-command')
+<
 		{options} must be a Dictionary.  It can contain many optional
 		items, see |job-options|.
 
@@ -5199,7 +5536,7 @@ job_status({job})					*job_status()* *E916*
 			"run"	job is running
 			"fail"	job failed to start
 			"dead"	job died or was stopped after running
-		
+
 		On Unix a non-existing command results in "dead" instead of
 		"fail", because a fork happens before the failure can be
 		detected.
@@ -5244,9 +5581,14 @@ job_stop({job} [, {how}])					*job_stop()*
 		0 if "how" is not supported on the system.
 		Note that even when the operation was executed, whether the
 		job was actually stopped needs to be checked with
-		job_status().
-		The status of the job isn't checked, the operation will even
-		be done when Vim thinks the job isn't running.
+		|job_status()|.
+
+		If the status of the job is "dead", the signal will not be
+		sent.  This is to avoid to stop the wrong job (esp. on Unix,
+		where process numbers are recycled).
+
+		When using "kill" Vim will assume the job will die and close
+		the channel.
 
 		{only available when compiled with the |+job| feature}
 
@@ -5288,13 +5630,29 @@ json_decode({string})					*json_decode()*
 		in Vim values.  See |json_encode()| for the relation between
 		JSON and Vim values.
 		The decoding is permissive:
-		- A trailing comma in an array and object is ignored.
+		- A trailing comma in an array and object is ignored, e.g.
+		  "[1, 2, ]" is the same as "[1, 2]".
 		- More floating point numbers are recognized, e.g. "1." for
-		  "1.0".
-		However, a duplicate key in an object is not allowed. *E938*
-		The result must be a valid Vim type:
-		- An empty object member name is not allowed.
-		- Duplicate object member names are not allowed.
+		  "1.0", or "001.2" for "1.2". Special floating point values
+		  "Infinity" and "NaN" (capitalization ignored) are accepted.
+		- Leading zeroes in integer numbers are ignored, e.g. "012"
+		  for "12" or "-012" for "-12".
+		- Capitalization is ignored in literal names null, true or
+		  false, e.g. "NULL" for "null", "True" for "true".
+		- Control characters U+0000 through U+001F which are not
+		  escaped in strings are accepted, e.g. "	" (tab
+		  character in string) for "\t".
+		- Backslash in an invalid 2-character sequence escape is
+		  ignored, e.g. "\a" is decoded as "a".
+		- A correct surrogate pair in JSON strings should normally be
+		  a 12 character sequence such as "\uD834\uDD1E", but
+		  json_decode() silently accepts truncated surrogate pairs
+		  such as "\uD834" or "\uD834\u"
+								*E938*
+		A duplicate key in an object, valid in rfc7159, is not
+		accepted by json_decode() as the result must be a valid Vim
+		type, e.g. this fails: {"a":"b", "a":"c"}
+
 
 json_encode({expr})					*json_encode()*
 		Encode {expr} as JSON and return this as a string.
@@ -5397,8 +5755,10 @@ line({expr})	The result is a Number, which is the line number of the file
 		    $	    the last line in the current buffer
 		    'x	    position of mark x (if the mark is not set, 0 is
 			    returned)
-		    w0	    first line visible in current window
-		    w$	    last line visible in current window
+		    w0	    first line visible in current window (one if the
+			    display isn't updated, e.g. in silent Ex mode)
+		    w$	    last line visible in current window (this is one
+			    less than "w0" if no lines are visible)
 		    v	    In Visual mode: the start of the Visual area (the
 			    cursor is the end).  When not in Visual mode
 			    returns the cursor position.  Differs from |'<| in
@@ -5414,7 +5774,10 @@ line({expr})	The result is a Number, which is the line number of the file
 <							*last-position-jump*
 		This autocommand jumps to the last known position in a file
 		just after opening it, if the '" mark is set: >
-	:au BufReadPost * if line("'\"") > 1 && line("'\"") <= line("$") | exe "normal! g`\"" | endif
+     :au BufReadPost *
+	 \ if line("'\"") > 1 && line("'\"") <= line("$") && &ft !~# 'commit'
+	 \ |   exe "normal! g`\""
+	 \ | endif
 
 line2byte({lnum})					*line2byte()*
 		Return the byte count from the start of the buffer for line
@@ -5464,16 +5827,16 @@ log10({expr})						*log10()*
 			:echo log10(0.01)
 <			-2.0
 		{only available when compiled with the |+float| feature}
-		
-luaeval({expr}[, {expr}])					*luaeval()*
-		Evaluate Lua expression {expr} and return its result converted 
-		to Vim data structures. Second {expr} may hold additional 
+
+luaeval({expr} [, {expr}])					*luaeval()*
+		Evaluate Lua expression {expr} and return its result converted
+		to Vim data structures. Second {expr} may hold additional
 		argument accessible as _A inside first {expr}.
 		Strings are returned as they are.
 		Boolean objects are converted to numbers.
-		Numbers are converted to |Float| values if vim was compiled 
+		Numbers are converted to |Float| values if vim was compiled
 		with |+float| and to numbers otherwise.
-		Dictionaries and lists obtained by vim.eval() are returned 
+		Dictionaries and lists obtained by vim.eval() are returned
 		as-is.
 		Other objects are returned as zero without any errors.
 		See |lua-luaeval| for more details.
@@ -5483,7 +5846,7 @@ map({expr1}, {expr2})					*map()*
 		{expr1} must be a |List| or a |Dictionary|.
 		Replace each item in {expr1} with the result of evaluating
 		{expr2}.  {expr2} must be a |string| or |Funcref|.
-		
+
 		If {expr2} is a |string|, inside {expr2} |v:val| has the value
 		of the current item.  For a |Dictionary| |v:key| has the key
 		of the current item and for a |List| |v:key| has the index of
@@ -5522,14 +5885,15 @@ map({expr1}, {expr2})					*map()*
 		defined with the "abort" flag.
 
 
-maparg({name}[, {mode} [, {abbr} [, {dict}]]])			*maparg()*
+maparg({name} [, {mode} [, {abbr} [, {dict}]]])			*maparg()*
 		When {dict} is omitted or zero: Return the rhs of mapping
 		{name} in mode {mode}.  The returned String has special
 		characters translated like in the output of the ":map" command
 		listing.
-		
+
 		When there is no mapping for {name}, an empty String is
-		returned.
+		returned.  When the mapping for {name} is empty, then "<Nop>"
+		is returned.
 
 		The {name} can have special key names, like in the ":map"
 		command.
@@ -5543,6 +5907,7 @@ maparg({name}[, {mode} [, {abbr} [, {dict}]]])			*maparg()*
 			"s"	Select
 			"x"	Visual
 			"l"	langmap |language-mapping|
+			"t"	Terminal-Job
 			""	Normal, Visual and Operator-pending
 		When {mode} is omitted, the modes for "" are used.
 
@@ -5576,7 +5941,7 @@ maparg({name}[, {mode} [, {abbr} [, {dict}]]])			*maparg()*
 			exe 'nnoremap <Tab> ==' . maparg('<Tab>', 'n')
 
 
-mapcheck({name}[, {mode} [, {abbr}]])			*mapcheck()*
+mapcheck({name} [, {mode} [, {abbr}]])			*mapcheck()*
 		Check if there is a mapping that matches with {name} in mode
 		{mode}.  See |maparg()| for {mode} and special names in
 		{name}.
@@ -5595,9 +5960,10 @@ mapcheck({name}[, {mode} [, {abbr}]])			*mapcheck()*
 		mapping that matches with {name}, while maparg() only finds a
 		mapping for {name} exactly.
 		When there is no mapping that starts with {name}, an empty
-		String is returned.  If there is one, the rhs of that mapping
+		String is returned.  If there is one, the RHS of that mapping
 		is returned.  If there are several mappings that start with
-		{name}, the rhs of one of them is returned.
+		{name}, the RHS of one of them is returned.  This will be
+		"<Nop>" if the RHS is empty.
 		The mappings local to the current buffer are checked first,
 		then the global mappings.
 		This function can be used to check if a mapping can be added
@@ -5608,7 +5974,7 @@ mapcheck({name}[, {mode} [, {abbr}]])			*mapcheck()*
 <		This avoids adding the "_vv" mapping when there already is a
 		mapping for "_v" or for "_vvv".
 
-match({expr}, {pat}[, {start}[, {count}]])			*match()*
+match({expr}, {pat} [, {start} [, {count}]])			*match()*
 		When {expr} is a |List| then this returns the index of the
 		first item where {pat} matches.  Each item is used as a
 		String, |Lists| and |Dictionaries| are used as echoed.
@@ -5663,8 +6029,8 @@ match({expr}, {pat}[, {start}[, {count}]])			*match()*
 		the pattern.  'smartcase' is NOT used.  The matching is always
 		done like 'magic' is set and 'cpoptions' is empty.
 
-					*matchadd()* *E798* *E799* *E801*
-matchadd({group}, {pattern}[, {priority}[, {id}[, {dict}]]])
+				*matchadd()* *E798* *E799* *E801* *E957*
+matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
 		Defines a pattern to be highlighted in the current window (a
 		"match").  It will be highlighted with {group}.  Returns an
 		identification number (ID), which can be used to delete the
@@ -5702,6 +6068,8 @@ matchadd({group}, {pattern}[, {priority}[, {id}[, {dict}]]])
 			conceal	    Special character to show instead of the
 				    match (only for |hl-Conceal| highlighted
 				    matches, see |:syn-cchar|)
+			window	    Instead of the current window use the
+				    window with this number or window ID.
 
 		The number of matches is not limited, as it is the case with
 		the |:match| commands.
@@ -5717,7 +6085,7 @@ matchadd({group}, {pattern}[, {priority}[, {id}[, {dict}]]])
 		one operation by |clearmatches()|.
 
 							*matchaddpos()*
-matchaddpos({group}, {pos}[, {priority}[, {id}[, {dict}]]])
+matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])
 		Same as |matchadd()|, but requires a list of positions {pos}
 		instead of a pattern. This command is faster than |matchadd()|
 		because it does not require to handle regular expressions and
@@ -5737,7 +6105,7 @@ matchaddpos({group}, {pos}[, {priority}[, {id}[, {dict}]]])
 		  be highlighted.
 		- A list with three numbers, e.g., [23, 11, 3]. As above, but
 		  the third number gives the length of the highlight in bytes.
-		
+
 		The maximum number of positions is 8.
 
 		Example: >
@@ -5749,8 +6117,6 @@ matchaddpos({group}, {pos}[, {priority}[, {id}[, {dict}]]])
 <		Matches added by |matchaddpos()| are returned by
 		|getmatches()| with an entry "pos1", "pos2", etc., with the
 		value a list like the {pos} item.
-		These matches cannot be set via |setmatches()|, however they
-		can still be deleted by |clearmatches()|.
 
 matcharg({nr})							*matcharg()*
 		Selects the {nr} match item, as set with a |:match|,
@@ -5770,7 +6136,7 @@ matchdelete({id})			       *matchdelete()* *E802* *E803*
 		otherwise -1.  See example for |matchadd()|.  All matches can
 		be deleted in one operation by |clearmatches()|.
 
-matchend({expr}, {pat}[, {start}[, {count}]])			*matchend()*
+matchend({expr}, {pat} [, {start} [, {count}]])			*matchend()*
 		Same as |match()|, but return the index of first character
 		after the match.  Example: >
 			:echo matchend("testing", "ing")
@@ -5789,7 +6155,7 @@ matchend({expr}, {pat}[, {start}[, {count}]])			*matchend()*
 <		result is "-1".
 		When {expr} is a |List| the result is equal to |match()|.
 
-matchlist({expr}, {pat}[, {start}[, {count}]])			*matchlist()*
+matchlist({expr}, {pat} [, {start} [, {count}]])		*matchlist()*
 		Same as |match()|, but return a |List|.  The first item in the
 		list is the matched string, same as what matchstr() would
 		return.  Following items are submatches, like "\1", "\2", etc.
@@ -5799,7 +6165,7 @@ matchlist({expr}, {pat}[, {start}[, {count}]])			*matchlist()*
 <		Results in: ['acd', 'a', '', 'c', 'd', '', '', '', '', '']
 		When there is no match an empty list is returned.
 
-matchstr({expr}, {pat}[, {start}[, {count}]])			*matchstr()*
+matchstr({expr}, {pat} [, {start} [, {count}]])			*matchstr()*
 		Same as |match()|, but return the matched string.  Example: >
 			:echo matchstr("testing", "ing")
 <		results in "ing".
@@ -5812,7 +6178,7 @@ matchstr({expr}, {pat}[, {start}[, {count}]])			*matchstr()*
 		When {expr} is a |List| then the matching item is returned.
 		The type isn't changed, it's not necessarily a String.
 
-matchstrpos({expr}, {pat}[, {start}[, {count}]])		*matchstrpos()*
+matchstrpos({expr}, {pat} [, {start} [, {count}]])		*matchstrpos()*
 		Same as |matchstr()|, but return the matched string, the start
 		position and the end position of the match.  Example: >
 			:echo matchstrpos("testing", "ing")
@@ -5836,7 +6202,7 @@ max({expr})	Return the maximum value of all items in {expr}.
 		it returns the maximum of all values in the dictionary.
 		If {expr} is neither a list nor a dictionary, or one of the
 		items in {expr} cannot be used as a Number this results in
-                an error.  An empty |List| or |Dictionary| results in zero.
+		an error.  An empty |List| or |Dictionary| results in zero.
 
 							*min()*
 min({expr})	Return the minimum value of all items in {expr}.
@@ -5844,7 +6210,7 @@ min({expr})	Return the minimum value of all items in {expr}.
 		it returns the minimum of all values in the dictionary.
 		If {expr} is neither a list nor a dictionary, or one of the
 		items in {expr} cannot be used as a Number this results in
-                an error.  An empty |List| or |Dictionary| results in zero.
+		an error.  An empty |List| or |Dictionary| results in zero.
 
 							*mkdir()* *E739*
 mkdir({name} [, {path} [, {prot}]])
@@ -5860,6 +6226,8 @@ mkdir({name} [, {path} [, {prot}]])
 		Example: >
 			:call mkdir($HOME . "/tmp/foo/bar", "p", 0700)
 <		This function is not available in the |sandbox|.
+		There is no error if the directory already exists and the "p"
+		flag is passed (since patch 8.0.1708).
 		Not available on all systems.  To check use: >
 			:if exists("*mkdir")
 <
@@ -5869,31 +6237,38 @@ mode([expr])	Return a string that indicates the current mode.
 		a non-empty String (|non-zero-arg|), then the full mode is
 		returned, otherwise only the first letter is returned.
 
-			n	Normal
-			no	Operator-pending
-			v	Visual by character
-			V	Visual by line
-			CTRL-V	Visual blockwise
-			s	Select by character
-			S	Select by line
-			CTRL-S	Select blockwise
-			i	Insert
-			ic	Insert mode completion |compl-generic|
-			ix	Insert mode |i_CTRL-X| completion
-			R	Replace |R|
-			Rc	Replace mode completion |compl-generic|
-			Rv	Virtual Replace |gR|
-			Rx	Replace mode |i_CTRL-X| completion
-			c	Command-line editing
-			cv	Vim Ex mode |gQ|
-			ce	Normal Ex mode |Q|
-			r	Hit-enter prompt
-			rm	The -- more -- prompt
-			r?	A |:confirm| query of some sort
-			!	Shell or external command is executing
+		   n	    Normal, Terminal-Normal
+		   no	    Operator-pending
+		   niI	    Normal using |i_CTRL-O| in |Insert-mode|
+		   niR	    Normal using |i_CTRL-O| in |Replace-mode|
+		   niV	    Normal using |i_CTRL-O| in |Virtual-Replace-mode|
+		   v	    Visual by character
+		   V	    Visual by line
+		   CTRL-V   Visual blockwise
+		   s	    Select by character
+		   S	    Select by line
+		   CTRL-S   Select blockwise
+		   i	    Insert
+		   ic	    Insert mode completion |compl-generic|
+		   ix	    Insert mode |i_CTRL-X| completion
+		   R	    Replace |R|
+		   Rc	    Replace mode completion |compl-generic|
+		   Rv	    Virtual Replace |gR|
+		   Rx	    Replace mode |i_CTRL-X| completion
+		   c	    Command-line editing
+		   cv	    Vim Ex mode |gQ|
+		   ce	    Normal Ex mode |Q|
+		   r	    Hit-enter prompt
+		   rm	    The -- more -- prompt
+		   r?	    A |:confirm| query of some sort
+		   !	    Shell or external command is executing
+		   t	    Terminal-Job mode: keys go to the job
 		This is useful in the 'statusline' option or when used
 		with |remote_expr()| In most other places it always returns
 		"c" or "n".
+		Note that in the future more modes and more specific modes may
+		be added. It's better not to compare the whole string but only
+		the leading character(s).
 		Also see |visualmode()|.
 
 mzeval({expr})							*mzeval()*
@@ -5921,7 +6296,7 @@ nextnonblank({lnum})					*nextnonblank()*
 		below it, zero is returned.
 		See also |prevnonblank()|.
 
-nr2char({expr}[, {utf8}])				*nr2char()*
+nr2char({expr} [, {utf8}])				*nr2char()*
 		Return a string with a single character, which has the number
 		value {expr}.  Examples: >
 			nr2char(64)		returns "@"
@@ -5973,7 +6348,7 @@ pow({x}, {y})						*pow()*
 			:echo pow(32, 0.20)
 <			2.0
 		{only available when compiled with the |+float| feature}
-		
+
 prevnonblank({lnum})					*prevnonblank()*
 		Return the line number of the first line at or above {lnum}
 		that is not blank.  Example: >
@@ -6133,14 +6508,14 @@ printf({fmt}, {expr1} ...)				*printf()*
 			feature works just like 's'.
 
 							*printf-f* *E807*
-		f F	The Float argument is converted into a string of the 
+		f F	The Float argument is converted into a string of the
 			form 123.456.  The precision specifies the number of
 			digits after the decimal point.  When the precision is
 			zero the decimal point is omitted.  When the precision
 			is not specified 6 is used.  A really big number
 			(out of range or dividing by zero) results in "inf"
-                        or "-inf" with %f (INF or -INF with %F).
-                        "0.0 / 0.0" results in "nan" with %f (NAN with %F).
+			or "-inf" with %f (INF or -INF with %F).
+			"0.0 / 0.0" results in "nan" with %f (NAN with %F).
 			Example: >
 				echo printf("%.2f", 12.115)
 <				12.12
@@ -6178,6 +6553,52 @@ printf({fmt}, {expr1} ...)				*printf()*
 		arguments an error is given.  Up to 18 arguments can be used.
 
 
+prompt_setcallback({buf}, {expr})			*prompt_setcallback()*
+		Set prompt callback for buffer {buf} to {expr}.  When {expr}
+		is an empty string the callback is removed.  This has only
+		effect if {buf} has 'buftype' set to "prompt".
+
+		The callback is invoked when pressing Enter.  The current
+		buffer will always be the prompt buffer.  A new line for a
+		prompt is added before invoking the callback, thus the prompt
+		for which the callback was invoked will be in the last but one
+		line.
+		If the callback wants to add text to the buffer, it must
+		insert it above the last line, since that is where the current
+		prompt is.  This can also be done asynchronously.
+		The callback is invoked with one argument, which is the text
+		that was entered at the prompt.  This can be an empty string
+		if the user only typed Enter.
+		Example: >
+		   call prompt_setcallback(bufnr(''), function('s:TextEntered'))
+		   func s:TextEntered(text)
+		     if a:text == 'exit' || a:text == 'quit'
+		       stopinsert
+		       close
+		     else
+		       call append(line('$') - 1, 'Entered: "' . a:text . '"')
+		       " Reset 'modified' to allow the buffer to be closed.
+		       set nomodified
+		     endif
+		   endfunc
+
+prompt_setinterrupt({buf}, {expr})			*prompt_setinterrupt()*
+		Set a callback for buffer {buf} to {expr}.  When {expr} is an
+		empty string the callback is removed.  This has only effect if
+		{buf} has 'buftype' set to "prompt".
+
+		This callback will be invoked when pressing CTRL-C in Insert
+		mode.  Without setting a callback Vim will exit Insert mode,
+		as in any buffer.
+
+prompt_setprompt({buf}, {text})				*prompt_setprompt()*
+		Set prompt for buffer {buf} to {text}.  You most likely want
+		{text} to end in a space.
+		The result is only visible if {buf} has 'buftype' set to
+		"prompt".  Example: >
+			call prompt_setprompt(bufnr(''), 'command: ')
+
+
 pumvisible()						*pumvisible()*
 		Returns non-zero when the popup menu is visible, zero
 		otherwise.  See |ins-completion-menu|.
@@ -6187,11 +6608,11 @@ pumvisible()						*pumvisible()*
 py3eval({expr})						*py3eval()*
 		Evaluate Python expression {expr} and return its result
 		converted to Vim data structures.
-		Numbers and strings are returned as they are (strings are 
-		copied though, Unicode strings are additionally converted to 
+		Numbers and strings are returned as they are (strings are
+		copied though, Unicode strings are additionally converted to
 		'encoding').
 		Lists are represented as Vim |List| type.
-		Dictionaries are represented as Vim |Dictionary| type with 
+		Dictionaries are represented as Vim |Dictionary| type with
 		keys converted to strings.
 		{only available when compiled with the |+python3| feature}
 
@@ -6199,10 +6620,10 @@ py3eval({expr})						*py3eval()*
 pyeval({expr})						*pyeval()*
 		Evaluate Python expression {expr} and return its result
 		converted to Vim data structures.
-		Numbers and strings are returned as they are (strings are 
+		Numbers and strings are returned as they are (strings are
 		copied though).
 		Lists are represented as Vim |List| type.
-		Dictionaries are represented as Vim |Dictionary| type, 
+		Dictionaries are represented as Vim |Dictionary| type,
 		non-string keys result in error.
 		{only available when compiled with the |+python| feature}
 
@@ -6265,6 +6686,15 @@ readfile({fname} [, {binary} [, {max}]])
 		the result is an empty list.
 		Also see |writefile()|.
 
+reg_executing()						*reg_executing()*
+		Returns the single letter name of the register being executed.
+		Returns an empty string when no register is being executed.
+		See |@|.
+
+reg_recording()						*reg_recording()*
+		Returns the single letter name of the register being recorded.
+		Returns an empty string string when not recording.  See |q|.
+
 reltime([{start} [, {end}]])				*reltime()*
 		Return an item that represents a time value.  The format of
 		the item depends on the system.  It can be passed to
@@ -6305,20 +6735,28 @@ reltimestr({time})				*reltimestr()*
 		{only available when compiled with the |+reltime| feature}
 
 							*remote_expr()* *E449*
-remote_expr({server}, {string} [, {idvar}])
+remote_expr({server}, {string} [, {idvar} [, {timeout}]])
 		Send the {string} to {server}.  The string is sent as an
 		expression and the result is returned after evaluation.
 		The result must be a String or a |List|.  A |List| is turned
 		into a String by joining the items with a line break in
 		between (not at the end), like with join(expr, "\n").
-		If {idvar} is present, it is taken as the name of a
-		variable and a {serverid} for later use with
-		remote_read() is stored there.
+		If {idvar} is present and not empty, it is taken as the name
+		of a variable and a {serverid} for later use with
+		|remote_read()| is stored there.
+		If {timeout} is given the read times out after this many
+		seconds.  Otherwise a timeout of 600 seconds is used.
 		See also |clientserver| |RemoteReply|.
 		This function is not available in the |sandbox|.
 		{only available when compiled with the |+clientserver| feature}
 		Note: Any errors will cause a local error message to be issued
 		and the result will be the empty string.
+
+		Variables will be evaluated in the global namespace,
+		independent of a function currently being active.  Except
+		when in debug mode, then local function variables and
+		arguments can be evaluated.
+
 		Examples: >
 			:echo remote_expr("gvim", "2+2")
 			:echo remote_expr("gvim1", "b:current_syntax")
@@ -6352,9 +6790,10 @@ remote_peek({serverid} [, {retvar}])		*remote_peek()*
 			:let repl = ""
 			:echo "PEEK: ".remote_peek(id, "repl").": ".repl
 
-remote_read({serverid})				*remote_read()*
+remote_read({serverid}, [{timeout}])			*remote_read()*
 		Return the oldest available reply from {serverid} and consume
-		it.  It blocks until a reply is available.
+		it.  Unless a {timeout} in seconds is given, it blocks until a
+		reply is available.
 		See also |clientserver|.
 		This function is not available in the |sandbox|.
 		{only available when compiled with the |+clientserver| feature}
@@ -6372,6 +6811,7 @@ remote_send({server}, {string} [, {idvar}])
 		See also |clientserver| |RemoteReply|.
 		This function is not available in the |sandbox|.
 		{only available when compiled with the |+clientserver| feature}
+
 		Note: Any errors will be reported in the server and may mess
 		up the display.
 		Examples: >
@@ -6383,6 +6823,12 @@ remote_send({server}, {string} [, {idvar}])
 		:echo remote_send("gvim", ":sleep 10 | echo ".
 		 \ 'server2client(expand("<client>"), "HELLO")<CR>')
 <
+					*remote_startserver()* *E941* *E942*
+remote_startserver({name})
+		Become the server {name}.  This fails if already running as a
+		server, when |v:servername| is not empty.
+		{only available when compiled with the |+clientserver| feature}
+
 remove({list}, {idx} [, {end}])				*remove()*
 		Without {end}: Remove the item at {idx} from |List| {list} and
 		return the item.
@@ -6453,12 +6899,12 @@ round({expr})							*round()*
 <			-5.0
 		{only available when compiled with the |+float| feature}
 
-screenattr(row, col)						*screenattr()*
+screenattr({row}, {col})					*screenattr()*
 		Like |screenchar()|, but return the attribute.  This is a rather
 		arbitrary number that can only be used to compare to the
 		attribute at other positions.
 
-screenchar(row, col)						*screenchar()*
+screenchar({row}, {col})					*screenchar()*
 		The result is a Number, which is the character at position
 		[row, col] on the screen.  This works for every possible
 		screen position, also status lines, window separators and the
@@ -6514,7 +6960,7 @@ search({pattern} [, {flags} [, {stopline} [, {timeout}]]])	*search()*
 		flag.
 
 		'ignorecase', 'smartcase' and 'magic' are used.
-		
+
 		When the 'z' flag is not given, searching always starts in
 		column zero and then matches before the cursor are skipped.
 		When the 'c' flag is present in 'cpo' the next search starts
@@ -6632,6 +7078,8 @@ searchpair({start}, {middle}, {end} [, {flags} [, {skip}
 		When {skip} is omitted or empty, every match is accepted.
 		When evaluating {skip} causes an error the search is aborted
 		and -1 returned.
+		{skip} can be a string, a lambda, a funcref or a partial.
+		Anything else makes the function fail.
 
 		For {stopline} and {timeout} see |search()|.
 
@@ -6726,6 +7174,19 @@ serverlist()					*serverlist()*
 		Example: >
 			:echo serverlist()
 <
+setbufline({expr}, {lnum}, {text})			*setbufline()*
+		Set line {lnum} to {text} in buffer {expr}.  To insert
+		lines use |append()|.
+
+		For the use of {expr}, see |bufname()| above.
+
+		{lnum} is used like with |setline()|.
+		This works like |setline()| for the specified buffer.
+		On success 0 is returned, on failure 1 is returned.
+
+		If {expr} is not a valid buffer or {lnum} is not valid, an
+		error message is given.
+
 setbufvar({expr}, {varname}, {val})			*setbufvar()*
 		Set option or local variable {varname} in buffer {expr} to
 		{val}.
@@ -6794,13 +7255,19 @@ setfperm({fname}, {mode})				*setfperm()* *chmod*
 
 setline({lnum}, {text})					*setline()*
 		Set line {lnum} of the current buffer to {text}.  To insert
-		lines use |append()|.
+		lines use |append()|. To set lines in another buffer use
+		|setbufline()|.
+
 		{lnum} is used like with |getline()|.
 		When {lnum} is just below the last line the {text} will be
 		added as a new line.
+
 		If this succeeds, 0 is returned.  If this fails (most likely
-		because {lnum} is invalid) 1 is returned.  Example: >
+		because {lnum} is invalid) 1 is returned.
+
+		Example: >
 			:call setline(5, strftime("%c"))
+
 <		When {text} is a |List| then line {lnum} and following lines
 		will be set to the items in the list.  Example: >
 			:call setline(5, ['aaa', 'bbb', 'ccc'])
@@ -6808,9 +7275,10 @@ setline({lnum}, {text})					*setline()*
 			:for [n, l] in [[5, 'aaa'], [6, 'bbb'], [7, 'ccc']]
 			:  call setline(n, l)
 			:endfor
+
 <		Note: The '[ and '] marks are not set.
 
-setloclist({nr}, {list}[, {action}[, {what}]])		*setloclist()*
+setloclist({nr}, {list} [, {action} [, {what}]])		*setloclist()*
 		Create or replace or add to the location list for window {nr}.
 		{nr} can be the window number or the |window-ID|.
 		When {nr} is zero the current window is used.
@@ -6878,16 +7346,20 @@ setpos({expr}, {list})
 		also set the preferred column.  Also see the "curswant" key in
 		|winrestview()|.
 
-setqflist({list} [, {action}[, {what}]])		*setqflist()*
-		Create or replace or add to the quickfix list using the items
-		in {list}.  Each item in {list} is a dictionary.
-		Non-dictionary items in {list} are ignored.  Each dictionary
-		item can contain the following entries:
+setqflist({list} [, {action} [, {what}]])		*setqflist()*
+		Create or replace or add to the quickfix list.
+
+		When {what} is not present, use the items in {list}.  Each
+		item must be a dictionary.  Non-dictionary items in {list} are
+		ignored.  Each dictionary item can contain the following
+		entries:
 
 		    bufnr	buffer number; must be the number of a valid
 				buffer
 		    filename	name of a file; only used when "bufnr" is not
 				present or it is invalid.
+		    module	name of a module; if given it will be used in
+				quickfix error window instead of the filename.
 		    lnum	line number in the file
 		    pattern	search pattern used to locate the error
 		    col		column number
@@ -6896,6 +7368,7 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		    nr		error number
 		    text	description of the error
 		    type	single-character error type, 'E', 'W', etc.
+		    valid	recognized error message
 
 		The "col", "vcol", "nr", "type" and "text" entries are
 		optional.  Either "lnum" or "pattern" entry can be used to
@@ -6905,49 +7378,74 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		item will not be handled as an error line.
 		If both "pattern" and "lnum" are present then "pattern" will
 		be used.
+		If the "valid" entry is not supplied, then the valid flag is
+		set when "bufnr" is a valid buffer or "filename" exists.
 		If you supply an empty {list}, the quickfix list will be
 		cleared.
 		Note that the list is not exactly the same as what
 		|getqflist()| returns.
 
-							*E927*
-		If {action} is set to 'a', then the items from {list} are
-		added to the existing quickfix list. If there is no existing
-		list, then a new list is created.
-		
-		If {action} is set to 'r', then the items from the current
-		quickfix list are replaced with the items from {list}.  This
-		can also be used to clear the list: >
-			:call setqflist([], 'r')
-<	
+		{action} values:				*E927*
+		'a'	The items from {list} are added to the existing
+			quickfix list. If there is no existing list, then a
+			new list is created.
+
+		'r'	The items from the current quickfix list are replaced
+			with the items from {list}.  This can also be used to
+			clear the list: >
+				:call setqflist([], 'r')
+<
+		'f'	All the quickfix lists in the quickfix stack are
+			freed.
+
 		If {action} is not present or is set to ' ', then a new list
-		is created.
+		is created. The new quickfix list is added after the current
+		quickfix list in the stack and all the following lists are
+		freed. To add a new quickfix list at the end of the stack,
+		set "nr" in {what} to "$".
 
 		If the optional {what} dictionary argument is supplied, then
 		only the items listed in {what} are set. The first {list}
 		argument is ignored.  The following items can be specified in
 		{what}:
-		    nr		list number in the quickfix stack
+		    context	quickfix list context. See |quickfix-context|
+		    efm		errorformat to use when parsing text from
+				"lines". If this is not present, then the
+				'errorformat' option value is used.
+		    id		quickfix list identifier |quickfix-ID|
+		    items	list of quickfix entries. Same as the {list}
+				argument.
+		    lines	use 'errorformat' to parse a list of lines and
+				add the resulting entries to the quickfix list
+				{nr} or {id}.  Only a |List| value is supported.
+		    nr		list number in the quickfix stack; zero
+				means the current quickfix list and "$" means
+				the last quickfix list
 		    title	quickfix list title text
 		Unsupported keys in {what} are ignored.
 		If the "nr" item is not present, then the current quickfix list
-		is modified.
+		is modified. When creating a new quickfix list, "nr" can be
+		set to a value one greater than the quickfix stack size.
+		When modifying a quickfix list, to guarantee that the correct
+		list is modified, "id" should be used instead of "nr" to
+		specify the list.
 
-		Examples: >
-			:call setqflist([], 'r', {'title': 'My search'})
-			:call setqflist([], 'r', {'nr': 2, 'title': 'Errors'})
+		Examples (See also |setqflist-examples|): >
+		   :call setqflist([], 'r', {'title': 'My search'})
+		   :call setqflist([], 'r', {'nr': 2, 'title': 'Errors'})
+		   :call setqflist([], 'a', {'id':qfid, 'lines':["F1:10:L10"]})
 <
 		Returns zero for success, -1 for failure.
 
 		This function can be used to create a quickfix list
 		independent of the 'errorformat' setting.  Use a command like
-		":cc 1" to jump to the first position.
+		`:cc 1` to jump to the first position.
 
 
 							*setreg()*
 setreg({regname}, {value} [, {options}])
 		Set the register {regname} to {value}.
-		{value} may be any value returned by |getreg()|, including 
+		{value} may be any value returned by |getreg()|, including
 		a |List|.
 		If {options} contains "a" or {regname} is upper case,
 		then the value is appended.
@@ -6961,14 +7459,14 @@ setreg({regname}, {value} [, {options}])
 		in the longest line (counting a <Tab> as 1 character).
 
 		If {options} contains no register settings, then the default
-		is to use character mode unless {value} ends in a <NL> for 
-		string {value} and linewise mode for list {value}. Blockwise 
+		is to use character mode unless {value} ends in a <NL> for
+		string {value} and linewise mode for list {value}. Blockwise
 		mode is never selected automatically.
 		Returns zero for success, non-zero for failure.
 
 							*E883*
-		Note: you may not use |List| containing more than one item to 
-		      set search and expression registers. Lists containing no 
+		Note: you may not use |List| containing more than one item to
+		      set search and expression registers. Lists containing no
 		      items act like empty strings.
 
 		Examples: >
@@ -6977,16 +7475,17 @@ setreg({regname}, {value} [, {options}])
 			:call setreg('a', "1\n2\n3", 'b5')
 
 <		This example shows using the functions to save and restore a
-		register (note: you may not reliably restore register value 
-		without using the third argument to |getreg()| as without it 
-		newlines are represented as newlines AND Nul bytes are 
-		represented as newlines as well, see |NL-used-for-Nul|). >
+		register: >
 			:let var_a = getreg('a', 1, 1)
 			:let var_amode = getregtype('a')
 			    ....
 			:call setreg('a', var_a, var_amode)
+<		Note: you may not reliably restore register value
+		without using the third argument to |getreg()| as without it
+		newlines are represented as newlines AND Nul bytes are
+		represented as newlines as well, see |NL-used-for-Nul|.
 
-<		You can also change the type of a register by appending
+		You can also change the type of a register by appending
 		nothing: >
 			:call setreg('a', '', 'al')
 
@@ -7031,18 +7530,22 @@ shellescape({string} [, {special}])			*shellescape()*
 		quotes within {string}.
 		Otherwise it will enclose {string} in single quotes and
 		replace all "'" with "'\''".
+
 		When the {special} argument is present and it's a non-zero
 		Number or a non-empty String (|non-zero-arg|), then special
 		items such as "!", "%", "#" and "<cword>" will be preceded by
 		a backslash.  This backslash will be removed again by the |:!|
 		command.
+
 		The "!" character will be escaped (again with a |non-zero-arg|
 		{special}) when 'shell' contains "csh" in the tail.  That is
 		because for csh and tcsh "!" is used for history replacement
 		even when inside single quotes.
-		The <NL> character is also escaped.  With a |non-zero-arg|
-		{special} and 'shell' containing "csh" in the tail it's
+
+		With a |non-zero-arg| {special} the <NL> character is also
+		escaped.  When 'shell' containing "csh" in the tail it's
 		escaped a second time.
+
 		Example of use with a |:!| command: >
 		    :exe '!dir ' . shellescape(expand('<cfile>'), 1)
 <		This results in a directory listing for the file under the
@@ -7083,7 +7586,7 @@ sin({expr})						*sin()*
 			:echo sin(-4.01)
 <			0.763301
 		{only available when compiled with the |+float| feature}
-		
+
 
 sinh({expr})						*sinh()*
 		Return the hyperbolic sine of {expr} as a |Float| in the range
@@ -7099,7 +7602,7 @@ sinh({expr})						*sinh()*
 
 sort({list} [, {func} [, {dict}]])			*sort()* *E702*
 		Sort the items in {list} in-place.  Returns {list}.
-		
+
 		If you want a list to remain unmodified make a copy first: >
 			:let sortedlist = sort(copy(mylist))
 
@@ -7110,7 +7613,7 @@ sort({list} [, {func} [, {dict}]])			*sort()* *E702*
 
 		When {func} is given and it is '1' or 'i' then case is
 		ignored.
-		
+
 		When {func} is given and it is 'n' then all items will be
 		sorted numerical (Implementation detail: This uses the
 		strtod() function to parse numbers, Strings, Lists, Dicts and
@@ -7245,7 +7748,7 @@ sqrt({expr})						*sqrt()*
 <			nan
 		"nan" may be different, it depends on system libraries.
 		{only available when compiled with the |+float| feature}
-		
+
 
 str2float({expr})					*str2float()*
 		Convert String {expr} to a Float.  This mostly works the same
@@ -7282,7 +7785,7 @@ strchars({expr} [, {skipcc}])					*strchars()*
 		counted separately.
 		When {skipcc} set to 1, Composing characters are ignored.
 		Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
-		
+
 		{skipcc} is only available after 7.4.755.  For backward
 		compatibility, you can define a wrapper function: >
 		    if has("patch-7.4.755")
@@ -7299,7 +7802,7 @@ strchars({expr} [, {skipcc}])					*strchars()*
 		      endfunction
 		    endif
 <
-strcharpart({src}, {start}[, {len}])			*strcharpart()*
+strcharpart({src}, {start} [, {len}])			*strcharpart()*
 		Like |strpart()| but using character index and length instead
 		of byte index and length.
 		When a character index is used where a character does not
@@ -7307,7 +7810,7 @@ strcharpart({src}, {start}[, {len}])			*strcharpart()*
 			strcharpart('abc', -1, 2)
 <		results in 'a'.
 
-strdisplaywidth({expr}[, {col}])			*strdisplaywidth()*
+strdisplaywidth({expr} [, {col}])			*strdisplaywidth()*
 		The result is a Number, which is the number of display cells
 		String {expr} occupies on the screen when it starts at {col}.
 		When {col} is omitted zero is used.  Otherwise it is the
@@ -7391,7 +7894,7 @@ strlen({expr})	The result is a Number, which is the length of the String
 		|strchars()|.
 		Also see |len()|, |strdisplaywidth()| and |strwidth()|.
 
-strpart({src}, {start}[, {len}])			*strpart()*
+strpart({src}, {start} [, {len}])			*strpart()*
 		The result is a String, which is part of {src}, starting from
 		byte {start}, with the byte length {len}.
 		To count characters instead of bytes use |strcharpart()|.
@@ -7443,7 +7946,7 @@ strwidth({expr})					*strwidth()*
 		Ambiguous, this function's return value depends on 'ambiwidth'.
 		Also see |strlen()|, |strdisplaywidth()| and |strchars()|.
 
-submatch({nr}[, {list}])			*submatch()* *E935*
+submatch({nr} [, {list}])			*submatch()* *E935*
 		Only for an expression in a |:substitute| command or
 		substitute() function.
 		Returns the {nr}'th submatch of the matched text.  When {nr}
@@ -7452,8 +7955,8 @@ submatch({nr}[, {list}])			*submatch()* *E935*
 		multi-line match or a NUL character in the text.
 		Also see |sub-replace-expression|.
 
-		If {list} is present and non-zero then submatch() returns 
-		a list of strings, similar to |getline()| with two arguments. 
+		If {list} is present and non-zero then submatch() returns
+		a list of strings, similar to |getline()| with two arguments.
 		NL characters in the text represent NUL characters in the
 		text.
 		Only returns more than one item for |:substitute|, inside
@@ -7463,8 +7966,9 @@ submatch({nr}[, {list}])			*submatch()* *E935*
 		When substitute() is used recursively only the submatches in
 		the current (deepest) call can be obtained.
 
-		Example: >
+		Examples: >
 			:s/\d\+/\=submatch(0) + 1/
+			:echo substitute(text, '\d\+', '\=submatch(0) + 1', '')
 <		This finds the first number in the line and adds one to it.
 		A line break is included as a newline character.
 
@@ -7473,7 +7977,7 @@ substitute({expr}, {pat}, {sub}, {flags})		*substitute()*
 		the first match of {pat} is replaced with {sub}.
 		When {flags} is "g", all matches of {pat} in {expr} are
 		replaced.  Otherwise {flags} should be "".
-		
+
 		This works like the ":substitute" command (without any flags).
 		But the matching with {pat} is always done like the 'magic'
 		option is set and 'cpoptions' is empty (to make scripts
@@ -7508,6 +8012,25 @@ substitute({expr}, {pat}, {sub}, {flags})		*substitute()*
 		matched string and up to nine submatches, like what
 		|submatch()| returns.  Example: >
 		   :echo substitute(s, '%\(\x\x\)', {m -> '0x' . m[1]}, 'g')
+
+swapinfo({fname})					*swapinfo()*
+		The result is a dictionary, which holds information about the
+		swapfile {fname}. The available fields are:
+			version VIM version
+			user	user name
+			host	host name
+			fname	original file name
+			pid	PID of the VIM process that created the swap
+				file
+			mtime	last modification time in seconds
+			inode	Optional: INODE number of the file
+			dirty	1 if file was modified, 0 if not
+		Note that "user" and "host" are truncated to at most 39 bytes.
+		In case of failure an "error" item is added with the reason:
+			Cannot open file: file not found or in accessible
+			Cannot read file: cannot read first block
+			Not a swap file: does not contain correct block ID
+			Magic number mismatch: Info in first block is invalid
 
 synID({lnum}, {col}, {trans})				*synID()*
 		The result is a Number, which is the syntax ID at the position
@@ -7562,6 +8085,7 @@ synIDattr({synID}, {what} [, {mode}])			*synIDattr()*
 		"standout"	"1" if standout
 		"underline"	"1" if underlined
 		"undercurl"	"1" if undercurled
+		"strike"	"1" if strikethrough
 
 		Example (echoes the color of the syntax item under the
 		cursor): >
@@ -7574,17 +8098,29 @@ synIDtrans({synID})					*synIDtrans()*
 		":highlight link" are followed.
 
 synconcealed({lnum}, {col})				*synconcealed()*
-		The result is a List. The first item in the list is 0 if the
-		character at the position {lnum} and {col} is not part of a
-		concealable region, 1 if it is. The second item in the list is
-		a string. If the first item is 1, the second item contains the
-		text which will be displayed in place of the concealed text,
-		depending on the current setting of 'conceallevel'. The third
-		and final item in the list is a unique number representing the
-		specific syntax region matched. This allows detection of the
-		beginning of a new concealable region if there are two
-		consecutive regions with the same replacement character.
-		For an example use see $VIMRUNTIME/syntax/2html.vim .
+		The result is a List with currently three items:
+		1. The first item in the list is 0 if the character at the
+		   position {lnum} and {col} is not part of a concealable
+		   region, 1 if it is.
+		2. The second item in the list is a string. If the first item
+		   is 1, the second item contains the text which will be
+		   displayed in place of the concealed text, depending on the
+		   current setting of 'conceallevel' and 'listchars'.
+		3. The third and final item in the list is a number
+		   representing the specific syntax region matched in the
+		   line. When the character is not concealed the value is
+		   zero. This allows detection of the beginning of a new
+		   concealable region if there are two consecutive regions
+		   with the same replacement character.  For an example, if
+		   the text is "123456" and both "23" and "45" are concealed
+		   and replace by the character "X", then:
+			call			returns ~
+			synconcealed(lnum, 1)   [0, '', 0]
+			synconcealed(lnum, 2)   [1, 'X', 1]
+			synconcealed(lnum, 3)   [1, 'X', 1]
+			synconcealed(lnum, 4)   [1, 'X', 2]
+			synconcealed(lnum, 5)   [1, 'X', 2]
+			synconcealed(lnum, 6)   [0, '', 0]
 
 
 synstack({lnum}, {col})					*synstack()*
@@ -7609,9 +8145,9 @@ system({expr} [, {input}])				*system()* *E677*
 		Get the output of the shell command {expr} as a string.  See
 		|systemlist()| to get the output as a List.
 
-		When {input} is given and is a string this string is written 
-		to a file and passed as stdin to the command.  The string is 
-		written as-is, you need to take care of using the correct line 
+		When {input} is given and is a string this string is written
+		to a file and passed as stdin to the command.  The string is
+		written as-is, you need to take care of using the correct line
 		separators yourself.
 		If {input} is given and is a |List| it is written to the file
 		in a way |writefile()| does with {binary} set to "b" (i.e.
@@ -7630,10 +8166,10 @@ system({expr} [, {input}])				*system()* *E677*
 		up on the screen which require |CTRL-L| to remove. >
 			:silent let f = system('ls *.vim')
 <
-		Note: Use |shellescape()| or |::S| with |expand()| or 
-		|fnamemodify()| to escape special characters in a command 
-		argument.  Newlines in {expr} may cause the command to fail.  
-		The characters in 'shellquote' and 'shellxquote' may also 
+		Note: Use |shellescape()| or |::S| with |expand()| or
+		|fnamemodify()| to escape special characters in a command
+		argument.  Newlines in {expr} may cause the command to fail.
+		The characters in 'shellquote' and 'shellxquote' may also
 		cause trouble.
 		This is not to be used for interactive commands.
 
@@ -7667,9 +8203,9 @@ system({expr} [, {input}])				*system()* *E677*
 
 
 systemlist({expr} [, {input}])				*systemlist()*
-		Same as |system()|, but returns a |List| with lines (parts of 
-		output separated by NL) with NULs transformed into NLs. Output 
-		is the same as |readfile()| will output with {binary} argument 
+		Same as |system()|, but returns a |List| with lines (parts of
+		output separated by NL) with NULs transformed into NLs. Output
+		is the same as |readfile()| will output with {binary} argument
 		set to "b".  Note that on MS-Windows you may get trailing CR
 		characters.
 
@@ -7716,8 +8252,13 @@ tagfiles()	Returns a |List| with the file names used to search for tags
 		for the current buffer.  This is the 'tags' option expanded.
 
 
-taglist({expr})							*taglist()*
+taglist({expr} [, {filename}])				*taglist()*
 		Returns a list of tags matching the regular expression {expr}.
+
+		If {filename} is passed it is used to prioritize the results
+		in the same way that |:tselect| does. See |tag-priority|.
+		{filename} should be the full path of the file.
+
 		Each list item is a dictionary with at least the following
 		entries:
 			name		Name of the tag.
@@ -7788,6 +8329,354 @@ tempname()					*tempname()* *temp-file-name*
 		For MS-Windows forward slashes are used when the 'shellslash'
 		option is set or when 'shellcmdflag' starts with '-'.
 
+							*term_dumpdiff()*
+term_dumpdiff({filename}, {filename} [, {options}])
+		Open a new window displaying the difference between the two
+		files.  The files must have been created with
+		|term_dumpwrite()|.
+		Returns the buffer number or zero when the diff fails.
+		Also see |terminal-diff|.
+		NOTE: this does not work with double-width characters yet.
+
+		The top part of the buffer contains the contents of the first
+		file, the bottom part of the buffer contains the contents of
+		the second file.  The middle part shows the differences.
+		The parts are separated by a line of dashes.
+
+		If the {options} argument is present, it must be a Dict with
+		these possible members:
+		   "term_name"	     name to use for the buffer name, instead
+				     of the first file name.
+		   "term_rows"	     vertical size to use for the terminal,
+				     instead of using 'termwinsize'
+		   "term_cols"	     horizontal size to use for the terminal,
+				     instead of using 'termwinsize'
+		   "vertical"	     split the window vertically
+		   "curwin"	     use the current window, do not split the
+				     window; fails if the current buffer
+				     cannot be |abandon|ed
+		   "norestore"	     do not add the terminal window to a
+				     session file
+
+		Each character in the middle part indicates a difference. If
+		there are multiple differences only the first in this list is
+		used:
+			X	different character
+			w	different width
+			f	different foreground color
+			b	different background color
+			a	different attribute
+			+	missing position in first file
+			-	missing position in second file
+
+		Using the "s" key the top and bottom parts are swapped.  This
+		makes it easy to spot a difference.
+
+							*term_dumpload()*
+term_dumpload({filename} [, {options}])
+		Open a new window displaying the contents of {filename}
+		The file must have been created with |term_dumpwrite()|.
+		Returns the buffer number or zero when it fails.
+		Also see |terminal-diff|.
+
+		For {options} see |term_dumpdiff()|.
+
+							*term_dumpwrite()*
+term_dumpwrite({buf}, {filename} [, {options}])
+		Dump the contents of the terminal screen of {buf} in the file
+		{filename}.  This uses a format that can be used with
+		|term_dumpload()| and |term_dumpdiff()|.
+		If {filename} already exists an error is given.	*E953*
+		Also see |terminal-diff|.
+
+		{options} is a dictionary with these optional entries:
+			"rows"		maximum number of rows to dump
+			"columns"	maximum number of columns to dump
+
+term_getaltscreen({buf})				*term_getaltscreen()*
+		Returns 1 if the terminal of {buf} is using the alternate
+		screen.
+		{buf} is used as with |term_getsize()|.
+		{only available when compiled with the |+terminal| feature}
+
+term_getansicolors({buf})				*term_getansicolors()*
+		Get the ANSI color palette in use by terminal {buf}.
+		Returns a List of length 16 where each element is a String
+		representing a color in hexadecimal "#rrggbb" format.
+		Also see |term_setansicolors()| and |g:terminal_ansi_colors|.
+		If neither was used returns the default colors.
+
+		{buf} is used as with |term_getsize()|.  If the buffer does not
+		exist or is not a terminal window, an empty list is returned.
+		{only available when compiled with the |+terminal| feature and
+		with GUI enabled and/or the |+termguicolors| feature}
+
+term_getattr({attr}, {what})				*term_getattr()*
+		Given {attr}, a value returned by term_scrape() in the "attr"
+		item, return whether {what} is on.  {what} can be one of:
+			bold
+			italic
+			underline
+			strike
+			reverse
+		{only available when compiled with the |+terminal| feature}
+
+term_getcursor({buf})					*term_getcursor()*
+		Get the cursor position of terminal {buf}. Returns a list with
+		two numbers and a dictionary: [row, col, dict].
+
+		"row" and "col" are one based, the first screen cell is row
+		1, column 1.  This is the cursor position of the terminal
+		itself, not of the Vim window.
+
+		"dict" can have these members:
+		   "visible"	one when the cursor is visible, zero when it
+				is hidden.
+		   "blink"	one when the cursor is visible, zero when it
+				is hidden.
+		   "shape"	1 for a block cursor, 2 for underline and 3
+				for a vertical bar.
+
+		{buf} must be the buffer number of a terminal window. If the
+		buffer does not exist or is not a terminal window, an empty
+		list is returned.
+		{only available when compiled with the |+terminal| feature}
+
+term_getjob({buf})					*term_getjob()*
+		Get the Job associated with terminal window {buf}.
+		{buf} is used as with |term_getsize()|.
+		Returns |v:null| when there is no job.
+		{only available when compiled with the |+terminal| feature}
+
+term_getline({buf}, {row})				*term_getline()*
+		Get a line of text from the terminal window of {buf}.
+		{buf} is used as with |term_getsize()|.
+
+		The first line has {row} one.  When {row} is "." the cursor
+		line is used.  When {row} is invalid an empty string is
+		returned.
+
+		To get attributes of each character use |term_scrape()|.
+		{only available when compiled with the |+terminal| feature}
+
+term_getscrolled({buf})					*term_getscrolled()*
+		Return the number of lines that scrolled to above the top of
+		terminal {buf}.  This is the offset between the row number
+		used for |term_getline()| and |getline()|, so that: >
+			term_getline(buf, N)
+<		is equal to: >
+			`getline(N + term_getscrolled(buf))
+<		(if that line exists).
+
+		{buf} is used as with |term_getsize()|.
+		{only available when compiled with the |+terminal| feature}
+
+term_getsize({buf})					*term_getsize()*
+		Get the size of terminal {buf}. Returns a list with two
+		numbers: [rows, cols].  This is the size of the terminal, not
+		the window containing the terminal.
+
+		{buf} must be the buffer number of a terminal window.  Use an
+		empty string for the current buffer.  If the buffer does not
+		exist or is not a terminal window, an empty list is returned.
+		{only available when compiled with the |+terminal| feature}
+
+term_getstatus({buf})					*term_getstatus()*
+		Get the status of terminal {buf}. This returns a comma
+		separated list of these items:
+			running		job is running
+			finished	job has finished
+			normal		in Terminal-Normal mode
+		One of "running" or "finished" is always present.
+
+		{buf} must be the buffer number of a terminal window. If the
+		buffer does not exist or is not a terminal window, an empty
+		string is returned.
+		{only available when compiled with the |+terminal| feature}
+
+term_gettitle({buf})					*term_gettitle()*
+		Get the title of terminal {buf}. This is the title that the
+		job in the terminal has set.
+
+		{buf} must be the buffer number of a terminal window. If the
+		buffer does not exist or is not a terminal window, an empty
+		string is returned.
+		{only available when compiled with the |+terminal| feature}
+
+term_gettty({buf} [, {input}])				*term_gettty()*
+		Get the name of the controlling terminal associated with
+		terminal window {buf}.  {buf} is used as with |term_getsize()|.
+
+		When {input} is omitted or 0, return the name for writing
+		(stdout). When {input} is 1 return the name for reading
+		(stdin). On UNIX, both return same name.
+		{only available when compiled with the |+terminal| feature}
+
+term_list()						*term_list()*
+		Return a list with the buffer numbers of all buffers for
+		terminal windows.
+		{only available when compiled with the |+terminal| feature}
+
+term_scrape({buf}, {row})				*term_scrape()*
+		Get the contents of {row} of terminal screen of {buf}.
+		For {buf} see |term_getsize()|.
+
+		The first line has {row} one.  When {row} is "." the cursor
+		line is used.  When {row} is invalid an empty string is
+		returned.
+
+		Return a List containing a Dict for each screen cell:
+		    "chars"	character(s) at the cell
+		    "fg"	foreground color as #rrggbb
+		    "bg"	background color as #rrggbb
+		    "attr"	attributes of the cell, use |term_getattr()|
+				to get the individual flags
+		    "width"	cell width: 1 or 2
+		{only available when compiled with the |+terminal| feature}
+
+term_sendkeys({buf}, {keys})				*term_sendkeys()*
+		Send keystrokes {keys} to terminal {buf}.
+		{buf} is used as with |term_getsize()|.
+
+		{keys} are translated as key sequences. For example, "\<c-x>"
+		means the character CTRL-X.
+		{only available when compiled with the |+terminal| feature}
+
+term_setansicolors({buf}, {colors})			*term_setansicolors()*
+		Set the ANSI color palette used by terminal {buf}.
+		{colors} must be a List of 16 valid color names or hexadecimal
+		color codes, like those accepted by |highlight-guifg|.
+		Also see |term_getansicolors()| and |g:terminal_ansi_colors|.
+
+		The colors normally are:
+			0    black
+			1    dark red
+			2    dark green
+			3    brown
+			4    dark blue
+			5    dark magenta
+			6    dark cyan
+			7    light grey
+			8    dark grey
+			9    red
+			10   green
+			11   yellow
+			12   blue
+			13   magenta
+			14   cyan
+			15   white
+
+		These colors are used in the GUI and in the terminal when
+		'termguicolors' is set.  When not using GUI colors (GUI mode
+		or 'termguicolors'), the terminal window always uses the 16
+		ANSI colors of the underlying terminal.
+		{only available when compiled with the |+terminal| feature and
+		with GUI enabled and/or the |+termguicolors| feature}
+
+term_setkill({buf}, {how})				*term_setkill()*
+		When exiting Vim or trying to close the terminal window in
+		another way, {how} defines whether the job in the terminal can
+		be stopped.
+		When {how} is empty (the default), the job will not be
+		stopped, trying to exit will result in |E947|.
+		Otherwise, {how} specifies what signal to send to the job.
+		See |job_stop()| for the values.
+
+		After sending the signal Vim will wait for up to a second to
+		check that the job actually stopped.
+
+term_setrestore({buf}, {command})			*term_setrestore()*
+		Set the command to write in a session file to restore the job
+		in this terminal.  The line written in the session file is: >
+			terminal ++curwin ++cols=%d ++rows=%d {command}
+<		Make sure to escape the command properly.
+
+		Use an empty {command} to run 'shell'.
+		Use "NONE" to not restore this window.
+		{only available when compiled with the |+terminal| feature}
+
+term_setsize({buf}, {rows}, {cols})		*term_setsize()* *E955*
+		Set the size of terminal {buf}. The size of the window
+		containing the terminal will also be adjusted, if possible.
+		If {rows} or {cols} is zero or negative, that dimension is not
+		changed.
+
+		{buf} must be the buffer number of a terminal window.  Use an
+		empty string for the current buffer.  If the buffer does not
+		exist or is not a terminal window, an error is given.
+		{only available when compiled with the |+terminal| feature}
+
+term_start({cmd}, {options})				*term_start()*
+		Open a terminal window and run {cmd} in it.
+
+		{cmd} can be a string or a List, like with |job_start()|. The
+		string "NONE" can be used to open a terminal window without
+		starting a job, the pty of the terminal can be used by a
+		command like gdb.
+
+		Returns the buffer number of the terminal window.  If {cmd}
+		cannot be executed the window does open and shows an error
+		message.
+		If opening the window fails zero is returned.
+
+		{options} are similar to what is used for |job_start()|, see
+		|job-options|.  However, not all options can be used.  These
+		are supported:
+		   all timeout options
+		   "stoponexit", "cwd", "env"
+		   "callback", "out_cb", "err_cb", "exit_cb", "close_cb"
+		   "in_io", "in_top", "in_bot", "in_name", "in_buf"
+		   "out_io", "out_name", "out_buf", "out_modifiable", "out_msg"
+		   "err_io", "err_name", "err_buf", "err_modifiable", "err_msg"
+		However, at least one of stdin, stdout or stderr must be
+		connected to the terminal.  When I/O is connected to the
+		terminal then the callback function for that part is not used.
+
+		There are extra options:
+		   "term_name"	     name to use for the buffer name, instead
+				     of the command name.
+		   "term_rows"	     vertical size to use for the terminal,
+				     instead of using 'termwinsize'
+		   "term_cols"	     horizontal size to use for the terminal,
+				     instead of using 'termwinsize'
+		   "vertical"	     split the window vertically; note that
+				     other window position can be defined with
+				     command modifiers, such as |:belowright|.
+		   "curwin"	     use the current window, do not split the
+				     window; fails if the current buffer
+				     cannot be |abandon|ed
+		   "hidden"	     do not open a window
+		   "norestore"	     do not add the terminal window to a
+				     session file
+		   "term_kill"	     what to do when trying to close the
+				     terminal window, see |term_setkill()|
+		   "term_finish"     What to do when the job is finished:
+					"close": close any windows
+					"open": open window if needed
+				     Note that "open" can be interruptive.
+				     See |term++close| and |term++open|.
+		   "term_opencmd"    command to use for opening the window when
+				     "open" is used for "term_finish"; must
+				     have "%d" where the buffer number goes,
+				     e.g. "10split|buffer %d"; when not
+				     specified "botright sbuf %d" is used
+		   "eof_chars"	     Text to send after all buffer lines were
+				     written to the terminal.  When not set
+				     CTRL-D is used on MS-Windows. For Python
+				     use CTRL-Z or "exit()". For a shell use
+				     "exit".  A CR is always added.
+		   "ansi_colors"     A list of 16 color names or hex codes
+				     defining the ANSI palette used in GUI
+				     color modes.  See |g:terminal_ansi_colors|.
+
+		{only available when compiled with the |+terminal| feature}
+
+term_wait({buf} [, {time}])					*term_wait()*
+		Wait for pending updates of {buf} to be handled.
+		{buf} is used as with |term_getsize()|.
+		{time} is how long to wait for updates to arrive in msec.  If
+		not set then 10 msec will be used.
+		{only available when compiled with the |+terminal| feature}
 
 test_alloc_fail({id}, {countdown}, {repeat})		*test_alloc_fail()*
 		This is for testing: If the memory allocation with {id} is
@@ -7798,6 +8687,11 @@ test_alloc_fail({id}, {countdown}, {repeat})		*test_alloc_fail()*
 test_autochdir()					*test_autochdir()*
 		Set a flag to enable the effect of 'autochdir' before Vim
 		startup has finished.
+
+test_feedinput({string})				*test_feedinput()*
+		Characters in {string} are queued for processing as if they
+		were typed by the user. This uses a low level input buffer.
+		This function works only when with |+unix| or GUI is running.
 
 test_garbagecollect_now()			 *test_garbagecollect_now()*
 		Like garbagecollect(), but executed right away.  This must
@@ -7839,12 +8733,26 @@ test_override({name}, {val})				*test_override()*
 		to run tests. Only to be used for testing Vim!
 		The override is enabled when {val} is non-zero and removed
 		when {val} is zero.
-		Current supported values for name are: 
+		Current supported values for name are:
 
 		name	     effect when {val} is non-zero ~
 		redraw       disable the redrawing() function
+		redraw_flag  ignore the RedrawingDisabled flag
 		char_avail   disable the char_avail() function
+		starting     reset the "starting" variable, see below
+		nfa_fail     makes the NFA regexp engine fail to force a
+			     fallback to the old engine
 		ALL	     clear all overrides ({val} is not used)
+
+		"starting" is to be used when a test should behave like
+		startup was done.  Since the tests are run by sourcing a
+		script the "starting" variable is non-zero. This is usually a
+		good thing (tests run faster), but sometimes changes behavior
+		in a way that the test doesn't work properly.
+		When using: >
+			call test_override('starting', 1)
+<		The value of "starting" is saved.  It is restored by: >
+			call test_override('starting', 0)
 
 test_settime({expr})					*test_settime()*
 		Set the time Vim uses internally.  Currently only used for
@@ -7907,6 +8815,10 @@ timer_start({time}, {callback} [, {options}])
 		   "repeat"	Number of times to repeat calling the
 				callback.  -1 means forever.  When not present
 				the callback will be called once.
+				If the timer causes an error three times in a
+				row the repeat is cancelled.  This avoids that
+				Vim becomes unusable because of all the error
+				messages.
 
 		Example: >
 			func MyHandler(timer)
@@ -7957,6 +8869,22 @@ tr({src}, {fromstr}, {tostr})				*tr()*
 			echo tr("<blob>", "<>", "{}")
 <		returns "{blob}"
 
+trim({text} [, {mask}])						*trim()*
+		Return {text} as a String where any character in {mask} is
+		removed from the beginning and  end of {text}.
+		If {mask} is not given, {mask} is all characters up to 0x20,
+		which includes Tab, space, NL and CR, plus the non-breaking
+		space character 0xa0.
+		This code deals with multibyte characters properly.
+
+		Examples: >
+			echo trim("   some text ")
+<		returns "some text" >
+			echo trim("  \r\t\t\r RESERVE \t\n\x0B\xA0") . "_TAIL"
+<		returns "RESERVE_TAIL" >
+			echo trim("rm<Xrm<>X>rrm", "rm<>")
+<		returns "Xrm<>X" (characters in the middle are not removed)
+
 trunc({expr})							*trunc()*
 		Return the largest integral value with magnitude less than or
 		equal to {expr} as a |Float| (truncate towards zero).
@@ -7969,7 +8897,7 @@ trunc({expr})							*trunc()*
 			echo trunc(4.0)
 <			4.0
 		{only available when compiled with the |+float| feature}
-		
+
 							*type()*
 type({expr})	The result is a Number representing the type of {expr}.
 		Instead of using the number directly, it is better to use the
@@ -8022,7 +8950,7 @@ undotree()						*undotree()*
 		  "save_last"	Number of the last file write.  Zero when no
 				write yet.
 		  "save_cur"	Number of the current position in the undo
-				tree.  
+				tree.
 		  "synced"	Non-zero when the last undo block was synced.
 				This happens when waiting from input from the
 				user.  See |undo-blocks|.
@@ -8141,7 +9069,7 @@ win_getid([{win} [, {tab}]])				*win_getid()*
 		Get the |window-ID| for the specified window.
 		When {win} is missing use the current window.
 		With {win} this is the window number.  The top window has
-		number 1.
+		number 1.  Use `win_getid(winnr())` for the current window.
 		Without {tab} use the current tab, otherwise the tab with
 		number {tab}.  The first tab has number one.
 		Return zero if the window cannot be found.
@@ -8159,6 +9087,14 @@ win_id2tabwin({expr})					*win_id2tabwin()*
 win_id2win({expr})					*win_id2win()*
 		Return the window number of window with ID {expr}.
 		Return 0 if the window cannot be found in the current tabpage.
+
+win_screenpos({nr})					*win_screenpos()*
+		Return the screen position of window {nr} as a list with two
+		numbers: [row, col].  The first window always has position
+		[1, 1], unless there is a tabline, then it is [2, 1].
+		{nr} can be the window number or the |window-ID|.
+		Return [0, 0] if the window cannot be found in the current
+		tabpage.
 
 							*winbufnr()*
 winbufnr({nr})	The result is a Number, which is the number of the buffer
@@ -8181,8 +9117,38 @@ winheight({nr})						*winheight()*
 		When {nr} is zero, the height of the current window is
 		returned.  When window {nr} doesn't exist, -1 is returned.
 		An existing window always has a height of zero or more.
+		This excludes any window toolbar line.
 		Examples: >
   :echo "The current window has " . winheight(0) . " lines."
+<
+winlayout([{tabnr}])					*winlayout()*
+		The result is a nested List containing the layout of windows
+		in a tabpage.
+
+		Without {tabnr} use the current tabpage, otherwise the tabpage
+		with number {tabnr}. If the tabpage {tabnr} is not found,
+		returns an empty list.
+
+		For a leaf window, it returns:
+			['leaf', {winid}]
+		For horizontally split windows, which form a column, it
+		returns:
+			['col', [{nested list of windows}]]
+		For vertically split windows, which form a row, it returns:
+			['row', [{nested list of windows}]]
+
+		Example: >
+			" Only one window in the tab page
+			:echo winlayout()
+			['leaf', 1000]
+			" Two horizontally split windows
+			:echo winlayout()
+			['col', [['leaf', 1000], ['leaf', 1001]]]
+			" Three horizontally split windows, with two
+			" vertically split windows in the middle window
+			:echo winlayout(2)
+			['col', [['leaf', 1002], ['row', ['leaf', 1003],
+					     ['leaf', 1001]]], ['leaf', 1000]]
 <
 							*winline()*
 winline()	The result is a Number, which is the screen line of the cursor
@@ -8264,10 +9230,10 @@ winwidth({nr})						*winwidth()*
 		Examples: >
   :echo "The current window has " . winwidth(0) . " columns."
   :if winwidth(0) <= 50
-  :  exe "normal 50\<C-W>|"
+  :  50 wincmd |
   :endif
-<               For getting the terminal or screen size, see the 'columns'
-               option.
+<		For getting the terminal or screen size, see the 'columns'
+		option.
 
 
 wordcount()						*wordcount()*
@@ -8285,11 +9251,11 @@ wordcount()						*wordcount()*
 			cursor_words    Number of words before cursor position
 					(not in Visual mode)
 			visual_bytes    Number of bytes visually selected
-			                (only in Visual mode)
+					(only in Visual mode)
 			visual_chars    Number of chars visually selected
-			                (only in Visual mode)
-			visual_words    Number of chars visually selected
-			                (only in Visual mode)
+					(only in Visual mode)
+			visual_words    Number of words visually selected
+					(only in Visual mode)
 
 
 							*writefile()*
@@ -8305,8 +9271,17 @@ writefile({list}, {fname} [, {flags}])
 		appended to the file: >
 			:call writefile(["foo"], "event.log", "a")
 			:call writefile(["bar"], "event.log", "a")
->
-<		All NL characters are replaced with a NUL character.
+<
+		When {flags} contains "s" then fsync() is called after writing
+		the file.  This flushes the file to disk, if possible.  This
+		takes more time but avoids losing the file if the system
+		crashes.
+		When {flags} does not contain "S" or "s" then fsync() is
+		called if the 'fsync' option is set.
+		When {flags} contains "S" then fsync() is not called, even
+		when 'fsync' is set.
+
+		All NL characters are replaced with a NUL character.
 		Inserting CR characters needs to be done before passing {list}
 		to writefile().
 		An existing file is overwritten, if possible.
@@ -8336,22 +9311,16 @@ There are four types of features:
     Example: >
 	:if has("gui_running")
 <							*has-patch*
-3.  Included patches.  The "patch123" feature means that patch 123 has been
-    included.  Note that this form does not check the version of Vim, you need
-    to inspect |v:version| for that.
-    Example (checking version 6.2.148 or later): >
-	:if v:version > 602 || v:version == 602 && has("patch148")
-<    Note that it's possible for patch 147 to be omitted even though 148 is
-    included.
-
-4.  Beyond a certain version or at a certain version and including a specific
-    patch.  The "patch-7.4.237" feature means that the Vim version is 7.5 or
-    later, or it is version 7.4 and patch 237 was included.
-    Note that this only works for patch 7.4.237 and later, before that you
-    need to use the example above that checks v:version.  Example: >
+3.  Beyond a certain version or at a certain version and including a specific
+    patch.  The "patch-7.4.248" feature means that the Vim version is 7.5 or
+    later, or it is version 7.4 and patch 248 was included.  Example: >
 	:if has("patch-7.4.248")
-<    Note that it's possible for patch 147 to be omitted even though 148 is
-    included.
+<    Note that it's possible for patch 248 to be omitted even though 249 is
+    included.  Only happens when cherry-picking patches.
+    Note that this form only works for patch 7.4.237 and later, before that
+    you need to check for the patch and the  v:version.  Example (checking
+    version 6.2.148 or later): >
+	:if v:version > 602 || (v:version == 602 && has("patch148"))
 
 Hint: To find out if Vim supports backslashes in a file name (MS-Windows),
 use: `if exists('+shellslash')`
@@ -8363,6 +9332,8 @@ amiga			Amiga version of Vim.
 arabic			Compiled with Arabic support |Arabic|.
 arp			Compiled with ARP support (Amiga).
 autocmd			Compiled with autocommand support. |autocommand|
+autochdir		Compiled with support for 'autochdir'
+autoservername		Automatically enable |clientserver|
 balloon_eval		Compiled with |balloon-eval| support.
 balloon_multiline	GUI supports multiline balloons.
 beos			BeOS version of Vim.
@@ -8436,9 +9407,8 @@ listcmds		Compiled with commands for the buffer list |:files|
 			and the argument list |arglist|.
 localmap		Compiled with local mappings and abbr. |:map-local|
 lua			Compiled with Lua interface |Lua|.
-mac			Any Macintosh version of Vim.
-macunix			Compiled for OS X, with darwin
-osx			Compiled for OS X, with or without darwin
+mac			Any Macintosh version of Vim  cf. osx
+macunix			Synonym for osxdarwin
 menu			Compiled with support for |:menu|.
 mksession		Compiled with support for |:mksession|.
 modify_fname		Compiled with file name modifiers. |filename-modifiers|
@@ -8461,6 +9431,8 @@ netbeans_enabled	Compiled with support for |netbeans| and connected.
 netbeans_intg		Compiled with support for |netbeans|.
 num64			Compiled with 64-bit |Number| support.
 ole			Compiled with OLE automation support for Win32.
+osx			Compiled for macOS  cf. mac
+osxdarwin		Compiled for macOS, with |mac-darwin-feature|
 packages		Compiled with |packages| support.
 path_extra		Compiled with up/downwards search in 'path' and 'tags'
 perl			Compiled with Perl interface.
@@ -8468,8 +9440,12 @@ persistent_undo		Compiled with support for persistent undo history.
 postscript		Compiled with PostScript file printing.
 printer			Compiled with |:hardcopy| support.
 profile			Compiled with |:profile| support.
-python			Compiled with Python 2.x interface. |has-python|
-python3			Compiled with Python 3.x interface. |has-python|
+python			Python 2.x interface available. |has-python|
+python_compiled		Compiled with Python 2.x interface. |has-python|
+python_dynamic		Python 2.x interface is dynamically loaded. |has-python|
+python3			Python 3.x interface available. |has-python|
+python3_compiled	Compiled with Python 3.x interface. |has-python|
+python3_dynamic		Python 3.x interface is dynamically loaded. |has-python|
 pythonx			Compiled with |python_x| interface. |has-pythonx|
 qnx			QNX version of Vim.
 quickfix		Compiled with |quickfix| support.
@@ -8497,6 +9473,7 @@ tag_any_white		Compiled with support for any white characters in tags
 			files |tag-any-white|.
 tcl			Compiled with Tcl interface.
 termguicolors		Compiled with true color in terminal support.
+terminal		Compiled with |terminal| support.
 terminfo		Compiled with terminfo instead of termcap.
 termresponse		Compiled with support for |t_RV| and |v:termresponse|.
 textobjects		Compiled with support for |text-objects|.
@@ -8507,9 +9484,11 @@ title			Compiled with window title support |'title'|.
 toolbar			Compiled with support for |gui-toolbar|.
 ttyin			input is a terminal (tty)
 ttyout			output is a terminal (tty)
-unix			Unix version of Vim.
+unix			Unix version of Vim. *+unix*
 unnamedplus		Compiled with support for "unnamedplus" in 'clipboard'
 user_commands		User-defined commands.
+vcon			Win32: Virtual console support is working, can use
+			'termguicolors'. Also see |+vtp|.
 vertsplit		Compiled with vertically split windows |:vsplit|.
 vim_starting		True while initial source'ing takes place. |startup|
 			*vim_starting*
@@ -8520,13 +9499,16 @@ visualextra		Compiled with extra Visual mode commands.
 			|blockwise-operators|.
 vms			VMS version of Vim.
 vreplace		Compiled with |gR| and |gr| commands.
+vtp			Compiled for vcon support |+vtp| (check vcon to find
+			out if it works in the current console).
 wildignore		Compiled with 'wildignore' option.
 wildmenu		Compiled with 'wildmenu' option.
+win16			old version for MS-Windows 3.1 (always False)
 win32			Win32 version of Vim (MS-Windows 95 and later, 32 or
 			64 bits)
 win32unix		Win32 version of Vim, using Unix files (Cygwin)
 win64			Win64 version of Vim (MS-Windows 64 bit).
-win95			Win32 version for MS-Windows 95/98/ME.
+win95			Win32 version for MS-Windows 95/98/ME (always False)
 winaltkeys		Compiled with 'winaltkeys' option.
 windows			Compiled with support for more than one window.
 writebackup		Compiled with 'writebackup' default on.
@@ -8611,13 +9593,16 @@ See |:verbose-cmd| for more information.
 
 						*E124* *E125* *E853* *E884*
 :fu[nction][!] {name}([arguments]) [range] [abort] [dict] [closure]
-			Define a new function by the name {name}.  The name
-			must be made of alphanumeric characters and '_', and
-			must start with a capital or "s:" (see above).  Note
-			that using "b:" or "g:" is not allowed. (since patch
-			7.4.260 E884 is given if the function name has a colon
-			in the name, e.g. for "foo:bar()".  Before that patch
-			no error was given).
+			Define a new function by the name {name}.  The body of
+			the function follows in the next lines, until the
+			matching |:endfunction|.
+
+			The name must be made of alphanumeric characters and
+			'_', and must start with a capital or "s:" (see
+			above).  Note that using "b:" or "g:" is not allowed.
+			(since patch 7.4.260 E884 is given if the function
+			name has a colon in the name, e.g. for "foo:bar()".
+			Before that patch no error was given).
 
 			{name} can also be a |Dictionary| entry that is a
 			|Funcref|: >
@@ -8633,6 +9618,9 @@ See |:verbose-cmd| for more information.
 			not used an error message is given.  When [!] is used,
 			an existing function is silently replaced.  Unless it
 			is currently being executed, that is an error.
+			NOTE: Use ! wisely.  If used without care it can cause
+			an existing function to be replaced unexpectedly,
+			which is hard to debug.
 
 			For the {arguments} see |function-argument|.
 
@@ -8682,18 +9670,36 @@ See |:verbose-cmd| for more information.
 			implies that the effect of |:nohlsearch| is undone
 			when the function returns.
 
-					*:endf* *:endfunction* *E126* *E193*
-:endf[unction]		The end of a function definition.  Must be on a line
-			by its own, without other commands.
+				*:endf* *:endfunction* *E126* *E193* *W22*
+:endf[unction] [argument]
+			The end of a function definition.  Best is to put it
+			on a line by its own, without [argument].
 
+			[argument] can be:
+				| command	command to execute next
+				\n command	command to execute next
+				" comment	always ignored
+				anything else	ignored, warning given when
+						'verbose' is non-zero
+			The support for a following command was added in Vim
+			8.0.0654, before that any argument was silently
+			ignored.
+
+			To be able to define a function inside an `:execute`
+			command, use line breaks instead of |:bar|: >
+				:exe "func Foo()\necho 'foo'\nendfunc"
+<
 				*:delf* *:delfunction* *E130* *E131* *E933*
-:delf[unction] {name}	Delete function {name}.
+:delf[unction][!] {name}
+			Delete function {name}.
 			{name} can also be a |Dictionary| entry that is a
 			|Funcref|: >
 				:delfunc dict.init
 <			This will remove the "init" entry from "dict".  The
 			function is deleted if there are no more references to
 			it.
+			With the ! there is no error if the function does not
+			exist.
 							*:retu* *:return* *E133*
 :retu[rn] [expr]	Return from a function.  When "[expr]" is given, it is
 			evaluated and returned as the result of the function.
@@ -8732,9 +9738,9 @@ to the number of named arguments.  When using "...", the number of arguments
 may be larger.
 
 It is also possible to define a function without any arguments.  You must
-still supply the () then.  The body of the function follows in the next lines,
-until the matching |:endfunction|.  It is allowed to define another function
-inside a function body.
+still supply the () then.
+
+It is allowed to define another function inside a function body.
 
 							*local-variables*
 Inside a function local variables can be used.  These will disappear when the
@@ -9116,6 +10122,14 @@ This does NOT work: >
 			deleted when the script ends).  Function-local
 			variables are automatically deleted when the function
 			ends.
+
+:unl[et] ${env-name} ...			*:unlet-environment* *:unlet-$*
+			Remove environment variable {env-name}.
+			Can mix {name} and ${env-name} in one :unlet command.
+			No error message is given for a non-existing
+			variable, also without !.
+			If the system does not support deleting an environment
+			variable, it is made emtpy.
 
 :lockv[ar][!] [depth] {name} ...			*:lockvar* *:lockv*
 			Lock the internal variable {name}.  Locking means that
@@ -10576,7 +11590,7 @@ code can be used: >
     redir => scriptnames_output
     silent scriptnames
     redir END
-    
+
     " Split the output into lines and parse each line.	Add an entry to the
     " "scripts" dictionary.
     let scripts = {}
@@ -10613,6 +11627,17 @@ missing: >
 	:  echo "You will _never_ see this message"
 	:endif
 
+To execute a command only when the |+eval| feature is disabled requires a trick,
+as this example shows: >
+
+	silent! while 0
+	  set history=111
+	silent! endwhile
+
+When the |+eval| feature is available the command is skipped because of the
+"while 0".  Without the |+eval| feature the "while 0" is an error, which is
+silently ignored, and the command is executed.
+
 ==============================================================================
 11. The sandbox					*eval-sandbox* *sandbox* *E48*
 
@@ -10625,7 +11650,7 @@ The sandbox is also used for the |:sandbox| command.
 
 These items are not allowed in the sandbox:
 	- changing the buffer text
-	- defining or changing mapping, autocommands, functions, user commands
+	- defining or changing mapping, autocommands, user commands
 	- setting certain options (see |option-summary|)
 	- setting certain v: variables (see |v:var|)  *E794*
 	- executing a shell command
@@ -10647,6 +11672,7 @@ location.  Insecure in this context are:
 - sourcing a .vimrc or .exrc in the current directory
 - while executing in the sandbox
 - value coming from a modeline
+- executing a function that was defined in the sandbox
 
 Note that when in the sandbox and saving an option value and restoring it, the
 option will still be marked as it was set in the sandbox.


### PR DESCRIPTION
For issue #207
eval.txt および eval.jax を Vim 8.1 用に更新しました。
まだ part 1 ですが、もし可能でしたらレビュー始めていただいても結構です。