### PR TITLE
fix: report workflow

### DIFF
--- a/tools/script/get_doc_info.sh
+++ b/tools/script/get_doc_info.sh
@@ -1,12 +1,16 @@
 #! /bin/bash
 #
-# ローカルの vimdoc-ja-working/en/*.txt と vim/runtime/doc/*.txt を比較して
+# vimdoc-ja-working/en/*.txt(old) と vim/runtime/doc/*.txt(new) を比較して
 # 変更行数情報をMarkdownのtable形式でファイルに出力する。
 #
-# 2018-05-31 h_east
+# 2018-05-31 h_east       : Create initial file.
+# 2022-10-02 Tsuyoshi CHO : Update comment and some settings.
 
-# 自分の環境にあわせて変更する必要がある
+# ローカルに利用する場合は自分の環境にあわせて変更する必要がある
+# リポジトリには GitHub workflow で利用する設定で格納する
+# GitHub workflow では vim/vim は ${GITHUB_WORKSPACE}/vim へ clone している
 new_doc_dir=${GITHUB_WORKSPACE}/vim/runtime/doc
+# GitHub workflow では vim-jp/vimdoc-ja-working は ${GITHUB_WORKSPACE}/work へ clone している
 old_doc_dir=${GITHUB_WORKSPACE}/work/en
 
 # 出力ファイル名

--- a/tools/script/get_doc_info.sh
+++ b/tools/script/get_doc_info.sh
@@ -7,7 +7,7 @@
 
 # 自分の環境にあわせて変更する必要がある
 new_doc_dir=${GITHUB_WORKSPACE}/vim/runtime/doc
-old_doc_dir=${GITHUB_WORKSPACE}/vimdoc-ja-working/en
+old_doc_dir=${GITHUB_WORKSPACE}/work/vimdoc-ja-working/en
 
 # 出力ファイル名
 outf=doc_info.md

--- a/tools/script/get_doc_info.sh
+++ b/tools/script/get_doc_info.sh
@@ -7,7 +7,7 @@
 
 # 自分の環境にあわせて変更する必要がある
 new_doc_dir=${GITHUB_WORKSPACE}/vim/runtime/doc
-old_doc_dir=${GITHUB_WORKSPACE}/work/vimdoc-ja-working/en
+old_doc_dir=${GITHUB_WORKSPACE}/work/en
 
 # 出力ファイル名
 outf=doc_info.md


### PR DESCRIPTION
close #1147

差分レポートを修正

<del>いままで、デフォルトで clone されている内容から差分を生成していた。
おそらくデフォルトの clone がされなくなったために失敗するようになった。</del>
#1134 での変更で対象が上手く選択できなくなった。

workflow で clone している work 以下を正しく利用するように変更

---
step: Checkout vimdoc-ja-working にて

https://github.com/vim-jp/vimdoc-ja-working/actions/runs/3165169613
> Run actions/checkout@v2
>  with:
>   path: work
>   repository: vim-jp/vimdoc-ja-working

> /usr/bin/git config --global --add safe.directory /home/runner/work/vimdoc-ja-working/vimdoc-ja-working/work

なのに

step: Build report の get_doc_info.sh
での定義が

> old_doc_dir=${GITHUB_WORKSPACE}/vimdoc-ja-working/en

これにより

> ls: cannot access '/home/runner/work/vimdoc-ja-working/vimdoc-ja-working/vimdoc-ja-working/en/*.txt': No such file or directory

という失敗
