### PR TITLE
Improve "matchgroup" description

### DIFF
--- a/doc/syntax.jax
+++ b/doc/syntax.jax
@@ -3711,9 +3711,10 @@ SYNTAX ISKEYWORD SETTING				*:syn-iskeyword*
 	るハイライトをしたいときに使える。例: >
   :syntax region String matchgroup=Quote start=+"+  skip=+\\"+	end=+"+
 <	こうすると引用符を "Quote" グループでハイライトし、その間にあるテキス
-	トを "String" グループでハイライトすることができる。"matchgroup" はそ
-	れが従うすべての開始・終了パターンに対して使われる。matchgroupを使わな
-	いように戻すには "matchgroup=NONE" を使う。
+	トを "String" グループでハイライトすることができる。
+	"matchgroup" は次の "matchgroup" が現れるまでその後に続くすべての開
+	始・終了パターンに対して使われる。matchgroup を使わないように戻すには
+	"matchgroup=NONE" を使う。
 
 	開始・終了パターンが "matchgroup" でハイライトされるとき、そのリージョ
 	ンに含まれているアイテムは無視される。これによって含まれているアイテム


### PR DESCRIPTION
該当部分の説明がわかりづらかったので私なりに直してみました。ついでに原文に合わせて改行を入れました。
原文は以下です。

	The "matchgroup" is used for all start and end patterns that follow,
	until the next "matchgroup".  Use "matchgroup=NONE" to go back to not
	using a matchgroup.
