### PR TITLE
ci: maintenance update

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -24,7 +24,7 @@ jobs:
           repo: reviewdog/reviewdog
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           author: 'github-actions <41898282+github-actions[bot]@users.noreply.github.com>'


### PR DESCRIPTION
CIでのactionの更新を行います。
移行措置が必要なものはありませんでした。

- https://github.com/actions/checkout
- https://github.com/peter-evans/create-pull-request/blob/main/docs/updating.md