### PR TITLE
Add a list description to v:val

### DIFF
--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -2102,9 +2102,9 @@ v:true		数値1。JSONでは "true" として使われる。|json_encode()|を�
 		これは eval() がその文字列をパースしたときに、元の値に戻せるよ
 		うにするためである。読出し専用。
 						*v:val* *val-variable*
-v:val		辞書|Dictionary|の現在の要素の値。|map()|と|filter()|で使わ
-		れる式を評価している最中のみ有効。
-		読出し専用。
+v:val		リスト|List|もしくは辞書|Dictionary|の現在の要素の値。|map()|
+		と|filter()|で使われる式を評価している最中のみ有効。読出し専
+		用。
 
 					*v:version* *version-variable*
 v:version	Vimのバージョン番号。メジャーバージョン番号は100倍され、マイ


### PR DESCRIPTION
v:val の説明が辞書だけになっていたので、本家にあわせてリストと辞書にしました。