### PR TITLE
Fix ch_evalraw()

### DIFF
--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -2847,7 +2847,7 @@ ch_evalexpr({handle}, {expr} [, {options}])			*ch_evalexpr()*
 		{|+channel| 機能付きでコンパイルされたときのみ有効}
 
 ch_evalraw({handle}, {string} [, {options}])		*ch_evalraw()*
-		{handle} へ {expr} を送信する。
+		{handle} へ {string} を送信する。
 		{handle} はチャネルもしくはチャネルを持つジョブであっても良い。
 
 		|ch_evalexpr()| と同様に動作する。しかしリクエストをエンコード


### PR DESCRIPTION
ch_evalraw() の説明文に、存在しない引数 "eval" が使われていたので "string" に修正しました。