### PR TITLE
ci: Update report settings

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -32,5 +32,5 @@ jobs:
         with:
           title: Weekly help diff
           content-filepath: ./doc_info.md
-            # next change, use previous issue number
-            # issue-number: <target issue>
+          issue-number: 968
+            # issue-number: if removed, create new issue/if define issue num, update numbered issue.


### PR DESCRIPTION
恒常的に固定issueを使うように変更します。

もしissueを変更する場合は、一度 

```yaml
issue-number: 
```

を除外することで、更新動作が止り、新規に作られます。