### PR TITLE
Use 切替 for boolean options

### DIFF
--- a/doc/vi_diff.jax
+++ b/doc/vi_diff.jax
@@ -45,22 +45,22 @@ Vimにオープンモードはありません。まったく便利ではない�
 セットしてもエラーメッセージは出ませんが、設定した値は使われませんし表示もされ
 ません。
 
-autoprint (ap)		二者択一  (初期値 オン)		*'autoprint'* *'ap'*
-beautify (bf)		二者択一  (初期値 オフ)		*'beautify'* *'bf'*
-flash (fl)		二者択一  (初期値 オン)		*'flash'* *'fl'*
-graphic (gr)		二者択一  (初期値 オフ)		*'graphic'* *'gr'*
-hardtabs (ht)		数値	  (初期値 8)		*'hardtabs'* *'ht'*
+autoprint (ap)		切替	(初期値 オン)		*'autoprint'* *'ap'*
+beautify (bf)		切替	(初期値 オフ)		*'beautify'* *'bf'*
+flash (fl)		切替	(初期値 オン)		*'flash'* *'fl'*
+graphic (gr)		切替	(初期値 オフ)		*'graphic'* *'gr'*
+hardtabs (ht)		数値	(初期値 8)		*'hardtabs'* *'ht'*
 	ディスプレイ上で一つの <Tab> が移動するスペースの数
-mesg			二者択一  (初期値 オン)		*'mesg'*
-novice			二者択一  (初期値 オフ)		*'novice'*
-open			二者択一  (初期値 オン)		*'open'*
-optimize (op)		二者択一  (初期値 オフ)		*'optimize'* *'op'*
-redraw			二者択一  (初期値 オフ)		*'redraw'*
-slowopen (slow)		二者択一  (初期値 オフ)		*'slowopen'* *'slow'*
-sourceany		二者択一  (初期値 オフ)		*'sourceany'*
-w300			数値	  (初期値 23)		*'w300'*
-w1200			数値	  (初期値 23)		*'w1200'*
-w9600			数値	  (初期値 23)		*'w9600'*
+mesg			切替	(初期値 オン)		*'mesg'*
+novice			切替	(初期値 オフ)		*'novice'*
+open			切替	(初期値 オン)		*'open'*
+optimize (op)		切替	(初期値 オフ)		*'optimize'* *'op'*
+redraw			切替	(初期値 オフ)		*'redraw'*
+slowopen (slow)		切替	(初期値 オフ)		*'slowopen'* *'slow'*
+sourceany		切替	(初期値 オフ)		*'sourceany'*
+w300			数値	(初期値 23)		*'w300'*
+w1200			数値	(初期値 23)		*'w1200'*
+w9600			数値	(初期値 23)		*'w9600'*
 
 Viはtermcapエントリの変更を許可しませんでした。Viを終了し、termcapエントリを編
 集して再試行する必要があります。Vimには |terminal-options| があります。
@@ -673,8 +673,8 @@ CTRL-A (加算) と CTRL-X (減算) コマンドが新たに追加されまし�
 るのに使うことができます。数は10進数、8進数(0で始まります)、16進数(0xで始まり
 ます)でもよいです。マクロを使うときに非常に便利です。
 
-:set コマンドでは "inv" を前置することで二者択一のオプションは逆の意味にするこ
-とができます。
+:set コマンドでは "inv" を前置することで切替オプションは逆の意味にすることがで
+きます。
 
 Vi と Vim の両方で ":substitute" コマンドで CTRL-M を使うことで改行を挿入する
 ことができます。Vi ではこのためにテキストに実際の CTRL-M を挿入することができ


### PR DESCRIPTION
doc/options.jax では `boolean` は `切替` と訳される。

合わせてインデントを原文(en)にあわせた。