### PR TITLE
update Go version for nvcheck building stability

### DIFF
--- a/.github/actions/vimhelp-nvcheck/Dockerfile
+++ b/.github/actions/vimhelp-nvcheck/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.6-alpine
+FROM golang:1.18.5-alpine3.16
 
 ENV REVIEWDOG_VERSION=v0.14.1
 
@@ -7,7 +7,7 @@ RUN apk --no-cache add git
 
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 
-RUN go get github.com/koron/nvcheck
+RUN go install github.com/koron/nvcheck@latest
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
nvcheckのbuildがgopkg.inのせいで不安定なのを解消する試み。

Go 1.15がgopkg.inにアクセスした際、gopkg.inがgithub.comにアクセスに行ってそこでrejectされてるっぽい。
(アクセス制限かトークンの利用上限に引っかかってるのかもしれない。それ以上は調べられない)

ただ最新のGoはパッケージの取得にgopkg.inに直接リクエストするわけではなくキャッシュサーバーに問い合わせるはずで、
かつ対象が yaml.v2 という有名なモジュールなのでキャッシュミスは確率が低い。

なのでGoが1.15と古いこと
および取得方法が `go install ...@latest` ではなく `go get` の古い方法であること
が上記のトリガーであると推定し、
それを検証するためGoを1.18にし `go install ...@latest` で取得するように変更してみた。