### PR TITLE
Update channel.jax

### DIFF
--- a/doc/channel.jax
+++ b/doc/channel.jax
@@ -75,7 +75,7 @@ $VIMRUNTIME/tools/demoserver.py
 T1 の中に次のように表示されます:
 	=== socket opened === ~
 
-ついにサーバーにメッセージを送信できます: >
+これでサーバーにメッセージを送信できます: >
 	echo ch_evalexpr(channel, 'hello!')
 
 このメッセージは T1 で受信され、Vim には応答が送り返されます。


### PR DESCRIPTION
チャネルのデモ説明の「ついにサーバーにメッセージを送信できます」ですが、「ついに」より「これで」の方が、意味が近いと思いました。
※「ついに」だと、それまでに数多くの手順があるように見えます。しかし、前段に１－２手順しかないため、違和感を感じました。

```
デモには Python が必要です。デモプログラムは次の場所にあります。
$VIMRUNTIME/tools/demoserver.py
それをあるターミナルで実行しましょう。そのターミナルを T1 と呼びます。

次に別のターミナルでVimを実行します。そして以下のコマンドでサーバーに接続しま
す:
        let channel = ch_open('localhost:8765')

T1 の中に次のように表示されます:
        === socket opened ===

ついにサーバーにメッセージを送信できます:
        echo ch_evalexpr(channel, 'hello!')
```

「これで」に変更しましたので、確認いただけると幸いです。