### PR TITLE
fix map.jax

### DIFF
--- a/doc/map.jax
+++ b/doc/map.jax
@@ -75,8 +75,8 @@
 :ln[oremap] {lhs} {rhs}		|mapmode-l|	*:ln*  *:lnoremap*
 :cno[remap] {lhs} {rhs}		|mapmode-c|	*:cno* *:cnor* *:cnoremap*
 :tno[remap] {lhs} {rhs}		|mapmode-t|	*:tno* *:tnoremap*
-			キー入力 {lhs} を {rhs} に割り当てます。作成したマッ
-			プ、はマップコマンドに対応したモードで使用できます。
+			キー入力 {lhs} を {rhs} に割り当てます。作成したマップ
+			は、マップコマンドに対応したモードで使用できます。
 			{rhs} は再マップされないので、マップが入れ子になったり
 			再帰的になることはありません。コマンドを再定義するとき
 			によく使われます。


### PR DESCRIPTION
`:noremap`系の説明の読点の位置が間違っていると思われたため、すぐ上の`:map`系の説明に合わせて修正しました

`マップ、は` → `マップは、`