### PR TITLE
Revert "Add a tag alias for PmenuSel"

### DIFF
--- a/tools/tag_aliases.vim
+++ b/tools/tag_aliases.vim
@@ -1,4 +1,3 @@
 let g:makehtml_tag_aliases = {
   \ '=~': 'expr-=~',
-  \ 'PmenuSel': 'hl-PmenuSel',
   \ }


### PR DESCRIPTION
Reverts vim-jp/vimdoc-ja-working#606.
This is not needed anymore with the latest help.