### PR TITLE
Stop using katakana for file types. (Close #1142)

### DIFF
--- a/doc/filetype.jax
+++ b/doc/filetype.jax
@@ -426,7 +426,7 @@ AWK							*ft-awk-plugin*
 	let g:awk_is_gawk = 1
 
 
-チェンジログ(CHANGELOG)					*ft-changelog-plugin*
+CHANGELOG						*ft-changelog-plugin*
 
 {訳注: エントリ=日付ごとの区切り アイテム=日付内の項目}
 
@@ -533,7 +533,7 @@ b:changelog_entry_prefix
 ムを加える。なければ新しいエントリとアイテムをファイルの先頭に加える。
 
 
-フォートラン(FORTRAN)					*ft-fortran-plugin*
+FORTRAN							*ft-fortran-plugin*
 
 オプション:
 'expandtab'	.vimrcでfortran_have_tabsが指定されなければ、フォートラン標準
@@ -580,7 +580,7 @@ gprof ファイルタイププラグインは gprof のフラットプロファ�
 	let g:no_gprof_maps = 1
 
 
-メール(MAIL)						*ft-mail-plugin*
+MAIL							*ft-mail-plugin*
 
 オプション:
 'modeline'	トロイの木馬の危険を避けるのと、「件名」に含まれる "Vim:" がエ
@@ -672,7 +672,6 @@ MARKDOWN                                                *ft-markdown-plugin*
 折り畳みを有効にするには、次のようにする: >
 	let g:markdown_folding = 1
 <
-
 
 PDF							*ft-pdf-plugin*
 


### PR DESCRIPTION
旧L676の空行削除は意図したものです。(.txt にはなかったので削除)