### PR TITLE
Update eval.{txt,jax}

### DIFF
--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim バージョン 8.2.  Last change: 2020 Feb 03
+*eval.txt*	For Vim バージョン 8.2.  Last change: 2020 Feb 14
 
 
 		VIMリファレンスマニュアル    by Bram Moolenaar
@@ -2367,6 +2367,7 @@ deletebufline({expr}, {first} [, {last}])
 did_filetype()			数値	FileTypeのautocommandが実行されたか?
 diff_filler({lnum})		数値	差分モードで{lnum}に挿入された行
 diff_hlID({lnum}, {col})	数値	差分モードで{lnum}/{col}位置の強調
+echoraw({expr})			なし	{expr} をそのまま出力する
 empty({expr})			数値	{expr}が空なら|TRUE|
 environ()			辞書	すべての環境変数を返す
 escape({string}, {chars})	文字列	{string}内の{chars}を '\' でエスケープ
@@ -2890,6 +2891,7 @@ win_screenpos({nr})		リスト	ウィンドウ {nr} のスクリーン位置を�
 win_splitmove({nr}, {target} [, {options}])
 				数値	ウィンドウ {nr} を {target} の分割へ移
 					動
+win_gettype([{nr}])		文字列	ウィンドウ{nr}の種別
 winbufnr({nr})			数値	ウィンドウ{nr}のバッファ番号
 wincol()			数値	カーソル位置のウィンドウ桁
 winheight({nr})			数値	ウィンドウ{nr}の高さ
@@ -3893,6 +3895,16 @@ diff_hlID({lnum}, {col})				*diff_hlID()*
 
 		|method| としても使用できる: >
 			GetLnum()->diff_hlID(col)
+
+echoraw({expr})						*echoraw()*
+		{expr}を表示不可能な文字を含み、そのまま出力する。これは端末
+		コードを出力するために使える。例えば、modifyOtherKeysを無効に
+		するためには: >
+			call echoraw(&t_TE)
+<		さらに再度有効にするためには: >
+			call echoraw(&t_TI)
+<		この方法でターミナルを壊すことができるため、気を付けて取り扱う
+		こと
 
 empty({expr})						*empty()*
 		{expr}が空なら1を、そうでなければ0を返す。
@@ -10051,6 +10063,23 @@ win_getid([{win} [, {tab}]])				*win_getid()*
 
 		|method| としても使用できる: >
 			GetWinnr()->win_getid()
+
+
+win_gettype([{nr}])					*win_gettype()*
+		ウィンドウの種別を返す:
+			"popup"		ポップアップウィンドウ |popup|
+			"command"	コマンドラインウィンドウ |cmdwin|
+			(empty)		通常のウィンドウ
+			"unknown"	ウィンドウ{nr}が見付からない
+
+		{nr} を省略した場合は現在のウィンドウの種別を返す。
+		{nr} が与えられた場合はそのウィンドウ番号または |window-ID| の
+		種別を返す。
+
+		'buftype' オプションも参照すること。ポップアップウィンドウ上で
+		ターミナルが起動している場合、'buftype' は "terminal" であり、
+		win_gettype() は "popup" を返す。
+
 
 win_gotoid({expr})					*win_gotoid()*
 		{expr} の ID で示されるウィンドウへ移動する。これは現在のタブ

--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -3904,7 +3904,7 @@ echoraw({expr})						*echoraw()*
 <		さらに再度有効にするためには: >
 			call echoraw(&t_TI)
 <		この方法でターミナルを壊すことができるため、気を付けて取り扱う
-		こと
+		こと。
 
 empty({expr})						*empty()*
 		{expr}が空なら1を、そうでなければ0を返す。
@@ -10138,6 +10138,7 @@ win_splitmove({nr}, {target} [, {options}])		*win_splitmove()*
 		|method| としても使用できる: >
 			GetWinid()->win_splitmove(target)
 <
+
 							*winbufnr()*
 winbufnr({nr})	結果は数値で、{nr}番目のウィンドウに関連付けられているバッファ
 		の番号。{nr} にはウィンドウ番号または|window-ID|が使える。

