### PR TITLE
ci: add lock mutex and update latest

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -30,6 +30,18 @@ jobs:
           vim -eu tools/maketags.vim
 
           cd ..
+      - name: Lock mutex
+        uses: shogo82148/actions-mutex@v1
+        with:
+          key: ${{ github.job }}
+      - name: Update target
+        run: |
+          cd target
+          # update latest
+          git pull --rebase
+          cd ..
+      - name: Install new document
+        run: |
           # install
           rsync -rlptD --delete-after work/doc/ target/doc
           rsync -rlptD --delete-after work/syntax/ target/syntax
@@ -75,6 +87,18 @@ jobs:
           make html
 
           cd ..
+      - name: Lock mutex
+        uses: shogo82148/actions-mutex@v1
+        with:
+          key: ${{ github.job }}
+      - name: Update target
+        run: |
+          cd target
+          # update latest
+          git pull --rebase
+          cd ..
+      - name: Install new document
+        run: |
           # install
           cp work/target/html/doc/*.html target
       - name: Commit updated master branch


### PR DESCRIPTION
## 概要

https://github.com/vim-jp/vimdoc-ja-working/pull/909#issuecomment-835470948

でコメントされているエラーについて調査し、修正を作成しました。

## 原因

問題の原因ですが、根本としては

* GitHub workflow の並列度が高いこと
* マージが複数連続で実施されたこと
* 特に gh-pages は生成に時間がかかること

が重なり、push 先である vimdoc-ja のコミットの状態が clone 時と push 時で差ができ、push失敗したことによります。

## 対策

これに対し、次の対策をするようにしました。

* 変更したファイルを格納する前に、git pull --rebaseするようにした
* 最新への更新 & 変更の格納 & コミットまでをアトミックに操作するための排他処理の導入

排他だけでも対策は不可能ではないけど、ロック時間の短縮と他の操作の可能性を考慮し、軽減策はそのまま入れています

## 参考

* [排他制御を行う GitHub Action を作った](https://shogo82148.github.io/blog/2020/12/30/github-actions-mutex/)