### PR TITLE
Update quickfix.{txt,jax}

### DIFF
--- a/doc/quickfix.jax
+++ b/doc/quickfix.jax
@@ -345,11 +345,24 @@ locationリストが |autocommand| に変更される場合、それは中断さ
 			ターンは、エントリのファイル名、モジュール名、パターン
 			およびテキストと照合される。
 
+:cl[ist] +{count}	カレントと次の {count} 個の有効なエラーをリストする。
+			これは ":clist from from+count" に似ており、"from" は
+			現在のエラー位置である。
+
 :cl[ist]! [from] [, [to]]
 			全てのエラーを表示する。
 
-							*:lli* *:llist*
-:lli[st] [from] [, [to]]
+:cl[ist]! +{count}	カレントと次の {count} 個のエラー行をリストする。これ
+			は、カレント行の後にある認識されていない行を確認するの
+			に役立つ。例えば、":clist" が次のように表示される場合:
+        8384 testje.java:252: error: cannot find symbol ~
+			そして ":cl！+3" を使うと理由が表示される:
+        8384 testje.java:252: error: cannot find symbol ~
+        8385:   ZexitCode = Fmainx(); ~
+        8386:               ^ ~
+        8387:   symbol:   method Fmainx() ~
+
+:lli[st] [from] [, [to]]				*:lli* *:llist*
 			":clist" と同様だが、quickfixリストでなく、カレントウィ
 			ンドウのlocationリストが使われる。
 

--- a/en/quickfix.txt
+++ b/en/quickfix.txt
@@ -378,14 +378,14 @@ processing a quickfix or location list command, it will be aborted.
 			List all errors.
 
 :cl[ist]! +{count}	List the current and next {count} error lines.  This
-                        is useful to see unrecognized lines after the current
+			is useful to see unrecognized lines after the current
 			one.  For example, if ":clist" shows:
-        8384 testje.java:252: error: cannot find symbol ~
-                        Then using ":cl! +3" shows the reason:
-        8384 testje.java:252: error: cannot find symbol ~
-        8385:   ZexitCode = Fmainx(); ~
-        8386:               ^ ~
-        8387:   symbol:   method Fmainx() ~
+	8384 testje.java:252: error: cannot find symbol ~
+			Then using ":cl! +3" shows the reason:
+	8384 testje.java:252: error: cannot find symbol ~
+	8385:   ZexitCode = Fmainx(); ~
+	8386:               ^ ~
+	8387:   symbol:   method Fmainx() ~
 
 :lli[st] [from] [, [to]]				*:lli* *:llist*
 			Same as ":clist", except the location list for the


### PR DESCRIPTION
「今回の変更対象が .jax にない！」と思ったら、以下のコマンドが .jax に反映されていないことが判明したので対応しました。
```
:cl[ist] +{count}
:cl[ist]! +{count}
```
あと、`:lli[st] [from] [, [to]]` とそのhelpタグが各行になっていたのが１行になっている変更も反映されていないのも併せて修正しました。
(何故か `:cl[ist] [from] [, [to]]` は各行のまま...)