### PR TITLE
Fix helptag having wrong highlight-ID

### DIFF
--- a/doc/builtin.jax
+++ b/doc/builtin.jax
@@ -9682,8 +9682,7 @@ tanh({expr})						*tanh()*
 			Compute()->tanh()
 
 
-						*tempname()* *temp-file-name*
-tempname()
+tempname()					*tempname()* *temp-file-name*
 		結果は文字列で、存在しないファイルのファイル名を示す。これはテ
 		ンポラリファイルの名前として使用可能である。少なくとも連続26回
 		の呼出しまでは違う名前を生成することが保証される。例: >
@@ -9911,7 +9910,7 @@ trunc({expr})							*trunc()*
 
 		|method| としても使用できる: >
 			Compute()->trunc()
-
+<
 							*type()*
 type({expr})	{expr}の型を示す数値を返す。
 		マジックナンバーを使わずに、v:t_ 変数を使う方が良い。それぞれ


### PR DESCRIPTION
いくつかのhelpタグ名のhighlightが誤ってhighlight ID項目名 `helpExample` になっているのを修正。
(Vim 9.0.0110 以降だと、それらが `:helptags` で tags-ja に収録されない)

※オリジナル(.txt)では正しいが、.jax だけ間違えていたので、対象は .jax のみです。