### PR TITLE
Update eval.{txt,jax}

### DIFF
--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -1967,7 +1967,7 @@ append({lnum}, {text})		数値	{lnum}行目に{text}を付け加える
 appendbufline({expr}, {lnum}, {text})
 				数値	バッファ{expr}の{lnum}行目に{text}を付
 					け加える
-argc( [{winid}])		数値	引数内のファイルの数
+argc([{winid}])			数値	引数内のファイルの数
 argidx()			数値	引数リスト内の現在のインデックス
 arglistid([{winnr} [, {tabnr}]])
 				数値	引数リストID
@@ -2345,7 +2345,7 @@ sha256({string})		文字列	{string}のSHA256チェックサム
 shellescape({string} [, {special}])
 				文字列	{string}をシェルコマンド引数として使う
 					ためにエスケープする。
-shiftwidth()			数値	実際に使用される 'shiftwidth' の値
+shiftwidth([{list}])		数値	実際に使用される 'shiftwidth' の値
 simplify({filename})		文字列	ファイル名を可能なかぎり簡略化する
 sin({expr})			浮動小数点数	{expr} の正弦(サイン)
 sinh({expr})			浮動小数点数	{expr}のハイパボリックサイン
@@ -7409,11 +7409,17 @@ shellescape({string} [, {special}])			*shellescape()*
 <		|::S| も参照のこと。
 
 
-shiftwidth()						*shiftwidth()*
+shiftwidth([{list}])						*shiftwidth()*
 		実際に使用される 'shiftwidth' の値を返す。'shiftwidth' がゼロ
 		以外の場合はその値が返る。ゼロの場合は 'tabstop' の値が返る。
 		この関数は2012年のパッチ 7.3.694 で導入されたので、現在では皆
 		使えるようになっているに違いない。
+
+		引数{list}があるとき、'shiftwidth' の値(実際には桁番号のみが関
+		連する)を返すための位置の |List| として使用される。これは、
+		'vartabstop' 機能のためのものである。{list}引数については、
+		|cursor()| 関数を参照。'vartabstop' 設定が有効で、{list}引数が
+		指定されていない場合、現在のカーソル位置が考慮される。
 
 
 simplify({filename})					*simplify()*

--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -2264,7 +2264,6 @@ perleval({expr})		任意	|Perl|の式を評価する
 pow({x}, {y})			浮動小数点数	{x} の {y} 乗
 prevnonblank({lnum})		数値	{lnum}行目以前の空行でない行の行番号
 printf({fmt}, {expr1}...)	文字列	文字列を組み立てる
-prompt_addtext({buf}, {expr})	なし	プロンプトバッファにテキストを追加する
 prompt_setcallback({buf}, {expr}) なし	プロンプトコールバック関数を設定する
 prompt_setinterrupt({buf}, {text}) なし	プロンプト割り込み関数を設定する
 prompt_setprompt({buf}, {text}) なし	プロンプトテキストを設定する
@@ -2345,7 +2344,7 @@ sha256({string})		文字列	{string}のSHA256チェックサム
 shellescape({string} [, {special}])
 				文字列	{string}をシェルコマンド引数として使う
 					ためにエスケープする。
-shiftwidth([{list}])		数値	実際に使用される 'shiftwidth' の値
+shiftwidth([{col}])		数値	実際に使用される 'shiftwidth' の値
 simplify({filename})		文字列	ファイル名を可能なかぎり簡略化する
 sin({expr})			浮動小数点数	{expr} の正弦(サイン)
 sinh({expr})			浮動小数点数	{expr}のハイパボリックサイン
@@ -7409,18 +7408,17 @@ shellescape({string} [, {special}])			*shellescape()*
 <		|::S| も参照のこと。
 
 
-shiftwidth([{list}])						*shiftwidth()*
+shiftwidth([{col}])						*shiftwidth()*
 		実際に使用される 'shiftwidth' の値を返す。'shiftwidth' がゼロ
 		以外の場合はその値が返る。ゼロの場合は 'tabstop' の値が返る。
 		この関数は2012年のパッチ 7.3.694 で導入されたので、現在では皆
-		使えるようになっているに違いない。
+		使えるようになっているに違いない。(ただし、オプションの引数
+		{col}は 8.1.542 まで使用できない)
 
-		引数{list}があるとき、'shiftwidth' の値(実際には桁番号のみが関
-		連する)を返すための位置の |List| として使用される。これは、
-		'vartabstop' 機能のためのものである。{list}引数については、
-		|cursor()| 関数を参照。'vartabstop' 設定が有効で、{list}引数が
-		指定されていない場合、現在のカーソル位置が考慮される。
-
+		引数{col}があるとき、'shiftwidth' の値を返す桁番号として使用さ
+		れる。これは、'vartabstop' 機能のためのものである。
+		'vartabstop' 設定が有効で、引数{col}が指定されていない場合、列
+		番号1だと仮定される。
 
 simplify({filename})					*simplify()*
 		ファイル名を、意味を変えずにできるだけ簡略化する。MS-Windowsで

