### PR TITLE
Fix a typo

### DIFF
--- a/doc/options.jax
+++ b/doc/options.jax
@@ -2217,7 +2217,7 @@ Note 1番目の形式では、行全体がオプション指定に使われる�
 		    "fuzzy" も含まれている場合は機能しない。
 
 					*'completepopup'* *'cpp'*
-'completepopup' 'cpp'	字列  (既定では空)
+'completepopup' 'cpp'	文字列  (既定では空)
 			グローバル
 			{|+textprop| または |+quickfix| 機能付きでコンパイルさ
 			れたときのみ有効}


### PR DESCRIPTION
「文字列」の「文」が消えて、「字列」となっていたので修正しました。