### PR TITLE
Update builtin.{txt,jax}

### DIFF
--- a/doc/builtin.jax
+++ b/doc/builtin.jax
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim バージョン 9.1.  Last change: 2024 Mar 29
+*builtin.txt*	For Vim バージョン 9.1.  Last change: 2024 Apr 04
 
 
 		VIMリファレンスマニュアル    by Bram Moolenaar
@@ -1806,7 +1806,8 @@ confirm({msg} [, {choices} [, {default} [, {type}]]])
 		confirm()はユーザーに選択させるためのダイアログを提供する。戻
 		り値は選択した番号になる。最初の選択肢が1である。
 		Note: confirm()は、ダイアログサポートを有効にしてコンパイルし
-		た時にだけ動作する。|+dialog_con|と|+dialog_gui|を参照。
+		た時にだけ動作する。|+dialog_con|, |+dialog_con_gui|
+		と|+dialog_gui|を参照。
 
 		ダイアログには{msg}に加えて{choices}の選択肢が表示される。
 		{choices}が指定されない、または空の場合は選択肢 "&OK" が表示さ
@@ -2315,7 +2316,8 @@ escape({string}, {chars})				*escape()*
 eval({string})	{string}を評価し、値を返す。|string()|の戻り値を元の値に戻すの
 		に非常に便利である。数値、浮動小数点数、文字列、Blob およびそ
 		れらの複合に対して動作する。実際に存在する関数への |Funcref|
-		に対しても動作する。
+		に対しても動作する。|Vim9| script においては、完全修飾名から
+		|enum| の値を取得するのに使用できる。
 
 		|method| としても使用できる: >
 			argv->join()->eval()
@@ -10921,6 +10923,7 @@ cscope			|cscope|をサポート
 cursorbind		|'cursorbind'| をサポート (常に true)
 debug			デバッグバージョンである
 dialog_con		コンソールダイアログのサポート
+dialog_con_gui		コンソールとGUIのダイアログのサポート
 dialog_gui		GUIダイアログのサポート
 diff			|vimdiff| と 'diff' のサポート
 digraphs		ダイグラフをサポート

--- a/doc/builtin.jax
+++ b/doc/builtin.jax
@@ -1806,8 +1806,8 @@ confirm({msg} [, {choices} [, {default} [, {type}]]])
 		confirm()はユーザーに選択させるためのダイアログを提供する。戻
 		り値は選択した番号になる。最初の選択肢が1である。
 		Note: confirm()は、ダイアログサポートを有効にしてコンパイルし
-		た時にだけ動作する。|+dialog_con|, |+dialog_con_gui|
-		と|+dialog_gui|を参照。
+		た時にだけ動作する。|+dialog_con|, |+dialog_con_gui| と
+		|+dialog_gui| を参照。
 
 		ダイアログには{msg}に加えて{choices}の選択肢が表示される。
 		{choices}が指定されない、または空の場合は選択肢 "&OK" が表示さ

--- a/en/builtin.txt
+++ b/en/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.1.  Last change: 2024 Mar 29
+*builtin.txt*	For Vim version 9.1.  Last change: 2024 Apr 04
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1771,7 +1771,7 @@ confirm({msg} [, {choices} [, {default} [, {type}]]])
 		made.  It returns the number of the choice.  For the first
 		choice this is 1.
 		Note: confirm() is only supported when compiled with dialog
-		support, see |+dialog_con| and |+dialog_gui|.
+		support, see |+dialog_con| |+dialog_con_gui| and |+dialog_gui|.
 
 		{msg} is displayed in a |dialog| with {choices} as the
 		alternatives.  When {choices} is missing or empty, "&OK" is
@@ -2307,7 +2307,8 @@ eval({string})	Evaluate {string} and return the result.  Especially useful to
 		turn the result of |string()| back into the original value.
 		This works for Numbers, Floats, Strings, Blobs and composites
 		of them.  Also works for |Funcref|s that refer to existing
-		functions.
+		functions.  In |Vim9| script, it can be used to obtain |enum|
+		values from their fully qualified names.
 
 		Can also be used as a |method|: >
 			argv->join()->eval()
@@ -11199,6 +11200,7 @@ cscope			Compiled with |cscope| support.
 cursorbind		Compiled with |'cursorbind'| (always true)
 debug			Compiled with "DEBUG" defined.
 dialog_con		Compiled with console dialog support.
+dialog_con_gui		Compiled with console and GUI dialog support.
 dialog_gui		Compiled with GUI dialog support.
 diff			Compiled with |vimdiff| and 'diff' support.
 digraphs		Compiled with support for digraphs.


### PR DESCRIPTION
翻訳しました。よろしくお願いします。

"Compiled with console and GUI dialog support." は「コンソールとGUIのダイアログのサポート」としましたが、周辺との兼ね合いを考えると、もしかしたら「コンソールダイアログとGUIダイアログのサポート」とした方が良いかもしれません。