### PR TITLE
docs: Update README : using GHA badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vimdoc-ja-working
 
-[![Build Status](https://travis-ci.com/vim-jp/vimdoc-ja-working.svg?branch=master)](https://travis-ci.com/github/vim-jp/vimdoc-ja-working)
+[![Generate vim help](https://github.com/vim-jp/vimdoc-ja-working/actions/workflows/generate.yml/badge.svg)](https://github.com/vim-jp/vimdoc-ja-working/actions/workflows/generate.yml)
 
 Vim 付属のヘルプを日本語に翻訳するためのプロジェクトです。
 


### PR DESCRIPTION
READMEのバッジが、Travisのままだったので、GHAのものに差し替え

どなたかがOKしたらマージでよいかと思いますが、おまかせします

(一応でreviewerを多めに付けています)

レンダリング: [README.md](https://github.com/tsuyoshicho/vimdoc-ja-working/blob/fix/reawdmebadge/README.md)