### PR TITLE
fix: eval.jax: translate miss

### DIFF
--- a/doc/eval.jax
+++ b/doc/eval.jax
@@ -6150,14 +6150,15 @@ getwininfo([{winid}])					*getwininfo()*
 			bufnr		ウィンドウ内のバッファ番号
 			height		ウィンドウの高さ (winbarを除く)
 			loclist		locationリストを表示してる場合は1
-					{Vimが|+quickfix|機能付きでコンパイルさ
-					れたときのみ有効}
+					{Vimが|+quickfix|機能付きでコンパイル
+					されたときのみ有効}
 			quickfix	quickfixまたはlocationリストウィンドウ
 					の場合は1
-					{Vimが|+quickfix|機能付きでコンパイルさ
-					れたときのみ有効}
+					{Vimが|+quickfix|機能付きでコンパイル
+					されたときのみ有効}
 			terminal	端末ウィンドウの場合は 1
-					{only with the +terminal feature}
+					{Vimが|+terminal|機能付きでコンパイル
+					されたときのみ有効}
 			tabnr		タブページ番号
 			topline		最上に表示されたバッファ行
 			variables	ウィンドウローカル変数の辞書への参照


### PR DESCRIPTION
未訳だったと思われる部分の修正と、あわせてフォーマット調整