### PR TITLE
ci: need quote for GHA schedule

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,7 +1,7 @@
 name: Weekly report
 on:
   schedule:
-    - cron: 30 15 * * SAT
+    - cron: '30 15 * * SAT'
   workflow_dispatch:
 permissions:
   issues: write


### PR DESCRIPTION
すいません、GitHub workflowでのscheduleはクォート必須でした...

( `*` が特殊文字のため)
https://docs.github.com/ja/actions/learn-github-actions/events-that-trigger-workflows#schedule