### PR TITLE
Use vim-jp bot app when running depup

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -23,10 +23,16 @@ jobs:
           version_name: REVIEWDOG_VERSION
           repo: reviewdog/reviewdog
 
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.VIM_JP_BOT_APP_ID }}
+          private-key: ${{ secrets.VIM_JP_BOT_PRIVATE_KEY }}
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           author: 'github-actions <41898282+github-actions[bot]@users.noreply.github.com>'
           title: "chore(deps): update ${{ steps.depup.outputs.repo }} to ${{ steps.depup.outputs.latest }}"
           commit-message: "chore(deps): update ${{ steps.depup.outputs.repo }} to ${{ steps.depup.outputs.latest }}"


### PR DESCRIPTION
CI jobs were not automatically executed because we used GITHUB_TOKEN.
To work around the restriction of GITHUB_TOKEN, use action/create-github-app-token to generate a token.

See:
* https://zenn.dev/suzutan/articles/how-to-use-github-apps-token-in-github-actions
* https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions
* https://github.com/marketplace/actions/create-github-app-token