### PR TITLE
update vim 9 for build

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Vim
         uses: thinca/action-setup-vim@v1
         with:
-          vim_version: 'v8.2.0020'
+          vim_version: 'v9.0.0814'
           vim_type: 'Vim'
       - name: Generate new document
         run: |
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Vim
         uses: thinca/action-setup-vim@v1
         with:
-          vim_version: 'v8.2.0020'
+          vim_version: 'v9.0.0814'
           vim_type: 'Vim'
       - name: Generate new document
         run: |

--- a/.github/workflows/tag-generate.yml
+++ b/.github/workflows/tag-generate.yml
@@ -1,0 +1,32 @@
+name: "Generate tag for check"
+on: [push, pull_request]
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Vim
+        uses: thinca/action-setup-vim@v1
+        with:
+          vim_version: 'v9.0.0814'
+          vim_type: 'Vim'
+
+      - name: Create tags
+        run: |
+          vim -eu tools/maketags.vim
+
+      - name: Rename for artifact/archive
+        run: |
+          mv -f README.md README-working.md
+          mv -f README-dist.md README.md
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: vimdoc-ja
+          path: |
+            doc/
+            syntax/
+            README.md


### PR DESCRIPTION
fix https://github.com/vim-jp/vimdoc-ja-working/issues/1287

ビルドに使うVimをいったん9.0.0814にしました。このバージョンは単に私のローカルに入ってるもので、追試が必要な時にローカルでできるから、ということにすぎません。いつでも任意のバージョンに変更してください。

タグをビルドするだけのワークフロー tag-generate.yml を追加しました。ワークフローgenerateがmasterブランチでしか機能しないので、このPRのようなビルドシステム自体の変更がCIでチェックされないことに対応するものです。このワークフローでは生成物をartifactとしているので、それをGHAからもダウンロードできるようになります。 cf. https://github.com/vim-jp/vimdoc-ja-working/actions/runs/5628556213

---

Vim9への更新に伴い、HTMLを生成するなどのチェックも必要なので、どうようにワークフローを追加するなどした方が良いです。

加えて、分離したワークフローの生成物を再利用することで、重複した作業をしないようにする改良が考えられます。しかしそれはこのPRのスコープではありません。