### PR TITLE
Remove unnecessary spaces in builtin.jax

### DIFF
--- a/doc/builtin.jax
+++ b/doc/builtin.jax
@@ -151,7 +151,7 @@ copy({expr})			任意	{expr}の浅いコピーを作る
 cos({expr})			浮動小数点数	{expr} の余弦(コサイン)
 cosh({expr})			浮動小数点数	{expr}のハイパボリックコサイン
 count({comp}, {expr} [, {ic} [, {start}]])
-				数値	 {comp}中に{expr}が何個現れるか数える
+				数値	{comp}中に{expr}が何個現れるか数える
 cscope_connection([{num}, {dbpath} [, {prepend}]])
 				数値	cscope接続の存在を判定する
 cursor({lnum}, {col} [, {off}])
@@ -3820,7 +3820,7 @@ getchar([{expr}])					*getchar()*
 		{expr} が1の場合は、1文字を取得できるかを判定するだけである。
 			入力は消費されない。取得できないと判定された時は0を返
 			す。
- 		常に文字列として取得したい場合は |getcharstr()| を使用する。
+		常に文字列として取得したい場合は |getcharstr()| を使用する。
 
 		{expr} が省略されたときや {expr} が0のときは、文字全体または特
 		殊キーを返す。それが1文字なら戻り値は数値である。これを文字列
@@ -4410,8 +4410,8 @@ getloclist({nr} [, {what}])				*getloclist()*
 					詳細は |location-list-file-window| を
 					参照。
 
- 		ウィンドウ {nr} にlocationリストがないなら、デフォルト値の辞書
- 		|Dictionary| を返す。
+		ウィンドウ {nr} にlocationリストがないなら、デフォルト値の辞書
+		|Dictionary| を返す。
 		ウィンドウが存在しない場合、空の辞書を返す。
 
 		例 (|getqflist-examples| もまた参照): >
@@ -5539,7 +5539,7 @@ hlset({list})						*hlset()*
 			:call hlset([#{name: 'MyHlg', cleared: v:true,
 					\ linksto: 'NONE'}])
 <
-		 |method| としても使用できる: >
+		|method| としても使用できる: >
 			GetAttrList()->hlset()
 <
 		戻り値の型: |Number|
@@ -8414,7 +8414,7 @@ remote_expr({server}, {string} [, {idvar} [, {timeout}]])
 
 remote_foreground({server})				*remote_foreground()*
 		サーバー名 {server} のVimをフォアグラウンドに移動させる。
- 		引数 {server} は文字列。|{server}| も参照。
+		引数 {server} は文字列。|{server}| も参照。
 		次を実行するのと同様である: >
 			remote_expr({server}, "foreground()")
 <		ただし、次の点が異なる: Win32では、OSが必ずしもサーバーが自分
@@ -9215,7 +9215,7 @@ setbufvar({buf}, {varname}, {val})			*setbufvar()*
 		ウィンドウローカルオプションの場合、グローバルな値は変更されな
 		い。
 		{buf}の解釈の仕方については|bufname()|を参照。
- 		引数 {varname} は文字列。
+		引数 {varname} は文字列。
 		Note 変数名には "b:" をつけてはならない。
 		例: >
 			:call setbufvar(1, "&mod", 1)
@@ -9249,8 +9249,8 @@ setcellwidths({list})					*setcellwidths()*
 		引数が無効な場合や、範囲が他の範囲と重なっている場合もエラーが
 		発生する。				*E1113*
 
- 		新しい値が原因で 'fillchars' か 'listchars' が無効になる場合
- 		は、拒否されてエラーになる。
+		新しい値が原因で 'fillchars' か 'listchars' が無効になる場合
+		は、拒否されてエラーになる。
 
 		空の {list} を渡すことで上書きがクリアされる: >
 		   setcellwidths([]);
@@ -9689,7 +9689,7 @@ setreg({regname}, {value} [, {options}])			*setreg()*
 settabvar({tabnr}, {varname}, {val})			*settabvar()*
 		タブページ {tabnr} のタブローカル変数 {varname} を {val} に設
 		定する。|t:var|
- 		引数 {varname} は文字列。
+		引数 {varname} は文字列。
 		Note 自動コマンドがブロックされ、副作用が発生しない可能性があ
 		る。例えば、'filetype' を設定する時。
 		Note: 指定する変数名は "t:" を除いた名前。
@@ -11030,7 +11030,7 @@ tabpagenr([{arg}])					*tabpagenr()*
 		結果は数値で、カレントタブページの番号。最初のタブページの番号
 		は1となる。
 
- 		省略可能な引数{arg}は以下の値をサポートする:
+		省略可能な引数{arg}は以下の値をサポートする:
 			$	最後のタブページの番号(つまりタブページの個
 				数)。
 			#	最後に利用したタブページの番号(|g<Tab>| で移動


### PR DESCRIPTION
builtin.txt で、タブの前後に混じっていたスペースのうち不要そうなものを削除しました。
https://github.com/vim-jp/issues/issues/1433#issuecomment-2409036445
ここで報告した、原文にもあった不要なスペースについてはこの PR では手をつけず、原文にはなかったものだけ削除しています。