### PR TITLE
ci: nvcheck test fail when error exists.

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
+          level: error
+          fail_on_error: true
 
       # on: [push, pull_request]
       # - name: nvcheck-github-check
@@ -32,6 +34,7 @@ jobs:
       #   with:
       #     github_token: ${{ secrets.github_token }}
       #     reporter: github-pr-check
+      #
       # - name: nvcheck-github-pr-review
       #   uses: ./.github/actions/vimhelp-nvcheck/
       #   with:


### PR DESCRIPTION
CIに入れている nvcheck のテストについて、いままでエラー時のテストでもテストとしてはpassになるため

* マージの阻害設定が意味をなしてなかった
* エラーについて見落しやすかった

となっていました。

これを修正します。
(問題は問題として認識はしていましたが、修正するに適切な方法がわかってなかった部分があり当座はあの状態でした...)

参考PR https://github.com/vim-jp/vimdoc-ja-working/pull/921