### PR TITLE
Update options.{txt,jax}

### DIFF
--- a/doc/options.jax
+++ b/doc/options.jax
@@ -1,4 +1,4 @@
-*options.txt*	For Vim バージョン 9.1.  Last change: 2024 Sep 10
+*options.txt*	For Vim バージョン 9.1.  Last change: 2024 Sep 26
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar
@@ -422,13 +422,14 @@ Note |global-local| オプションの挙動は、文字列ベースのオプシ
 			値で、既定値と異なるものを表示する。
 
 バッファ／ウィンドウについてローカルなオプションに対して:
-	コマンド	    グローバルな値	ローカルな値 ~
-      :set オプション=値    設定される		設定される
- :setlocal オプション=値    なし		設定される
-:setglobal オプション=値    設定される		なし
-      :set オプション?	    なし		表示される
- :setlocal オプション?	    なし		表示される
-:setglobal オプション?	    表示される		なし
+	コマンド	 グローバルな値	  ローカルな値	       条件 ~
+      :set option=value	     set	      set
+ :setlocal option=value	      -		      set
+:setglobal option=value	     set	       -
+      :set option?	      -		     display	 ローカル値設定あり
+      :set option?	    display	       -	 ローカル値設定なし
+ :setlocal option?	      -		     display
+:setglobal option?	    display	       -
 
 
 ローカルな値を持つグローバルオプション			*global-local*

--- a/en/options.txt
+++ b/en/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 9.1.  Last change: 2024 Sep 10
+*options.txt*	For Vim version 9.1.  Last change: 2024 Sep 26
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -396,13 +396,14 @@ between string and number-based options.
 			options which are different from the default.
 
 For buffer-local and window-local options:
-	Command		 global value	    local value ~
-      :set option=value	     set		set
- :setlocal option=value	      -			set
-:setglobal option=value	     set		 -
-      :set option?	      -		       display
- :setlocal option?	      -		       display
-:setglobal option?	    display		 -
+	Command		 global value	  local value	       condition ~
+      :set option=value	     set	      set
+ :setlocal option=value	      -		      set
+:setglobal option=value	     set	       -
+      :set option?	      -		     display	 local value is set
+      :set option?	    display	       -	 local value is not set
+ :setlocal option?	      -		     display
+:setglobal option?	    display	       -
 
 
 Global options with a local value			*global-local*


### PR DESCRIPTION
- スペースの都合もあって、`set`や`display`等はそのままとしました。(これくらいは逆に訳さない方が分かりやすいと思う)