### PR TITLE
Fix untranslated lines

### DIFF
--- a/doc/builtin.jax
+++ b/doc/builtin.jax
@@ -9428,7 +9428,7 @@ win_move_statusline({nr}, {offset})			*win_move_statusline()*
 		して)。ウィンドウを見付ければ戻り値が TRUE になり、そうでない
 		なら FALSE になる。
 
-		Can also be used as a |method|: >
+		|method| としても使用できる: >
 			GetWinnr()->win_move_statusline(offset)
 
 win_screenpos({nr})					*win_screenpos()*

--- a/doc/channel.jax
+++ b/doc/channel.jax
@@ -575,7 +575,7 @@ ch_getjob({channel})						*ch_getjob()*
 		もしジョブが無い場合、戻り値の Job で |job_status()| を呼び出
 		すと "fail" が返される。
 
-		Can also be used as a |method|: >
+		|method| としても使用できる: >
 			GetChannel()->ch_getjob()
 
 


### PR DESCRIPTION
関数のメソッド記法についての文が原文のままになっていたので修正しました。