### PR TITLE
remove unnecessary "<" from isdirectory()

### DIFF
--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -6051,7 +6051,7 @@ isdirectory({directory})				*isdirectory()*
 		して解釈できるのならば{directory}の表現はどのようなもので
 		あってもかまわない。
 
-<		|method| としても使用できる: >
+		|method| としても使用できる: >
 			GetName()->isdirectory()
 
 isinf({expr})						*isinf()*


### PR DESCRIPTION
isdirectory() の説明に余分な "<" がありました。