### PR TITLE
ci: use github-pr-check instead of github-pr-review

### DIFF
--- a/.github/actions/vimhelp-nvcheck/entrypoint.sh
+++ b/.github/actions/vimhelp-nvcheck/entrypoint.sh
@@ -4,14 +4,14 @@ cd "$GITHUB_WORKSPACE" || true
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-# find doc -name \*.jax -print0 | xargs -0 nvcheck        \
-#       | reviewdog -f=checkstyle                         \
-#         -name="${INPUT_TOOL_NAME}"                      \
-#         -reporter="${INPUT_REPORTER:-github-pr-review}" \
-#         -filter-mode="${INPUT_FILTER_MODE}"             \
-#         -fail-on-error="${INPUT_FAIL_ON_ERROR}"         \
-#         -level="${INPUT_LEVEL}"                         \
-#         ${INPUT_REVIEWDOG_FLAGS}
+find doc -name \*.jax -print0 | xargs -0 nvcheck        \
+      | reviewdog -efm="%f:%l: %m"                      \
+        -name="${INPUT_TOOL_NAME}"                      \
+        -reporter="${INPUT_REPORTER:-github-pr-review}" \
+        -filter-mode="${INPUT_FILTER_MODE}"             \
+        -fail-on-error="${INPUT_FAIL_ON_ERROR}"         \
+        -level="${INPUT_LEVEL}"                         \
+        ${INPUT_REVIEWDOG_FLAGS}
 
 # github-pr-review only diff adding
 if [ "${INPUT_REPORTER}" = "github-pr-review" ]; then

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,8 +9,31 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: nvcheck-github-pr-review
+      - name: nvcheck-github-pr-check
         uses: ./.github/actions/vimhelp-nvcheck/
         with:
           github_token: ${{ secrets.github_token }}
-          reporter: github-pr-review
+          reporter: github-pr-check
+
+      # on: [push, pull_request]
+      # - name: nvcheck-github-check
+      #   uses: ./.github/actions/vimhelp-nvcheck/
+      #   with:
+      #     github_token: ${{ secrets.github_token }}
+      #     reporter: github-check
+      #
+      # if need mix setting, limit push/pull_request
+      #   if: github.event_name != 'pull_request'
+      #   if: github.event_name == 'pull_request'
+      #
+      # on: pull_request
+      # - name: nvcheck-github-pr-check
+      #   uses: ./.github/actions/vimhelp-nvcheck/
+      #   with:
+      #     github_token: ${{ secrets.github_token }}
+      #     reporter: github-pr-check
+      # - name: nvcheck-github-pr-review
+      #   uses: ./.github/actions/vimhelp-nvcheck/
+      #   with:
+      #     github_token: ${{ secrets.github_token }}
+      #     reporter: github-pr-review


### PR DESCRIPTION
rel #916 

CI動作について:

nvcheckの報告を github-pr-review(トークンの権限がある程度必要)からgithub-pr-check(不要)に変更するPRです。
テストのためのダミーコミットが含まれています。

File changedを参照。

入れるとなった場合

* レビュー(確認)していただく
* ダミーをdropしたものをforce push
* 再確認して入れる

になるかなと考えています。

(see also https://github.com/tsuyoshicho/vimdoc-ja-working/pull/10/files)