### PR TITLE
Update builtin.{txt,jax}

### DIFF
--- a/doc/builtin.jax
+++ b/doc/builtin.jax
@@ -192,7 +192,7 @@ extendnew({expr1}, {expr2} [, {expr3}])
 				リスト/辞書 |extend()| と同じだが新しいリスト/
 				辞書を作る
 feedkeys({string} [, {mode}])	数値	先行入力バッファにキーシーケンスを追加
-filecopy({from}, {to})		数値	ファイル {from} を {to} へコピー出来た
+filecopy({from}, {to})		数値	ファイル {from} を {to} へコピーできた
 					場合は |TRUE|
 filereadable({file})		数値	{file}が読み込み可能なら|TRUE|
 filewritable({file})		数値	{file}が書き込み可能なら|TRUE|

--- a/doc/builtin.jax
+++ b/doc/builtin.jax
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim バージョン 9.1.  Last change: 2024 May 18
+*builtin.txt*	For Vim バージョン 9.1.  Last change: 2024 Jun 03
 
 
 		VIMリファレンスマニュアル    by Bram Moolenaar
@@ -192,6 +192,8 @@ extendnew({expr1}, {expr2} [, {expr3}])
 				リスト/辞書 |extend()| と同じだが新しいリスト/
 				辞書を作る
 feedkeys({string} [, {mode}])	数値	先行入力バッファにキーシーケンスを追加
+filecopy({from}, {to})		数値	ファイル {from} を {to} へコピー出来た
+					場合は |TRUE|
 filereadable({file})		数値	{file}が読み込み可能なら|TRUE|
 filewritable({file})		数値	{file}が書き込み可能なら|TRUE|
 filter({expr1}, {expr2})	リスト/辞書/Blob/文字列
@@ -2755,8 +2757,19 @@ feedkeys({string} [, {mode}])				*feedkeys()*
 		|method| としても使用できる: >
 			GetInput()->feedkeys()
 <
-							*filereadable()*
-filereadable({file})
+filecopy({from}, {to})					*filecopy()*
+		名前 {from} で指定されたファイルを {to} にコピーする。結果は数
+		値で、ファイルのコピーが成功した場合は |TRUE|、失敗した場合は
+		|FALSE| になる。
+		名前 {to} のファイルがすでに存在する場合は失敗する。
+		Note ディレクトリは処理されないことに注意 (まだ)。
+
+		この関数は |sandbox| では使用できない。
+
+		|method| としても使用できる: >
+			GetOldName()->filecopy(newname)
+
+filereadable({file})					*filereadable()*
 		結果は数値で、{file}というファイルが存在し、読み込むことが可能
 		ならば|TRUE|となる。ファイル{file}が存在しないかディレクトリ
 		だった場合には、結果は|FALSE|となる。引数{file}は文字列として
@@ -4254,11 +4267,10 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 
 		オプショナル引数の {opts} は以下の項目をサポートする辞書である:
 
-			type		範囲の選択のタイプを指定する (デフォル
-					ト: "v"):
-			    "v"		|characterwise| モード
-			    "V"		|linewise| モード
-			    "<CTRL-V>"	|blockwise-visual| モード
+			type		範囲の選択のタイプを指定する。可能な値
+					については |getregtype()| を参照。ただ
+					し、幅は省略可能で、空の文字列は使用で
+					きない。(デフォルト: "v")
 
 			exclusive	|TRUE| の場合、末尾の位置に排他的な選
 					択を用いる。
@@ -4305,6 +4317,25 @@ getregionpos({pos1}, {pos2} [, {opts}])            *getregionpos()*
 		    [bufnum, lnum, col, off]
 		"bufnum" はバッファ番号。
 		"lnum" と "col" はバッファ内の位置。最初の桁は 1 である。
+
+		開始位置の "off" の数値がゼロ以外の場合、それは文字の先頭から
+		の画面桁のオフセットである。例えば、<Tab> 内の位置、または最後
+		の文字の後の位置である。
+		終了位置の "off" の数値がゼロ以外の場合、それは選択範囲に含ま
+		れない文字の最初のセルのオフセットである。それ以外の場合は、そ
+		のすべてのセルが含まれる。
+
+		|getregion()| でサポートされているオプションとは別に、{opts}
+		は次のオプションもサポートしている:
+
+			eol		|TRUE| の場合、行末を超える位置を、行
+					の長さより 1 大きい "col" 値で示す。
+					|FALSE| の場合、位置は行内に制限され、
+					行が空の場合、または選択範囲が行の末尾
+					を完全に超えている場合は、両方の位置に
+					対して "col" 値 0 が使用される。
+					(デフォルト: |FALSE|)
+
 		'virtualedit' が使用されない限り、"off" の数値はゼロである。次
 		に、それは文字の先頭からの画面桁のオフセットになる。例えば、
 		<Tab> 内または最後の文字の後の位置である。

