### PR TITLE
Update syntax.{txt,jax}

### DIFF
--- a/doc/syntax.jax
+++ b/doc/syntax.jax
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim バージョン 9.1.  Last change: 2024 Sep 18
+*syntax.txt*	For Vim バージョン 9.1.  Last change: 2024 Sep 19
 
 
 		VIMリファレンスマニュアル    by Bram Moolenaar
@@ -2109,11 +2109,12 @@ Java プラットフォームへの重要な変更は、リリース用に実装
 に対応するため Vim には実装されている構文関連のプレビュー機能に対するオプショ
 ンのサポートがある。以下のようにプレビュー機能番号のリストを指定して、これをリ
 クエストできる: >
-	:let g:java_syntax_previews = [455]
+	:let g:java_syntax_previews = [455, 476]
 
 サポートされている JEP 番号は以下の表から取得される:
 	`430`: String Templates [JDK 21]
 	`455`: Primitive types in Patterns, instanceof, and switch
+	`476`: Module Import Declarations
 
 Note 特定のプレビュー機能が Java プラットフォームに統合されると、すぐにそのエ
 ントリはテーブルから削除され、関連するオプション機能は廃止されることに注意。

--- a/doc/syntax.jax
+++ b/doc/syntax.jax
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim バージョン 9.1.  Last change: 2024 Sep 11
+*syntax.txt*	For Vim バージョン 9.1.  Last change: 2024 Sep 18
 
 
 		VIMリファレンスマニュアル    by Bram Moolenaar
@@ -2109,10 +2109,11 @@ Java プラットフォームへの重要な変更は、リリース用に実装
 に対応するため Vim には実装されている構文関連のプレビュー機能に対するオプショ
 ンのサポートがある。以下のようにプレビュー機能番号のリストを指定して、これをリ
 クエストできる: >
-	:let g:java_syntax_previews = [430]
+	:let g:java_syntax_previews = [455]
 
 サポートされている JEP 番号は以下の表から取得される:
 	`430`: String Templates [JDK 21]
+	`455`: Primitive types in Patterns, instanceof, and switch
 
 Note 特定のプレビュー機能が Java プラットフォームに統合されると、すぐにそのエ
 ントリはテーブルから削除され、関連するオプション機能は廃止されることに注意。

--- a/en/syntax.txt
+++ b/en/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 9.1.  Last change: 2024 Sep 18
+*syntax.txt*	For Vim version 9.1.  Last change: 2024 Sep 19
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -2176,11 +2176,12 @@ cycles for such a feature to become either integrated into the platform or
 withdrawn from this effort.  To cater for early adopters, there is optional
 support in Vim for syntax related preview features that are implemented.  You
 can request it by specifying a list of preview feature numbers as follows: >
-	:let g:java_syntax_previews = [455]
+	:let g:java_syntax_previews = [455, 476]
 
 The supported JEP numbers are to be drawn from this table:
 	`430`: String Templates [JDK 21]
 	`455`: Primitive types in Patterns, instanceof, and switch
+	`476`: Module Import Declarations
 
 Note that as soon as the particular preview feature will have been integrated
 into the Java platform, its entry will be removed from the table and related

--- a/en/syntax.txt
+++ b/en/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 9.1.  Last change: 2024 Sep 11
+*syntax.txt*	For Vim version 9.1.  Last change: 2024 Sep 18
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -2176,10 +2176,11 @@ cycles for such a feature to become either integrated into the platform or
 withdrawn from this effort.  To cater for early adopters, there is optional
 support in Vim for syntax related preview features that are implemented.  You
 can request it by specifying a list of preview feature numbers as follows: >
-	:let g:java_syntax_previews = [430]
+	:let g:java_syntax_previews = [455]
 
 The supported JEP numbers are to be drawn from this table:
 	`430`: String Templates [JDK 21]
+	`455`: Primitive types in Patterns, instanceof, and switch
 
 Note that as soon as the particular preview feature will have been integrated
 into the Java platform, its entry will be removed from the table and related


### PR DESCRIPTION
今のところ、JEP 番号テーブル(L2115～L2117)は訳していません。
訳した方が良い？私、Java疎いので、変訳するよりは原文ママの方かマシかなぁと思ってます。
意見ください。