### PR TITLE
fix typo

### DIFF
--- a/doc/various.jax
+++ b/doc/various.jax
@@ -409,7 +409,7 @@ m  *+mzscheme*		Mzscheme インターフェイス |mzscheme|
 m  *+mzscheme/dyn*	Mzscheme インターフェイス |mzscheme-dynamic| |/dyn|
 m  *+netbeans_intg*	|netbeans|
    *+num64*		64ビットの数値をサポート |Number|
-   			8.2.0217以降は常に有効になっている。実際の数値のサイズ
+   			8.2.0271以降は常に有効になっている。実際の数値のサイズ
 			を確認するにはv:numbersizeを使用すること。
 m  *+ole*		Win32 GUI のみ: |ole-interface|
 N  *+packages*		|packages| の読み込み


### PR DESCRIPTION
原文は

```
Always enabled since 8.2.0271, 
```

でした。はじめて xp しました。