### PR TITLE
fix builtin.jax

### DIFF
--- a/doc/builtin.jax
+++ b/doc/builtin.jax
@@ -9865,7 +9865,7 @@ tr({src}, {fromstr}, {tostr})				*tr()*
 <		戻り値は "{blob}" となる。
 
 		|method| としても使用できる: >
-			GetText()->toupper()
+			GetText()->tr(from, to)
 
 trim({text} [, {mask} [, {dir}]])				*trim()*
 		{text} の先頭と/もしくは末尾から、{mask} 内のすべての文字を取


### PR DESCRIPTION
`tr()`のmethod例が`toupper()`になっていたため、英語版に合わせて修正しました