### PR TITLE
Fix translation of TextChangedP

### DIFF
--- a/doc/autocmd.jax
+++ b/doc/autocmd.jax
@@ -1112,10 +1112,10 @@ TextChangedI			挿入モードでカレントバッファのテキストが変�
 				しない。
 				他は TextChanged と同じ。
 							*TextChangedP*
-TextChangedP			挿入モードでカレントバッファのテキストに変更が
-				加えられた後で、ポップアップメニューが表示され
-				ている場合に限られる。そうでなければ
-				TextChanged と同じ。
+TextChangedP			挿入モードでカレントバッファのテキストが変更さ
+				れたとき。ただしポップアップメニューが表示され
+				ている場合に限られる。
+				他は TextChanged と同じ。
 							*TextYankPost*
 TextYankPost			カレントバッファでテキストがヤンクもしくは削除
 				された後。|v:event| の以下の値は、この autocmd


### PR DESCRIPTION
TextChangedPの翻訳を2点修正します。TextChangedIの翻訳は意味が通っているので、そちらに寄せています。


TextChangedIの訳

https://github.com/vim-jp/vimdoc-ja-working/blob/81766c8a60f1fdc10eef1111b1150c8d7885dfdb/doc/autocmd.jax#L1109-L1113


原文



> After a change was made to the text in the
> current buffer in Insert mode, only when the
> popup menu is visible.  Otherwise the same as
> TextChanged.



# 修正点



まず、「挿入モードでカレントバッファのテキストに変更が加えられた後で、ポップアップメニューが表示されている場合に限られる。」となっている翻訳を修正しました。
この「後で、」は原文の文頭の「After」を直訳したものだと思いますが、「変更が加えられた後で、ポップアップメニューが表示されている場合」というのはすこし意味が取りづらいように思えます。
正しくは「変更されたとき。かつポップアップメニューが表示されている場合」なので、それを示すように修正しました。
他の訳を見ても、"After"は「〜されたとき。」という言葉が対応していそうです。




2つ目は、原文の"Otherwise"に「そうでなければ」と訳があてられているのを直しました。
でこの文脈では"Otherwise"は条件に対してではなく、機能に対して修飾をしています。
そのため「他は」と訳すのが適切だと思います。


この翻訳もTextChangedPの直前にあるTextChangedIの翻訳に合わせています。
また、ついでに改行位置もTextChangedIと同じ位置にしています。



