### PR TITLE
Support symbolic link

### DIFF
--- a/tools/script/get_doc_info.sh
+++ b/tools/script/get_doc_info.sh
@@ -29,8 +29,9 @@ version7.txt
 exclude_files=(`echo $exclude_files_str`)
 unchanged_file_count=0
 
-for fp in `ls -1 ${new_doc_dir}/*.txt`; do
-	fname=`basename ${fp}`
+for sfp in `ls -1 ${new_doc_dir}/*.txt`; do
+	fname=`basename ${sfp}`
+	fp=`readlink -f ${sfp}`
 	old_fp=${old_doc_dir}/${fname}
 	for (( i = 0; i < ${#exclude_files[@]}; ++i )); do
 		if [ ${fname} == ${exclude_files[$i]} ]; then


### PR DESCRIPTION
下記に対応。

https://github.com/vim-jp/vimdoc-ja-working/pull/1927#issuecomment-2628699384
> シンボリックリンクになったから、diff statusで変な差分情報の表示になってしまってますね。。どうしよっかな。
