### PR TITLE
Update pattern.{txt,jax}

### DIFF
--- a/doc/pattern.jax
+++ b/doc/pattern.jax
@@ -1,4 +1,4 @@
-*pattern.txt*   For Vim バージョン 9.1.  Last change: 2024 Apr 26
+*pattern.txt*   For Vim バージョン 9.1.  Last change: 2024 Jun 03
 
 
 		  VIMリファレンスマニュアル	  by Bram Moolenaar
@@ -1484,11 +1484,7 @@ matchfuzzypos() はマッチのリスト、マッチの位置およびファジ�
 
 `:vimgrep` の フラグ "f" はファジーマッチを有効にします。
 
+|ins-completion| のファジーマッチを有効にするには、'completeopt' オプションに
+"fuzzy" 値を追加します。
 
-{訳注: 訳語:
-         concat 連接
-         multi >量指定子< 量指定詞 数量子 数量詞
-         ordinary atom 普通のアトム
-         a sequence of optionally matched atoms 任意にマッチするアトム列
-         last search pattern 最終検索パターン}
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/en/pattern.txt
+++ b/en/pattern.txt
@@ -1,4 +1,4 @@
-*pattern.txt*   For Vim version 9.1.  Last change: 2024 Apr 26
+*pattern.txt*   For Vim version 9.1.  Last change: 2024 Jun 03
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1513,5 +1513,7 @@ the matching positions and the fuzzy match scores.
 
 The "f" flag of `:vimgrep` enables fuzzy matching.
 
+To enable fuzzy matching for |ins-completion|, add the "fuzzy" value to the
+'completeopt' option.
 
  vim:tw=78:ts=8:noet:ft=help:norl:


### PR DESCRIPTION
@k-takata 
.jax の最後の「{訳注 ～}」を削除しました。
理由: 対応する原文を確認すれば分かると判断した。