### PR TITLE
fix builtin.jax

### DIFF
--- a/doc/builtin.jax
+++ b/doc/builtin.jax
@@ -9243,7 +9243,7 @@ uniq({list} [, {func} [, {dict}]])			*uniq()* *E882*
 
 values({dict})						*values()*
 		{dict}の全ての値からなるリスト|List|を返す。このリストの順序は
-		不定である。|items()| と |values()| も参照。
+		不定である。|items()| と |keys()| も参照。
 
 		|method| としても使用できる: >
 			mydict->values()


### PR DESCRIPTION
`values()`の説明に`values()`自身へのリンクが含まれていました
英語版が`Also see |items()| and |keys()|.`となっているのに合わせて修正しました