### PR TITLE
Update filetype.{txt,jax}

### DIFF
--- a/doc/filetype.jax
+++ b/doc/filetype.jax
@@ -1,4 +1,4 @@
-*filetype.txt*  For Vim バージョン 9.0.  Last change: 2023 Sep 11
+*filetype.txt*  For Vim バージョン 9.0.  Last change: 2023 Dec 05
 
 
 		VIMリファレンスマニュアル    by Bram Moolenaar
@@ -555,14 +555,15 @@ b:changelog_entry_prefix
 FORTRAN							*ft-fortran-plugin*
 
 オプション:
-'expandtab'	.vimrcでfortran_have_tabsが指定されなければ、フォートラン標準
+'expandtab'	.vimrc で fortran_have_tabs が指定されなければ、Fortran 標準
 		に従ってタブ文字を避けるために有効にする。
-'textwidth'	フォートラン標準に従って固定形式のソースでは72に、自由形式の
-		ソースでは80に設定される。
+'textwidth'	Fortran 標準に従って固定形式のソースでは 80 に、自由形式のソー
+		スでは 132 に設定される。fortran_extended_line_length 変数を設
+		定すると、固定形式のソースでは幅が 132 に増加する。
 'formatoptions' コードとコメントを分けて、長い行を保持するように設定される。
-		これにより|gq|でコメントを整形できる。
-fortran_have_tabsについての議論とソース形式の判定法については
-|ft-fortran-syntax|を参照。
+		これにより |gq| でコメントを整形できる。
+fortran_have_tabs についての議論とソース形式の判定法については
+|ft-fortran-syntax| を参照。
 
 
 FREEBASIC						*ft-freebasic-plugin*

--- a/en/filetype.txt
+++ b/en/filetype.txt
@@ -1,4 +1,4 @@
-*filetype.txt*  For Vim version 9.0.  Last change: 2023 Sep 11
+*filetype.txt*  For Vim version 9.0.  Last change: 2023 Dec 05
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -567,8 +567,9 @@ FORTRAN							*ft-fortran-plugin*
 Options:
 'expandtab'	is switched on to avoid tabs as required by the Fortran
 		standards unless the user has set fortran_have_tabs in .vimrc.
-'textwidth'	is set to 72 for fixed source format as required by the
-		Fortran standards and to 80 for free source format.
+'textwidth'	is set to 80 for fixed source format whereas it is set to 132
+		for free source format. Setting the fortran_extended_line_length
+		variable increases the width to 132 for fixed source format.
 'formatoptions' is set to break code and comment lines and to preserve long
 		lines.  You can format comments with |gq|.
 For further discussion of fortran_have_tabs and the method used for the


### PR DESCRIPTION
今回以外の以下の修正も併せて実施。
- 言語名 `Fortran` は日本語でもそのまま表記。
- 半角と全角にスペースを入れた。