### PR TITLE
Remove unnecessary white-space at the head of line

### DIFF
--- a/doc/builtin.jax
+++ b/doc/builtin.jax
@@ -7315,7 +7315,7 @@ setcellwidths({list})					*setcellwidths()*
 <		既知の絵文字への効果を確認するのに
 		$VIMRUNTIME/tools/emoji_list.vim スクリプトが使える。
 
- setcharpos({expr}, {list})				*setcharpos()*
+setcharpos({expr}, {list})				*setcharpos()*
 		|setpos()| と同様だが指定に使う桁番号はその行のバイトインデッ
 		クスの代わりに文字インデックスである。
 


### PR DESCRIPTION
他で関数名の前に空白があるものが見当たらなかったので、setcharpos()の前にあった空白を削除しました。