--- a/en/eval.txt
+++ b/en/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim version 8.2.  Last change: 2020 Feb 03
+*eval.txt*	For Vim version 8.2.  Last change: 2020 Feb 14
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -2414,6 +2414,7 @@ deletebufline({expr}, {first} [, {last}])
 did_filetype()			Number	|TRUE| if FileType autocmd event used
 diff_filler({lnum})		Number	diff filler lines about {lnum}
 diff_hlID({lnum}, {col})	Number	diff highlighting at {lnum}/{col}
+echoraw({expr})			none	output {expr} as-is
 empty({expr})			Number	|TRUE| if {expr} is empty
 environ()			Dict	return environment variables
 escape({string}, {chars})	String	escape {chars} in {string} with '\'
@@ -2899,6 +2900,7 @@ win_id2win({expr})		Number	get window nr from window ID
 win_screenpos({nr})		List	get screen position of window {nr}
 win_splitmove({nr}, {target} [, {options}])
 				Number	move window {nr} to split of {target}
+win_type([{nr}])		String	type of window {nr}
 winbufnr({nr})			Number	buffer number of window {nr}
 wincol()			Number	window column of the cursor
 winheight({nr})			Number	height of window {nr}
@@ -3943,6 +3945,17 @@ diff_hlID({lnum}, {col})				*diff_hlID()*
 
 		Can also be used as a |method|: >
 			GetLnum()->diff_hlID(col)
+
+
+echoraw({expr})						*echoraw()*
+		Output {expr} as-is, including unprintable characters.  This
+		can be used to output a terminal code. For example, to disable
+		modifyOtherKeys: >
+			call echoraw(&t_TE)
+<		and to enable it again: >
+			call echoraw(&t_TI)
+<		Use with care, you can mess up the terminal this way.
+
 
 empty({expr})						*empty()*
 		Return the Number 1 if {expr} is empty, zero otherwise.
@@ -10328,6 +10341,23 @@ win_getid([{win} [, {tab}]])				*win_getid()*
 		Can also be used as a |method|: >
 			GetWinnr()->win_getid()
 
+
+win_gettype([{nr}])					*win_gettype()*
+		Return the type of the window:
+			"popup"		popup window |popup|
+			"command"	command-line window |cmdwin|
+			(empty)		normal window
+			"unknown"	window {nr} not found
+
+		When {nr} is omitted return the type of the current window.
+		When {nr} is given return the type of this window by number or
+		|window-ID|.
+
+		Also see the 'buftype' option.  When running a terminal in a
+		popup window then 'buftype' is "terminal" and win_gettype()
+		returns "popup".
+
+
 win_gotoid({expr})					*win_gotoid()*
 		Go to window with ID {expr}.  This may also change the current
 		tabpage.
@@ -10385,6 +10415,7 @@ win_splitmove({nr}, {target} [, {options}])		*win_splitmove()*
 		Can also be used as a |method|: >
 			GetWinid()->win_splitmove(target)
 <
+
 							*winbufnr()*
 winbufnr({nr})	The result is a Number, which is the number of the buffer
 		associated with window {nr}.  {nr} can be the window number or


### PR DESCRIPTION
* `echoraw()` 関数の追加
  * 生で {expr} を表示するための関数
* `win_getype()` 関数の追加
  * 本家の typo あり(`win_type()` となっている(ref. https://github.com/vim-jp/issues/issues/1321#issuecomment-589038147))
  * window 種別を表示するための関数

英字の間を開けるかどうかが、変更部の前後でもぶれていたので、どちらに合わせるか悩んでいます
```
文中に英数字がある場合には前後に空白を入れる。
例: 文の中に 1 つの English が混ざる。But 句読点の前後は空白なし。
他の翻訳プロジェクトでも空白を入れているところ多し
ただ、空白を入れないほうが書きやすいし読みやすいと感じる
ファイル名やコマンド、コード片などは空白で区切った方が分かりやすいのでは？
```
議論がありつつ前後空白が正でよいのでしょうか?