### PR TITLE
Update map.{txt,jax}

### DIFF
--- a/doc/map.jax
+++ b/doc/map.jax
@@ -1,4 +1,4 @@
-*map.txt*       For Vim バージョン 9.1.  Last change: 2024 May 05
+*map.txt*       For Vim バージョン 9.1.  Last change: 2024 Jul 11
 
 
 		  VIMリファレンスマニュアル	  by Bram Moolenaar
@@ -1612,6 +1612,7 @@ script2.vimを実行すると "None" が表示されます。期待した結果�
 	-complete=compiler	コンパイラ
 	-complete=cscope	|:cscope| サブオプション
 	-complete=dir		ディレクトリ
+	-complete=dir_in_path	|'cdpath'| 内のディレクトリ
 	-complete=environment	環境変数
 	-complete=event		自動コマンドのイベント
 	-complete=expression	Vimの式

--- a/en/map.txt
+++ b/en/map.txt
@@ -1,4 +1,4 @@
-*map.txt*       For Vim version 9.1.  Last change: 2024 May 05
+*map.txt*       For Vim version 9.1.  Last change: 2024 Jul 11
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1631,6 +1631,7 @@ completion can be enabled:
 	-complete=compiler	compilers
 	-complete=cscope	|:cscope| suboptions
 	-complete=dir		directory names
+	-complete=dir_in_path	directory names in |'cdpath'|
 	-complete=environment	environment variable names
 	-complete=event		autocommand events
 	-complete=expression	Vim expression


### PR DESCRIPTION
`'~'` はそれだけでリンクになるしハイライトもされるので、さらに `|~|` で囲む必要はないと思うんですが、ここの一覧の既存のやつ囲んじゃってますね。
本家を修正すべき？