### PR TITLE
ci: fix mutex and pull strategy

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
 
+concurrency: vimdoc-ja-deploy
+  # global concurrency limit access to vim-jp/vimdoc-ja per workflow
+
 jobs:
   generate:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -30,10 +30,6 @@ jobs:
           vim -eu tools/maketags.vim
 
           cd ..
-      - name: Lock mutex
-        uses: shogo82148/actions-mutex@v1
-        with:
-          key: ${{ github.job }}
       - name: Update target
         run: |
           cd target
@@ -56,10 +52,14 @@ jobs:
 
             https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           branch: master
-          pull_strategy: 'NO-PULL'
+          pull: 'NO-PULL'
 
   deploy:
     runs-on: ubuntu-latest
+    needs: generate
+      # "deploy" update vimdoc-ja/gh-pages branch
+      # work after "generate" to updated vimdoc-ja/master branch
+      # parallel work conflict vimdoc-ja repo status
     steps:
       - name: checkout master
         uses: actions/checkout@v2
@@ -84,10 +84,6 @@ jobs:
           make html
 
           cd ..
-      - name: Lock mutex
-        uses: shogo82148/actions-mutex@v1
-        with:
-          key: ${{ github.job }}
       - name: Update target
         run: |
           cd target
@@ -108,4 +104,4 @@ jobs:
 
             https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           branch: gh-pages
-          pull_strategy: 'NO-PULL'
+          pull: 'NO-PULL'


### PR DESCRIPTION
fix #993 
fix #994

元の #918 にありますが、masterへのファイルデプロイとgh-pagesへのページ生成デプロイが併走することによる対策としてmutexを入れていました。

mutexは除去し、concurrent制御と、並列jobを直列化しています。
これでvimdoc-jaへのアクセスはつねに1つだけが行うことになり問題は出なくなる(予定)です。

pull_strategyについては、推奨にそってpullへ改訂しています。
(不要になるか考えてみましたが、たしか、素で動くだけでも他repoだとNGだった覚えがあるので、現状はまだあったほうがいいかなと)

手元での動確が(tokenではなくなったので)ちょっとできていませんが...