### PR TITLE
Update testing.{txt,jax}

### DIFF
--- a/doc/testing.jax
+++ b/doc/testing.jax
@@ -1,4 +1,4 @@
-*testing.txt*	For Vim バージョン 9.1.  Last change: 2024 Apr 07
+*testing.txt*	For Vim バージョン 9.1.  Last change: 2024 May 03
 
 
 		  VIMリファレンスマニュアル	  by Bram Moolenaar
@@ -373,6 +373,9 @@ test_override({name}, {val})				*test_override()*
 		autoload     `import autoload` でスクリプトを正しい手順でロー
 			     ドし、項目が使用されるまで延期はしない
 		char_avail   char_avail() 関数を無効化する
+		defcompile   ソースされたスクリプト内のすべての |:def| 関数は、
+			     定義時にコンパイルされる。これは、スクリプトで
+			     |:defcompile| コマンドを使用するのと似ている
 		nfa_fail     古い正規表現エンジンに戻すために、NFA regexp エン
 			     ジンを失敗させる
 		no_query_mouse  "dec" 端末のマウス位置を問い合わせない
@@ -382,9 +385,9 @@ test_override({name}, {val})				*test_override()*
 		redraw_flag  RedrawingDisabled フラグを無視する
 		starting     "starting" 変数を初期化する、下記参照
 		term_props   バージョン文字列が検出された場合、すべてのターミ
-			     ナルプロパティをリセットする。
+			     ナルプロパティをリセットする
 		ui_delay     ui_delay() で使用するミリ秒単位の時間; メッセージ
-			     の最大3秒の待ち時間を上書きする。
+			     の最大3秒の待ち時間を上書きする
 		unreachable  `throw` と `:return` の後のコードではエラーになら
 			     ない
 		uptime	     sysinfo.uptime を上書きする

--- a/doc/testing.jax
+++ b/doc/testing.jax
@@ -373,7 +373,7 @@ test_override({name}, {val})				*test_override()*
 		autoload     `import autoload` でスクリプトを正しい手順でロー
 			     ドし、項目が使用されるまで延期はしない
 		char_avail   char_avail() 関数を無効化する
-		defcompile   ソースされたスクリプト内のすべての |:def| 関数は、
+		defcompile   読み込まれたスクリプト内のすべての |:def| 関数は、
 			     定義時にコンパイルされる。これは、スクリプトで
 			     |:defcompile| コマンドを使用するのと似ている
 		nfa_fail     古い正規表現エンジンに戻すために、NFA regexp エン

--- a/en/testing.txt
+++ b/en/testing.txt
@@ -1,4 +1,4 @@
-*testing.txt*	For Vim version 9.1.  Last change: 2024 Apr 07
+*testing.txt*	For Vim version 9.1.  Last change: 2024 May 03
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -369,6 +369,9 @@ test_override({name}, {val})				*test_override()*
 		autoload     `import autoload` will load the script right
 			     away, not postponed until an item is used
 		char_avail   disable the char_avail() function
+		defcompile   all the |:def| functions in a sourced script are
+			     compiled when defined.  This is similar to using
+			     the |:defcompile| command in a script.
 		nfa_fail     makes the NFA regexp engine fail to force a
 			     fallback to the old engine
 		no_query_mouse  do not query the mouse position for "dec"


### PR DESCRIPTION
原文は、`test_override()`の各{name}の説明の最後の文章に `.` があったりなかったりと不統一ですね。
.jax は一旦、`.`なしに統一しました。
(でも、あった方が良い気がする) → What do you think?