### PR TITLE
Translate an english line in popup.jax

### DIFF
--- a/doc/popup.jax
+++ b/doc/popup.jax
@@ -758,7 +758,7 @@ popup_create() に渡す。
 			      ロールしてこの行を表示する( 'wrap' がオフの場合
 			      のみ適切に機能する)。
 			0:    カーソル行をハイライトしない。
-			Default is zero, except for |popup_menu()|.
+			|popup_menu()| を除いて、デフォルトは0である。
 	filter		入力した文字をフィルタ処理できるコールバック。
 			|popup-filter| を参照。
 	mapping		キーマッピングを許可する。FALSEで、かつポップアップが


### PR DESCRIPTION
popup.jax の `popup_create-arguments` 中の `cursorline` の項に英語のまま残っている部分があったので翻訳しました。
#968 に popup.txt の名前が見当たらなかったので、翻訳漏れかなーと思います。
また、en/popup.txt の方については、既に同じ文が en/popup.txt に存在したことと #968 に popup.txt の名前がなかったことから、何もさわらなくて良いと判断したのですが、もし何か変更を加えた方が良い部分があれば教えてください。
https://github.com/vim-jp/vimdoc-ja-working/blob/64a8fdf212be06619e63d571d53253447f3fdc1f/en/popup.txt#L769