### PR TITLE
Fix eval.jax

### DIFF
--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -3885,7 +3885,7 @@ copy({expr})	{expr}のコピーを作る。数値と文字列の場合は、{exp
 		辞書はリストと同様な方法でコピーされる。
 		|deepcopy()|も参照。
 		|method| としても使用できる: >
-			mylist->count(val)
+			mylist->copy()
 
 cos({expr})						*cos()*
 		{expr} の余弦(コサイン)をラジアンで浮動小数点数 |Float| で返す。


### PR DESCRIPTION
eval.jaxに載っている例が正しくないものになっていたので、eval.txtを参考に修正しました。 
eval.txtの該当箇所はこちら↓です。

 https://github.com/vim-jp/vimdoc-ja-working/blob/d662a6de489454af66377b44dd2da59c1c45cf5f/en/eval.txt#L3924

よろしくお願いいたします。