--- a/doc/builtin.jax
+++ b/doc/builtin.jax
@@ -2756,7 +2756,7 @@ feedkeys({string} [, {mode}])				*feedkeys()*
 
 		|method| としても使用できる: >
 			GetInput()->feedkeys()
-<
+
 filecopy({from}, {to})					*filecopy()*
 		名前 {from} で指定されたファイルを {to} にコピーする。結果は数
 		値で、ファイルのコピーが成功した場合は |TRUE|、失敗した場合は

--- a/en/builtin.txt
+++ b/en/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.1.  Last change: 2024 May 18
+*builtin.txt*	For Vim version 9.1.  Last change: 2024 Jun 03
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -178,6 +178,8 @@ extendnew({expr1}, {expr2} [, {expr3}])
 				List/Dict like |extend()| but creates a new
 					List or Dictionary
 feedkeys({string} [, {mode}])	Number	add key sequence to typeahead buffer
+filecopy({from}, {to})		Number	|TRUE| if copying file {from} to {to}
+					worked
 filereadable({file})		Number	|TRUE| if {file} is a readable file
 filewritable({file})		Number	|TRUE| if {file} is a writable file
 filter({expr1}, {expr2})	List/Dict/Blob/String
@@ -2757,6 +2759,18 @@ feedkeys({string} [, {mode}])				*feedkeys()*
 		Can also be used as a |method|: >
 			GetInput()->feedkeys()
 
+filecopy({from}, {to})					*filecopy()*
+		Copy the file pointed to by the name {from} to {to}. The
+		result is a Number, which is |TRUE| if the file was copied
+		successfully, and |FALSE| when it failed.
+		If a file with name {to} already exists, it will fail.
+		Note that it does not handle directories (yet).
+
+		This function is not available in the |sandbox|.
+
+		Can also be used as a |method|: >
+			GetOldName()->filecopy(newname)
+
 filereadable({file})					*filereadable()*
 		The result is a Number, which is |TRUE| when a file with the
 		name {file} exists, and can be read.  If {file} doesn't exist,
@@ -4288,14 +4302,14 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 		The optional argument {opts} is a Dict and supports the
 		following items:
 
-			type		Specify the region's selection type
-					(default: "v"):
-			    "v"		for |characterwise| mode
-			    "V"		for |linewise| mode
-			    "<CTRL-V>"	for |blockwise-visual| mode
+			type		Specify the region's selection type.
+					See |getregtype()| for possible values,
+					except that the width can be omitted
+					and an empty string cannot be used.
+					(default: "v")
 
 			exclusive	If |TRUE|, use exclusive selection
-					for the end position
+					for the end position.
 					(default: follow 'selection')
 
 		You can get the last selection type by |visualmode()|.
@@ -4341,10 +4355,25 @@ getregionpos({pos1}, {pos2} [, {opts}])            *getregionpos()*
 		"bufnum" is the buffer number.
 		"lnum" and "col" are the position in the buffer.  The first
 		column is 1.
-		The "off" number is zero, unless 'virtualedit' is used.  Then
-		it is the offset in screen columns from the start of the
-		character.  E.g., a position within a <Tab> or after the last
-		character.
+		If the "off" number of a starting position is non-zero, it is
+		the offset in screen columns from the start of the character.
+		E.g., a position within a <Tab> or after the last character.
+		If the "off" number of an ending position is non-zero, it is
+		the offset of the character's first cell not included in the
+		selection, otherwise all its cells are included.
+
+		Apart from the options supported by |getregion()|, {opts} also
+		supports the following:
+
+			eol		If |TRUE|, indicate positions beyond
+					the end of a line with "col" values
+					one more than the length of the line.
+					If |FALSE|, positions are limited
+					within their lines, and if a line is
+					empty or the selection is entirely
+					beyond the end of a line, a "col"
+					value of 0 is used for both positions.
+					(default: |FALSE|)
 
 		Can also be used as a |method|: >
 			getpos('.')->getregionpos(getpos("'a"))


### PR DESCRIPTION
(Just before adding descriptions of the function's return value)

関数の戻り値の記述を追加した以下のcommitの直前のcommit `60c8743ab6c90e402e6ed49d27455ef7e5698abe` までの更新です。
(結構量あると思ったらそうでもなかったｗ)

```
commit 5674c9a7de503d5e798055a5e1115343ff885221
Author: Christian Brabandt <cb@256bit.org>
Date:   Sun Jun 9 00:13:43 2024 +0200

    runtime(doc): add return type info for Vim function descriptions
```