### PR TITLE
Fix typo of "haystack" in eval.jax

### DIFF
--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -9017,7 +9017,7 @@ strgetchar({str}, {index})				*strgetchar()*
 			GetText()->strgetchar(5)
 
 stridx({haystack}, {needle} [, {start}])		*stridx()*
-		結果は数値で、{heystack}の中で文字列{needle}が最初に現れる位置
+		結果は数値で、{haystack}の中で文字列{needle}が最初に現れる位置
 		のバイトインデックスを表す。{start}を指定すると、インデックス
 		{start}の位置から検索を開始する。
 		2番目のマッチを探すには次のようにする: >


### PR DESCRIPTION
s/heystack/haystack/ しました。
git grepした結果、ここ以外にはtypoしているところはなさそうでした。また原文にもtypoはありませんでした。