### PR TITLE
fix: example block in builtin.jax

### DIFF
--- a/doc/builtin.jax
+++ b/doc/builtin.jax
@@ -9113,7 +9113,7 @@ trim({text} [, {mask} [, {dir}]])				*trim()*
 			echo trim("  \r\t\t\r RESERVE \t\n\x0B\xA0") .. "_TAIL"
 <		"RESERVE_TAIL" を返す >
 			echo trim("rm<Xrm<>X>rrm", "rm<>")
-<		"Xrm<>X" を返す (中央部分の文字は取り除かれない)
+<		"Xrm<>X" を返す (中央部分の文字は取り除かれない) >
 			echo trim("  vim  ", " ", 2)
 <		"  vim" を返す
 


### PR DESCRIPTION
Example ブロック開始タグの不足。