### PR TITLE
remove invalid code

### DIFF
--- a/doc/builtin.jax
+++ b/doc/builtin.jax
@@ -3694,9 +3694,6 @@ getfontname([{name}])					*getfontname()*
 		Note GTKのGUIはどんなフォント名でも受け付けてしまうため、名前
 		が有効であるかのチェックは機能しない。
 
-		|method| としても使用できる: >
-			mydict->has_key(key)
-
 getfperm({fname})					*getfperm()*
 		{fname}で指定されたファイルの読み込み、書き込み、実行の許可属
 		性を示す文字列を返す。


### PR DESCRIPTION
This deleted code is for getenv() not for getfontname().