### PR TITLE
Update index.{txt,jax}

### DIFF
--- a/doc/index.jax
+++ b/doc/index.jax
@@ -1,4 +1,4 @@
-*index.txt*     For Vim バージョン 9.1.  Last change: 2025 Jun 23
+*index.txt*     For Vim バージョン 9.1.  Last change: 2025 Jun 27
 
 
 		  VIMリファレンスマニュアル	  by Bram Moolenaar
@@ -1645,6 +1645,7 @@ Note: 1 = カーソル移動コマンド  2 = アンドゥ/リドゥ可能
 |:redrawtabpanel| :redrawtabp[anel] タブパネルを再描画する
 |:registers|	:reg[isters]	レジスタの内容を表示
 |:resize|	:res[ize]	カレントウィンドウの高さを変更
+|:clipreset|	:clip[reset]	'clipmethod' をリセットする
 |:retab|	:ret[ab]	タブの大きさを変更
 |:return|	:retu[rn]	ユーザー関数から戻る
 |:rewind|	:rew[ind]	引数リストの先頭のファイルを開く
@@ -1849,6 +1850,7 @@ Note: 1 = カーソル移動コマンド  2 = アンドゥ/リドゥ可能
 				いコマンド)
 |:wincmd|	:winc[md]	ウィンドウコマンド(CTRL-W)を実行する
 |:winpos|	:winp[os]	ウィンドウの位置を取得もしくはセットする
+|:wlrestore|	:wl[restore]	Wayland コンポジター接続を復元する
 |:wnext|	:wn[ext]	ファイルに保存して、引数リストの次のファイル
 				を開く
 |:wprevious|	:wp[revious]	ファイルに保存して、引数リストの直前のファイ

--- a/doc/index.jax
+++ b/doc/index.jax
@@ -1,4 +1,4 @@
-*index.txt*     For Vim バージョン 9.1.  Last change: 2025 Jun 27
+*index.txt*     For Vim バージョン 9.1.  Last change: 2025 Jun 28
 
 
 		  VIMリファレンスマニュアル	  by Bram Moolenaar

--- a/doc/index.jax
+++ b/doc/index.jax
@@ -1289,6 +1289,7 @@ Note: 1 = カーソル移動コマンド  2 = アンドゥ/リドゥ可能
 |:class|	:class		クラス宣言の開始
 |:clast|	:cla[st]	指定のエラーへジャンプ、省略時は最後のエラー
 |:clearjumps|	:cle[arjumps]	ジャンプリストを削除する
+|:clipreset|	:clip[reset]	'clipmethod' をリセットする
 |:clist|	:cl[ist]	すべてのエラーを一覧表示
 |:close|	:clo[se]	カレントウィンドウを閉じる
 |:cmap|		:cm[ap]		コマンドラインモードを対象とする":map"コマンド
@@ -1645,7 +1646,6 @@ Note: 1 = カーソル移動コマンド  2 = アンドゥ/リドゥ可能
 |:redrawtabpanel| :redrawtabp[anel] タブパネルを再描画する
 |:registers|	:reg[isters]	レジスタの内容を表示
 |:resize|	:res[ize]	カレントウィンドウの高さを変更
-|:clipreset|	:clip[reset]	'clipmethod' をリセットする
 |:retab|	:ret[ab]	タブの大きさを変更
 |:return|	:retu[rn]	ユーザー関数から戻る
 |:rewind|	:rew[ind]	引数リストの先頭のファイルを開く

--- a/en/index.txt
+++ b/en/index.txt
@@ -1,4 +1,4 @@
-*index.txt*     For Vim version 9.1.  Last change: 2025 Jun 27
+*index.txt*     For Vim version 9.1.  Last change: 2025 Jun 28
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1264,6 +1264,7 @@ tag		command		action ~
 |:class|	:class		start of a class declaration
 |:clast|	:cla[st]	go to the specified error, default last one
 |:clearjumps|	:cle[arjumps]	clear the jump list
+|:clipreset|	:clip[reset]	reset 'clipmethod'
 |:clist|	:cl[ist]	list all errors
 |:close|	:clo[se]	close current window
 |:cmap|		:cm[ap]		like ":map" but for Command-line mode
@@ -1587,7 +1588,6 @@ tag		command		action ~
 |:redrawtabpanel| :redrawtabp[anel] force a redraw of the tabpanel
 |:registers|	:reg[isters]	display the contents of registers
 |:resize|	:res[ize]	change current window height
-|:clipreset|	:clip[reset]	reset 'clipmethod'
 |:retab|	:ret[ab]	change tab size
 |:return|	:retu[rn]	return from a user function
 |:rewind|	:rew[ind]	go to the first file in the argument list

--- a/en/index.txt
+++ b/en/index.txt
@@ -1,4 +1,4 @@
-*index.txt*     For Vim version 9.1.  Last change: 2025 Jun 23
+*index.txt*     For Vim version 9.1.  Last change: 2025 Jun 27
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1587,6 +1587,7 @@ tag		command		action ~
 |:redrawtabpanel| :redrawtabp[anel] force a redraw of the tabpanel
 |:registers|	:reg[isters]	display the contents of registers
 |:resize|	:res[ize]	change current window height
+|:clipreset|	:clip[reset]	reset 'clipmethod'
 |:retab|	:ret[ab]	change tab size
 |:return|	:retu[rn]	return from a user function
 |:rewind|	:rew[ind]	go to the first file in the argument list
@@ -1777,6 +1778,7 @@ tag		command		action ~
 |:winsize|	:wi[nsize]	get or set window size (obsolete)
 |:wincmd|	:winc[md]	execute a Window (CTRL-W) command
 |:winpos|	:winp[os]	get or set window position
+|:wlrestore|	:wl[restore]	restore the Wayland compositor connection
 |:wnext|	:wn[ext]	write to a file and go to next file in
 				argument list
 |:wprevious|	:wp[revious]	write to a file and go to previous file in


### PR DESCRIPTION
原文の `:clipreset` の場所がおかしいのはPR済み。
(以下愚痴: WaylandサポートのPRに頑張って大量のコードとドキュメントをレビューしてpatch貼り付けたのに、コード部分しかmergeされてなかったなんでだよ。PR出したわ)