### PR TITLE
Update Vim version that generates helptags to 9.1.0065.

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Vim
         uses: thinca/action-setup-vim@v1
         with:
-          vim_version: 'v8.2.0020'
+          vim_version: 'v9.1.0065'
           vim_type: 'Vim'
       - name: Generate new document
         run: |
@@ -88,7 +88,7 @@ jobs:
       - name: Setup Vim
         uses: thinca/action-setup-vim@v1
         with:
-          vim_version: 'v8.2.0020'
+          vim_version: 'v9.1.0065'
           vim_type: 'Vim'
       - name: Generate new document
         run: |


### PR DESCRIPTION
Related: #1206, #1432, vim-jp/vimdoc-ja/issues/279
Close: #1287, #1288 

今までhelptagsの生成に使用していたVimが 8.2.0020。
9.0.0110以降からhelpファイルの例中のタグを除外するようになったので、9.1.0065 に更新します。
ローカルで確認済み。