### PR TITLE
Update version9.{txt,jax}

### DIFF
--- a/doc/version9.jax
+++ b/doc/version9.jax
@@ -1,4 +1,4 @@
-*version9.txt*  For Vim バージョン 9.1.  Last change: 2025 Mar 15
+*version9.txt*  For Vim バージョン 9.1.  Last change: 2025 Mar 18
 
 
 		  VIMリファレンスマニュアル	  by Bram Moolenaar
@@ -41694,6 +41694,10 @@ Ex コマンド: ~
 コマンド: ~
 
 |[r| および |]r|	カーソルを前/次の稀な単語に移動する
+
+Ex コマンド: ~
+
+|:iput|			|:put| と似ているが、インデントを調整する
 |:pbuffer|		バッファリストからバッファ [N] をプレビューウィンドウ
 			で編集する
 

--- a/en/version9.txt
+++ b/en/version9.txt
@@ -1,4 +1,4 @@
-*version9.txt*  For Vim version 9.1.  Last change: 2025 Mar 15
+*version9.txt*  For Vim version 9.1.  Last change: 2025 Mar 18
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -41704,6 +41704,10 @@ Highlighting: ~
 Commands: ~
 
 |[r| and |]r|		to move the cursor to previous/next rare word
+
+Ex-Commands: ~
+
+|:iput|			like |:put| but adjust indent
 |:pbuffer|		Edit buffer [N] from the buffer list in the preview
 			window
 


### PR DESCRIPTION
`Ex-Commands:` は「Ex コマンド」と訳しました。
.txt には他に `/^Ex commands:` があるからそれの訳にあわせたけど、.txt を修正依頼すべきかな？ 