### PR TITLE
Update autocmd.{txt,jax}

### DIFF
--- a/doc/autocmd.jax
+++ b/doc/autocmd.jax
@@ -1,4 +1,4 @@
-*autocmd.txt*   For Vim バージョン 9.1.  Last change: 2023 May 20
+*autocmd.txt*   For Vim バージョン 9.1.  Last change: 2024 Jan 14
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar
@@ -343,7 +343,8 @@ Vimは以下のイベントを認識する。イベント名が大文字か小�
 |VimEnter|		全ての起動処理が終わった後
 |GUIEnter|		GUIの起動が成功した後
 |GUIFailed|		GUIの起動が失敗した後
-|TermResponse|		|t_RV|に対する端末の反応を受け取った後
+|TermResponse|		|t_RV| に対する端末の反応を受け取った後
+|TermResponseAll|	|t_RV| および他の端末応答を受信した後
 
 |QuitPre|		`:quit` を使ったとき、本当に終了するか決定する前
 |ExitPre|		Vimを終了するコマンドを使ったとき
@@ -1204,6 +1205,24 @@ TermResponse			|t_RV| に対する応答をターミナルから受け取った
 				Note: このイベントは他のイベントの処理中にも発
 				行されることがある。特に、ファイル入出力、シェ
 				ルコマンドの実行、時間の掛かる処理など。
+							*TermResponseAll*
+TermResponseAll			|t_RV|, |t_RC|, |t_RS|, |t_RB|, |t_RF|, または
+				|t_u7| に対する応答をターミナルから受信した後。
+				|v:termresponse|, |v:termblinkresp|,
+				|v:termstyleresp|, |v:termrbgresp|,
+				|v:termrfgresp|, および |v:termu7resp| の値を
+				それぞれ使用できる。<amatch> は次のいずれかに
+				設定される。
+				    "version",
+				    "cursorblink",
+				    "cursorshape",
+				    "background",
+				    "foreground",
+				    "ambiguouswidth"
+				Note このイベントは、特にファイル I/O、シェル
+				コマンド、またはその他の時間の掛かるものが関係
+				する場合、別のイベントの実行途中でトリガーされ
+				る可能性があることに注意。
 							*TextChanged*
 TextChanged			ノーマルモードでカレントバッファのテキストが変
 				更されたとき。つまり |b:changedtick| が更新さ

--- a/en/autocmd.txt
+++ b/en/autocmd.txt
@@ -1,4 +1,4 @@
-*autocmd.txt*   For Vim version 9.1.  Last change: 2023 May 20
+*autocmd.txt*   For Vim version 9.1.  Last change: 2024 Jan 14
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -340,6 +340,7 @@ Name			triggered by ~
 |GUIEnter|		after starting the GUI successfully
 |GUIFailed|		after starting the GUI failed
 |TermResponse|		after the terminal response to |t_RV| is received
+|TermResponseAll|	after the terminal response to |t_RV| and others is received
 
 |QuitPre|		when using `:quit`, before deciding whether to exit
 |ExitPre|		when using a command that may make Vim exit
@@ -1220,6 +1221,24 @@ TermResponse			After the response to |t_RV| is received from
 				triggered halfway executing another event,
 				especially if file I/O, a shell command or
 				anything else that takes time is involved.
+							*TermResponseAll*
+TermResponseAll			After the response to |t_RV|, |t_RC|, |t_RS|,
+				|t_RB|, |t_RF|, or |t_u7| are received from
+				the terminal.  The value of |v:termresponse|,
+				|v:termblinkresp|, |v:termstyleresp|,
+				|v:termrbgresp|, |v:termrfgresp|, and
+				|v:termu7resp|, correspondingly, can be used.
+				<amatch> will be set to any of:
+				    "version",
+				    "cursorblink",
+				    "cursorshape",
+				    "background",
+				    "foreground",
+				    "ambiguouswidth"
+				Note that this event may be triggered halfway
+				executing another event, especially if file I/O,
+				a shell command or anything else that takes time
+				is involved.
 							*TextChanged*
 TextChanged			After a change was made to the text in the
 				current buffer in Normal mode.  That is after


### PR DESCRIPTION
`the terminal` の訳は`TermResponse`で「ターミナル」になっているので、それを踏襲しました。
(「端末」に統一した方がいい気がした)