### PR TITLE
Fix popup.jax

### DIFF
--- a/doc/popup.jax
+++ b/doc/popup.jax
@@ -4,7 +4,8 @@
 		  VIMリファレンスマニュアル    by Bram Moolenaar
 
 
-フローティングウィンドウにテキストを表示する。*popup* *popup-window* *popupwin*
+					*popup* *popup-window* *popupwin*
+フローティングウィンドウにテキストを表示する。
 
 
 1. 前書き				|popup-intro|


### PR DESCRIPTION
popupタグが機能していなかったのと、桁数が78を超えていたので該当の行を二行に分けました
参照:https://vim-jp.slack.com/archives/C03C4RC9F/p1590826870495100