### PR TITLE
eval: Translate has('pythonx')

### DIFF
--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -10500,7 +10500,7 @@ python3_compiled	Python 3.x インターフェイス付きでコンパイルさ�
 			|has-python|
 python3_dynamic		Python 3.x インターフェイスが動的にロードされた。
 			|has-python|
-pythonx			Compiled with |python_x| interface. |has-pythonx|
+pythonx			|python_x| インターフェイスが使用可能。|has-pythonx|
 qnx			QNXバージョン
 quickfix		|quickfix|をサポート
 reltime			|reltime()|をサポート


### PR DESCRIPTION
翻訳が漏れていたので翻訳。
内容は https://github.com/vim/vim/pull/5653 を反映。