--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -7417,7 +7417,7 @@ shiftwidth([{col}])						*shiftwidth()*
 
 		引数{col}があるとき、'shiftwidth' の値を返す桁番号として使用さ
 		れる。これは、'vartabstop' 機能のためのものである。
-		'vartabstop' 設定が有効で、引数{col}が指定されていない場合、列
+		'vartabstop' 設定が有効で、引数{col}が指定されていない場合、桁
 		番号1だと仮定される。
 
 simplify({filename})					*simplify()*

--- a/en/eval.txt
+++ b/en/eval.txt
@@ -2308,7 +2308,6 @@ perleval({expr})		any	evaluate |Perl| expression
 pow({x}, {y})			Float	{x} to the power of {y}
 prevnonblank({lnum})		Number	line nr of non-blank line <= {lnum}
 printf({fmt}, {expr1}...)	String	format text
-prompt_addtext({buf}, {expr})	none	add text to a prompt buffer
 prompt_setcallback({buf}, {expr}) none	set prompt callback function
 prompt_setinterrupt({buf}, {text}) none	set prompt interrupt function
 prompt_setprompt({buf}, {text}) none	set prompt text
@@ -2386,7 +2385,7 @@ sha256({string})		String	SHA256 checksum of {string}
 shellescape({string} [, {special}])
 				String	escape {string} for use as shell
 					command argument
-shiftwidth([{list}])		Number	effective value of 'shiftwidth'
+shiftwidth([{col}])		Number	effective value of 'shiftwidth'
 simplify({filename})		String	simplify filename as much as possible
 sin({expr})			Float	sine of {expr}
 sinh({expr})			Float	hyperbolic sine of {expr}
@@ -7639,19 +7638,17 @@ shellescape({string} [, {special}])			*shellescape()*
 <		See also |::S|.
 
 
-shiftwidth([{list}])						*shiftwidth()*
+shiftwidth([{col}])						*shiftwidth()*
 		Returns the effective value of 'shiftwidth'. This is the
 		'shiftwidth' value unless it is zero, in which case it is the
 		'tabstop' value.  This function was introduced with patch
-		7.3.694 in 2012, everybody should have it by now.
+		7.3.694 in 2012, everybody should have it by now (however it
+		did not allow for the optional {col} argument until 8.1.542).
 
-		When there is one argument {list} this is used as position
-		|List| for which to return the 'shiftwidth' value (actually
-		only the column number is relevant). This matters for the
-		'vartabstop' feature. For the {list} arguments see |cursor()|
-		function. If the 'vartabstop' setting is enabled and no
-		{list} argument is given, the current cursor position is
-		taken into account.
+		When there is one argument {col} this is used as column number
+		for which to return the 'shiftwidth' value. This matters for the
+		'vartabstop' feature. If the 'vartabstop' setting is enabled and
+		no {col} argument is given, column 1 will be assumed.
 
 
 simplify({filename})					*simplify()*

--- a/en/eval.txt
+++ b/en/eval.txt
@@ -2026,7 +2026,7 @@ append({lnum}, {text})		Number	append {text} below line {lnum}
 appendbufline({expr}, {lnum}, {text})
 				Number	append {text} below line {lnum}
 					in buffer {expr}
-argc( [{winid}])		Number	number of files in the argument list
+argc([{winid}])			Number	number of files in the argument list
 argidx()			Number	current index in the argument list
 arglistid([{winnr} [, {tabnr}]]) Number	argument list id
 argv({nr} [, {winid}])		String	{nr} entry of the argument list
@@ -2386,7 +2386,7 @@ sha256({string})		String	SHA256 checksum of {string}
 shellescape({string} [, {special}])
 				String	escape {string} for use as shell
 					command argument
-shiftwidth()			Number	effective value of 'shiftwidth'
+shiftwidth([{list}])		Number	effective value of 'shiftwidth'
 simplify({filename})		String	simplify filename as much as possible
 sin({expr})			Float	sine of {expr}
 sinh({expr})			Float	hyperbolic sine of {expr}
@@ -7639,11 +7639,19 @@ shellescape({string} [, {special}])			*shellescape()*
 <		See also |::S|.
 
 
-shiftwidth()						*shiftwidth()*
+shiftwidth([{list}])						*shiftwidth()*
 		Returns the effective value of 'shiftwidth'. This is the
 		'shiftwidth' value unless it is zero, in which case it is the
 		'tabstop' value.  This function was introduced with patch
 		7.3.694 in 2012, everybody should have it by now.
+
+		When there is one argument {list} this is used as position
+		|List| for which to return the 'shiftwidth' value (actually
+		only the column number is relevant). This matters for the
+		'vartabstop' feature. For the {list} arguments see |cursor()|
+		function. If the 'vartabstop' setting is enabled and no
+		{list} argument is given, the current cursor position is
+		taken into account.
 
 
 simplify({filename})					*simplify()*


### PR DESCRIPTION
本家で指摘されている通り、実際には`shiftwidth()`に引数追加はされていないけど、そのまま取り込みました。