### PR TITLE
Update {debugger,diff,digraph,gui_x11,helphelp,if_cscop,if_perl,if_py…

### DIFF
--- a/doc/debugger.jax
+++ b/doc/debugger.jax
@@ -1,4 +1,4 @@
-*debugger.txt*  For Vim バージョン 9.1.  Last change: 2019 Dec 21
+*debugger.txt*  For Vim バージョン 9.1.  Last change: 2025 Oct 12
 
 
 		VIMリファレンスマニュアル    by Gordon Prieur

--- a/doc/diff.jax
+++ b/doc/diff.jax
@@ -1,4 +1,4 @@
-*diff.txt*      For Vim バージョン 9.1.  Last change: 2025 Sep 15
+*diff.txt*      For Vim バージョン 9.1.  Last change: 2025 Oct 12
 
 
 		VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/digraph.jax
+++ b/doc/digraph.jax
@@ -1,4 +1,4 @@
-*digraph.txt*   For Vim バージョン 9.1.  Last change: 2025 Aug 16
+*digraph.txt*   For Vim バージョン 9.1.  Last change: 2025 Oct 12
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/gui_x11.jax
+++ b/doc/gui_x11.jax
@@ -1,4 +1,4 @@
-*gui_x11.txt*   For Vim バージョン 9.1.  Last change: 2025 Sep 22
+*gui_x11.txt*   For Vim バージョン 9.1.  Last change: 2025 Oct 12
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/helphelp.jax
+++ b/doc/helphelp.jax
@@ -1,4 +1,4 @@
-*helphelp.txt*	For Vim バージョン 9.1.  Last change: 2025 Sep 29
+*helphelp.txt*	For Vim バージョン 9.1.  Last change: 2025 Oct 12
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/if_cscop.jax
+++ b/doc/if_cscop.jax
@@ -1,4 +1,4 @@
-*if_cscop.txt*  For Vim バージョン 9.1.  Last change: 2025 Aug 10
+*if_cscop.txt*  For Vim バージョン 9.1.  Last change: 2025 Oct 12
 
 
 		  VIMリファレンスマニュアル    by Andy Kahn

--- a/doc/if_perl.jax
+++ b/doc/if_perl.jax
@@ -1,4 +1,4 @@
-*if_perl.txt*   For Vim バージョン 9.1.  Last change: 2025 Oct 04
+*if_perl.txt*   For Vim バージョン 9.1.  Last change: 2025 Oct 12
 
 
 		  VIMリファレンスマニュアル    by Sven Verdoolaege

--- a/doc/if_pyth.jax
+++ b/doc/if_pyth.jax
@@ -1,4 +1,4 @@
-*if_pyth.txt*   For Vim バージョン 9.1.  Last change: 2025 Mar 26
+*if_pyth.txt*   For Vim バージョン 9.1.  Last change: 2025 Oct 12
 
 
 		  VIMリファレンスマニュアル    by Paul Moore

--- a/doc/if_ruby.jax
+++ b/doc/if_ruby.jax
@@ -1,4 +1,4 @@
-*if_ruby.txt*   For Vim バージョン 9.1.  Last change: 2019 Jul 21
+*if_ruby.txt*   For Vim バージョン 9.1.  Last change: 2025 Oct 12
 
 
 		 VIM リファレンスマニュアル    by Shugo Maeda

--- a/doc/if_tcl.jax
+++ b/doc/if_tcl.jax
@@ -1,4 +1,4 @@
-*if_tcl.txt*    For Vim バージョン 9.1.  Last change: 2025 Aug 29
+*if_tcl.txt*    For Vim バージョン 9.1.  Last change: 2025 Oct 12
 
 
 		  VIMリファレンスマニュアル    by Ingo Wilken

--- a/doc/intro.jax
+++ b/doc/intro.jax
@@ -1,4 +1,4 @@
-*intro.txt*     For Vim バージョン 9.1.  Last change: 2025 Oct 11
+*intro.txt*     For Vim バージョン 9.1.  Last change: 2025 Oct 12
 
 
 		  VIMリファレンスマニュアル    by Bram Moolenaar

--- a/doc/mlang.jax
+++ b/doc/mlang.jax
@@ -1,4 +1,4 @@
-*mlang.txt*     For Vim バージョン 9.1.  Last change: 2024 Jul 11
+*mlang.txt*     For Vim バージョン 9.1.  Last change: 2025 Oct 12
 
 
 		VIMリファレンスマニュアル    by Bram Moolenaar

--- a/en/debugger.txt
+++ b/en/debugger.txt
@@ -1,4 +1,4 @@
-*debugger.txt*  For Vim version 9.1.  Last change: 2019 Dec 21
+*debugger.txt*  For Vim version 9.1.  Last change: 2025 Oct 12
 
 
 		  VIM REFERENCE MANUAL    by Gordon Prieur
@@ -51,9 +51,9 @@ Many debuggers mark specific lines by placing a small sign or color highlight
 on the line.  The |:sign| command lets the debugger set this graphic mark.  Some
 examples where this feature would be used would be a debugger showing an arrow
 representing the Program Counter (PC) of the program being debugged.  Another
-example would be a small stop sign for a line with a breakpoint.  These visible
-highlights let the user keep track of certain parts of the state of the
-debugger.
+example would be a small stop sign for a line with a breakpoint.  These
+visible highlights let the user keep track of certain parts of the state of
+the debugger.
 
 This feature can be used with more than debuggers, too.  An IPE can use a sign
 to highlight build errors, searched text, or other things.  The sign feature

--- a/en/diff.txt
+++ b/en/diff.txt
@@ -1,4 +1,4 @@
-*diff.txt*      For Vim version 9.1.  Last change: 2025 Sep 15
+*diff.txt*      For Vim version 9.1.  Last change: 2025 Oct 12
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -74,7 +74,8 @@ See `:diffoff` for an easy way to revert the options.
 The differences shown are actually the differences in the buffer.  Thus if you
 make changes after loading a file, these will be included in the displayed
 diffs.  You might have to do ":diffupdate" now and then, not all changes are
-immediately taken into account, especially when using an external diff command.
+immediately taken into account, especially when using an external diff
+command.
 
 In your .vimrc file you could do something special when Vim was started in
 diff mode.  You could use a construct like this: >
@@ -292,7 +293,7 @@ that the buffers will be equal within the specified range.
 
 							*do*
 [count]do	Same as ":diffget" without range.  The "o" stands for "obtain"
-		("dg" can't be used, it could be the start of "dgg"!). Note:
+		("dg" can't be used, it could be the start of "dgg"!).  Note:
 		this doesn't work in Visual mode.
 		If you give a [count], it is used as the [bufspec] argument
 		for ":diffget".
@@ -465,7 +466,7 @@ Also see 'diffopt' and the "diff" item of 'fillchars'.
 
 					    *diff-slow* *diff_translations*
 For very long lines, the diff syntax highlighting might be slow, especially
-since it tries to match all different kind of localisations. To disable
+since it tries to match all different kind of localisations.  To disable
 localisations and speed up the syntax highlighting, set the global variable
 g:diff_translations to zero: >
 
@@ -547,7 +548,7 @@ The `redraw!` command may not be needed, depending on whether executing a
 shell command shows something on the display or not.
 
 If the 'diffexpr' expression starts with s: or |<SID>|, then it is replaced
-with the script ID (|local-function|). Example: >
+with the script ID (|local-function|).  Example: >
 		set diffexpr=s:MyDiffExpr()
 		set diffexpr=<SID>SomeDiffExpr()
 Otherwise, the expression is evaluated in the context of the script where the
@@ -608,7 +609,7 @@ directory are accidentally patched.  Vim will also delete files starting with
 v:fname_in and ending in ".rej" and ".orig".
 
 If the 'patchexpr' expression starts with s: or |<SID>|, then it is replaced
-with the script ID (|local-function|). Example: >
+with the script ID (|local-function|).  Example: >
 		set patchexpr=s:MyPatchExpr()
 		set patchexpr=<SID>SomePatchExpr()
 Otherwise, the expression is evaluated in the context of the script where the

--- a/en/digraph.txt
+++ b/en/digraph.txt
@@ -1,4 +1,4 @@
-*digraph.txt*   For Vim version 9.1.  Last change: 2025 Aug 16
+*digraph.txt*   For Vim version 9.1.  Last change: 2025 Oct 12
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -112,7 +112,7 @@ mode.  After leaving the Insert mode everything is fine.  On some Unix systems
 this means you have to define the environment-variable LC_CTYPE.  If you are
 using csh, then put the following line in your .cshrc: >
 	setenv LC_CTYPE en_US.utf8
-(or similar for a different language or country). The value must be a valid
+(or similar for a different language or country).  The value must be a valid
 locale on your system, i.e. on Unix-like systems it must be present in the
 output of >
 	locale -a

--- a/en/gui_x11.txt
+++ b/en/gui_x11.txt
@@ -1,4 +1,4 @@
-*gui_x11.txt*   For Vim version 9.1.  Last change: 2025 Sep 22
+*gui_x11.txt*   For Vim version 9.1.  Last change: 2025 Oct 12
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -602,7 +602,7 @@ your pkg-config works with your GTK+ 2: >
 
     $ pkg-config --modversion gtk+-2.0
 
-Replace gtk+-2.0 with gtk+-3.0 for GTK+ 3. If you get the correct version
+Replace gtk+-2.0 with gtk+-3.0 for GTK+ 3.  If you get the correct version
 number of your GTK+, you can proceed; if not, you probably need to do some
 system administration chores to set up pkg-config and GTK+ correctly.
 

--- a/en/helphelp.txt
+++ b/en/helphelp.txt
@@ -1,4 +1,4 @@
-*helphelp.txt*	For Vim version 9.1.  Last change: 2025 Sep 29
+*helphelp.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -297,9 +297,9 @@ the following pattern is used: >
 
 	^\w\+@\w\+:\f\+\$\s
 
-This is meant to match a default bash prompt.  If it doesn't match your prompt,
-you can change the regex with the `shell_prompt` key from the `g:helptoc`
-dictionary variable: >
+This is meant to match a default bash prompt.  If it doesn't match your
+prompt, you can change the regex with the `shell_prompt` key from the
+`g:helptoc` dictionary variable: >
 
 	let g:helptoc = {'shell_prompt': 'regex matching your shell prompt'}
 
@@ -456,8 +456,8 @@ This will highlight the column heading in a different color.  E.g.
 Column heading~
 
 To separate sections in a help file, place a series of '=' characters in a
-line starting from the first column.  The section separator line is highlighted
-differently.
+line starting from the first column.  The section separator line is
+highlighted differently.
 
 To quote a block of ex-commands verbatim, place a greater than (>) character
 at the end of the line before the block and a less than (<) character as the

--- a/en/if_cscop.txt
+++ b/en/if_cscop.txt
@@ -1,4 +1,4 @@
-*if_cscop.txt*  For Vim version 9.1.  Last change: 2025 Aug 10
+*if_cscop.txt*  For Vim version 9.1.  Last change: 2025 Oct 12
 
 
 		  VIM REFERENCE MANUAL    by Andy Kahn
@@ -255,7 +255,7 @@ started will have no effect!
 					    *cscopequickfix* *csqf* *E469*
 {not available when compiled without the |+quickfix| feature}
 'cscopequickfix' specifies whether to use quickfix window to show cscope
-results.  This is a list of comma-separated values. Each item consists of
+results.  This is a list of comma-separated values.  Each item consists of
 |cscope-find| command (s, g, d, c, t, e, f, i or a) and flag (+, - or 0).
 '+' indicates that results must be appended to quickfix window,
 '-' implies previous results clearance, '0' or command absence - don't use

--- a/en/if_perl.txt
+++ b/en/if_perl.txt
@@ -1,4 +1,4 @@
-*if_perl.txt*   For Vim version 9.1.  Last change: 2025 Oct 04
+*if_perl.txt*   For Vim version 9.1.  Last change: 2025 Oct 12
 
 
 		  VIM REFERENCE MANUAL    by Sven Verdoolaege
@@ -17,9 +17,9 @@ Perl and Vim				*perl* *Perl*
 1. Editing Perl files					*perl-editing*
 
 Vim syntax highlighting supports Perl and POD files.  Vim assumes a file is
-Perl code if the filename has a .pl or .pm suffix.  Vim also examines the first
-line of a file, regardless of the filename suffix, to check if a file is a
-Perl script (see scripts.vim in Vim's syntax directory).  Vim assumes a file
+Perl code if the filename has a .pl or .pm suffix.  Vim also examines the
+first line of a file, regardless of the filename suffix, to check if a file is
+a Perl script (see scripts.vim in Vim's syntax directory).  Vim assumes a file
 is POD text if the filename has a .POD suffix.
 
 To use tags with Perl, you need Universal/Exuberant Ctags.  Look here:
@@ -90,9 +90,9 @@ To see what version of Perl you have: >
 							*:perldo* *:perld*
 :[range]perld[o] {cmd}	Execute Perl command {cmd} for each line in the
 			[range], with $_ being set to the text of each line in
-			turn, without a trailing <EOL>.  Setting $_ will change
-			the text, but note that it is not possible to add or
-			delete lines using this command.
+			turn, without a trailing <EOL>.  Setting $_ will
+			change the text, but note that it is not possible to
+			add or delete lines using this command.
 			The default for [range] is the whole file: "1,$".
 
 Here are some things you can try: >
@@ -296,8 +296,8 @@ version of the shared library must match the Perl version Vim was compiled
 with.
 
 Note: If you are building Perl locally, you have to use a version compiled
-with threading support for it for Vim to successfully link against it. You can
-use the `-Dusethreads` flags when configuring Perl, and check that a Perl
+with threading support for it for Vim to successfully link against it.  You
+can use the `-Dusethreads` flags when configuring Perl, and check that a Perl
 binary has it enabled by running `perl -V` and verify that `USE_ITHREADS` is
 under "Compile-time options".
 

--- a/en/if_pyth.txt
+++ b/en/if_pyth.txt
@@ -1,4 +1,4 @@
-*if_pyth.txt*   For Vim version 9.1.  Last change: 2025 Mar 26
+*if_pyth.txt*   For Vim version 9.1.  Last change: 2025 Oct 12
 
 
 		  VIM REFERENCE MANUAL    by Paul Moore
@@ -80,9 +80,9 @@ and "EOF" do not have any indent.
 			{body}" for each line in the [range], with the
 			function arguments being set to the text of each line
 			in turn, without a trailing <EOL>, and the current
-			line number. The function should return a string or
-			None. If a string is returned, it becomes the text of
-			the line in the current turn. The default for [range]
+			line number.  The function should return a string or
+			None.  If a string is returned, it becomes the text of
+			the line in the current turn.  The default for [range]
 			is the whole file: "1,$".
 
 Examples:
@@ -91,7 +91,7 @@ Examples:
 	:pydo if line: return "%4d: %s" % (linenr, line)
 <
 One can use `:pydo` in possible conjunction with `:py` to filter a range using
-python. For example: >
+python.  For example: >
 
 	:py3 << EOF
 	needle = vim.eval('@a')
@@ -205,12 +205,12 @@ vim.eval(str)						*python-eval*
 	'eval_expr', 'kind': 'f', 'filename': './src/eval.c'}] ~
 
 	NOTE: In Vim9 script, local variables in def functions are not visible
-	to python evaluations. To pass local variables to python evaluations,
+	to python evaluations.  To pass local variables to python evaluations,
 	use the {locals} dict when calling |py3eval()| and friends.
 
 vim.bindeval(str)					*python-bindeval*
 	Like |python-eval|, but returns special objects described in
-	|python-bindeval-objects|. These python objects let you modify
+	|python-bindeval-objects|.  These python objects let you modify
 	(|List|, |Tuple| or |Dictionary|) or call (|Funcref|) vim objects.
 
 vim.strwidth(str)					*python-strwidth*
@@ -220,14 +220,14 @@ vim.strwidth(str)					*python-strwidth*
 vim.foreach_rtp(callable)				*python-foreach_rtp*
 	Call the given callable for each path in 'runtimepath' until either
 	callable returns something but None, the exception is raised or there
-	are no longer paths. If stopped in case callable returned non-None,
+	are no longer paths.  If stopped in case callable returned non-None,
 	vim.foreach_rtp function returns the value returned by callable.
 
 vim.chdir(*args, **kwargs)				*python-chdir*
 vim.fchdir(*args, **kwargs)				*python-fchdir*
 	Run os.chdir or os.fchdir, then all appropriate vim stuff.
 	Note: you should not use these functions directly, use os.chdir and
-	      os.fchdir instead. Behavior of vim.fchdir is undefined in case
+	      os.fchdir instead.  Behavior of vim.fchdir is undefined in case
 	      os.fchdir does not exist.
 
 Error object of the "vim" module
@@ -265,12 +265,12 @@ vim.windows						*python-windows*
 <	Note: vim.windows object always accesses current tab page.
 	|python-tabpage|.windows objects are bound to parent |python-tabpage|
 	object and always use windows from that tab page (or throw vim.error
-	in case tab page was deleted). You can keep a reference to both
+	in case tab page was deleted).  You can keep a reference to both
 	without keeping a reference to vim module object or |python-tabpage|,
 	they will not lose their properties in this case.
 
 vim.tabpages						*python-tabpages*
-	A sequence object providing access to the list of vim tab pages. The
+	A sequence object providing access to the list of vim tab pages.  The
 	object supports the following operations: >
 	    :py t = vim.tabpages[i]	# Indexing (read-only)
 	    :py t in vim.tabpages	# Membership test
@@ -293,10 +293,10 @@ vim.current						*python-current*
 
 	Note: When assigning to vim.current.{buffer,window,tabpage} it expects
 	valid |python-buffer|, |python-window| or |python-tabpage| objects
-	respectively. Assigning triggers normal (with |autocommand|s)
-	switching to given buffer, window or tab page. It is the only way to
+	respectively.  Assigning triggers normal (with |autocommand|s)
+	switching to given buffer, window or tab page.  It is the only way to
 	switch UI objects in python: you can't assign to
-	|python-tabpage|.window attribute. To switch without triggering
+	|python-tabpage|.window attribute.  To switch without triggering
 	autocommands use >
 	    py << EOF
 	    saved_eventignore = vim.options['eventignore']
@@ -310,16 +310,16 @@ vim.current						*python-current*
 vim.vars						*python-vars*
 vim.vvars						*python-vvars*
 	Dictionary-like objects holding dictionaries with global (|g:|) and
-	vim (|v:|) variables respectively. Identical to `vim.bindeval("g:")`,
+	vim (|v:|) variables respectively.  Identical to `vim.bindeval("g:")`,
 	but faster.
 
 vim.options						*python-options*
 	Object partly supporting mapping protocol (supports setting and
 	getting items) providing a read-write access to global options.
-	Note: unlike |:set| this provides access only to global options. You
+	Note: unlike |:set| this provides access only to global options.  You
 	cannot use this object to obtain or set local options' values or
-	access local-only options in any fashion. Raises KeyError if no global
-	option with such name exists (i.e. does not raise KeyError for
+	access local-only options in any fashion.  Raises KeyError if no
+	global option with such name exists (i.e. does not raise KeyError for
 	|global-local| options and global only options, but does for window-
 	and buffer-local ones).  Use |python-buffer| objects to access to
 	buffer-local options and |python-window| objects to access to
@@ -340,8 +340,8 @@ Output from Python					*python-output*
 
 							*python-input*
 	Input (via sys.stdin, including input() and raw_input()) is not
-	supported, and may cause the program to crash.  This should probably be
-	fixed.
+	supported, and may cause the program to crash.  This should probably
+	be fixed.
 
 		    *python2-directory* *python3-directory* *pythonx-directory*
 Python 'runtimepath' handling				*python-special-path*
@@ -401,11 +401,11 @@ Implementation is similar to the following, but written in C: >
 
     sys.path_hooks.append(hook)
 
-vim.VIM_SPECIAL_PATH					*python-VIM_SPECIAL_PATH*
-	String constant used in conjunction with vim path hook. If path hook
+vim.VIM_SPECIAL_PATH				*python-VIM_SPECIAL_PATH*
+	String constant used in conjunction with vim path hook.  If path hook
 	installed by vim is requested to handle anything but path equal to
-	vim.VIM_SPECIAL_PATH constant it raises ImportError. In the only other
-	case it uses special loader.
+	vim.VIM_SPECIAL_PATH constant it raises ImportError.  In the only
+	other case it uses special loader.
 
 	Note: you must not use value of this constant directly, always use
 	      vim.VIM_SPECIAL_PATH object.
@@ -422,7 +422,7 @@ vim.find_spec(...)					*python-find_spec*
 
 vim._get_paths						*python-_get_paths*
 	Methods returning a list of paths which will be searched for by path
-	hook. You should not rely on this method being present in future
+	hook.  You should not rely on this method being present in future
 	versions, but can use it for debugging.
 
 	It returns a list of {rtp}/python2 (or {rtp}/python3) and
@@ -431,7 +431,8 @@ vim._get_paths						*python-_get_paths*
 ==============================================================================
 3. Buffer objects					*python-buffer*
 
-Buffer objects represent vim buffers.  You can obtain them in a number of ways:
+Buffer objects represent vim buffers.  You can obtain them in a number of
+ways:
 	- via vim.current.buffer (|python-current|)
 	- from indexing vim.buffers (|python-buffers|)
 	- from the "buffer" attribute of a window (|python-window|)
@@ -445,9 +446,10 @@ act as if they were lists (yes, they are mutable) of strings, with each
 element being a line of the buffer.  All of the usual sequence operations,
 including indexing, index assignment, slicing and slice assignment, work as
 you would expect.  Note that the result of indexing (slicing) a buffer is a
-string (list of strings).  This has one unusual consequence - b[:] is different
-from b.  In particular, "b[:] = None" deletes the whole of the buffer, whereas
-"b = None" merely updates the variable b, with no effect on the buffer.
+string (list of strings).  This has one unusual consequence - b[:] is
+different from b.  In particular, "b[:] = None" deletes the whole of the
+buffer, whereas "b = None" merely updates the variable b, with no effect on
+the buffer.
 
 Buffer indexes start at zero, as is normal in Python.  This differs from vim
 line numbers, which start from 1.  This is particularly relevant when dealing
@@ -458,17 +460,17 @@ The buffer object attributes are:
 			|buffer-variable|s.
 	b.options	Mapping object (supports item getting, setting and
 			deleting) that provides access to buffer-local options
-			and buffer-local values of |global-local| options. Use
+			and buffer-local values of |global-local| options.  Use
 			|python-window|.options if option is window-local,
-			this object will raise KeyError. If option is
+			this object will raise KeyError.  If option is
 			|global-local| and local value is missing getting it
 			will return None.
-	b.name		String, RW. Contains buffer name (full path).
+	b.name		String, RW.  Contains buffer name (full path).
 			Note: when assigning to b.name |BufFilePre| and
 			|BufFilePost| autocommands are launched.
-	b.number	Buffer number. Can be used as |python-buffers| key.
+	b.number	Buffer number.  Can be used as |python-buffers| key.
 			Read-only.
-	b.valid		True or False. Buffer object becomes invalid when
+	b.valid		True or False.  Buffer object becomes invalid when
 			corresponding buffer is wiped out.
 
 The buffer object methods are:
@@ -541,7 +543,8 @@ Example (assume r is the current range): >
 ==============================================================================
 5. Window objects					*python-window*
 
-Window objects represent vim windows.  You can obtain them in a number of ways:
+Window objects represent vim windows.  You can obtain them in a number of
+ways:
 	- via vim.current.window (|python-current|)
 	- from indexing vim.windows (|python-windows|)
 	- from indexing "windows" attribute of a tab page (|python-tabpage|)

--- a/en/if_ruby.txt
+++ b/en/if_ruby.txt
@@ -1,4 +1,4 @@
-*if_ruby.txt*   For Vim version 9.1.  Last change: 2019 Jul 21
+*if_ruby.txt*   For Vim version 9.1.  Last change: 2025 Oct 12
 
 
 		  VIM REFERENCE MANUAL    by Shugo Maeda
@@ -69,14 +69,14 @@ To see what version of Ruby you have: >
 						*:rubydo* *:rubyd* *E265*
 :[range]rubyd[o] {cmd}	Evaluate Ruby command {cmd} for each line in the
 			[range], with $_ being set to the text of each line in
-			turn, without a trailing <EOL>.  Setting $_ will change
-			the text, but note that it is not possible to add or
-			delete lines using this command.
+			turn, without a trailing <EOL>.  Setting $_ will
+			change the text, but note that it is not possible to
+			add or delete lines using this command.
 			The default for [range] is the whole file: "1,$".
 
 							*:rubyfile* *:rubyf*
-:rubyf[ile] {file}	Execute the Ruby script in {file}.  This is the same as
-			`:ruby load 'file'`, but allows file name completion.
+:rubyf[ile] {file}	Execute the Ruby script in {file}.  This is the same
+			as `:ruby load 'file'`, but allows file name completion.
 
 Executing Ruby commands is not possible in the |sandbox|.
 
@@ -148,8 +148,8 @@ Class Methods:
 
 current		Returns the current buffer object.
 count		Returns the number of buffers.
-self[{n}]	Returns the buffer object for the number {n}.  The first number
-		is 0.
+self[{n}]	Returns the buffer object for the number {n}.  The first
+		number is 0.
 
 Methods:
 
@@ -157,10 +157,10 @@ name		Returns the full name of the buffer.
 number		Returns the number of the buffer.
 count		Returns the number of lines.
 length		Returns the number of lines.
-self[{n}]	Returns a line from the buffer. {n} is the line number.
+self[{n}]	Returns a line from the buffer.  {n} is the line number.
 self[{n}] = {str}
-		Sets a line in the buffer. {n} is the line number.
-delete({n})	Deletes a line from the buffer. {n} is the line number.
+		Sets a line in the buffer.  {n} is the line number.
+delete({n})	Deletes a line from the buffer.  {n} is the line number.
 append({n}, {str})
 		Appends a line after the line {n}.
 line		Returns the current line of the buffer if the buffer is
@@ -178,8 +178,8 @@ Class Methods:
 
 current		Returns the current window object.
 count		Returns the number of windows.
-self[{n}]	Returns the window object for the number {n}.  The first number
-		is 0.
+self[{n}]	Returns the window object for the number {n}.  The first
+		number is 0.
 
 Methods:
 

--- a/en/if_tcl.txt
+++ b/en/if_tcl.txt
@@ -1,4 +1,4 @@
-*if_tcl.txt*    For Vim version 9.1.  Last change: 2025 Aug 29
+*if_tcl.txt*    For Vim version 9.1.  Last change: 2025 Oct 12
 
 
 		  VIM REFERENCE MANUAL    by Ingo Wilken
@@ -234,8 +234,8 @@ The ::vim::current(window) variable contains the name of the window command
 for the current window.  A window command is automatically deleted when the
 corresponding vim window is closed.
 
-Let's assume the name of the window command is stored in the Tcl variable "win",
-i.e. "$win" calls the command.  The following options are available: >
+Let's assume the name of the window command is stored in the Tcl variable
+"win", i.e. "$win" calls the command.  The following options are available: >
 
 	$win buffer		# Create Tcl command for window's buffer.
 	$win command {cmd}	# Execute Ex command in windows context.
@@ -264,7 +264,8 @@ Options:
 		array set here [$win cursor]
 <	"here(row)" and "here(column)" now contain the cursor position.
 	With a single argument, the argument is interpreted as the name of a
-	Tcl array variable, which must contain two elements "row" and "column".
+	Tcl array variable, which must contain two elements "row" and
+	"column".
 	These are used to set the cursor to the new position: >
 		$win cursor here	;# not $here !
 <	With two arguments, sets the cursor to the specified row and column: >
@@ -313,8 +314,8 @@ changed, all marks in the buffer are automatically adjusted.  Any changes to
 the buffer's contents made by Tcl commands can be undone with the "undo" vim
 command (see |undo|).
 
-Let's assume the name of the buffer command is stored in the Tcl variable "buf",
-i.e. "$buf" calls the command.  The following options are available: >
+Let's assume the name of the buffer command is stored in the Tcl variable
+"buf", i.e. "$buf" calls the command.  The following options are available: >
 
 	$buf append {n} {str}	# Append a line to buffer, after line {n}.
 	$buf command {cmd}	# Execute Ex command in buffers context.
@@ -404,8 +405,8 @@ Options:
 	deleted from the buffer.
 
 	$buf windows					*tcl-buffer-windows*
-	Creates a window command for each window that displays this buffer, and
-	returns a list of the command names as the result.
+	Creates a window command for each window that displays this buffer,
+	and returns a list of the command names as the result.
 	Example: >
 		set winlist [$buf windows]
 		foreach win $winlist { $win height 4 }

--- a/en/intro.txt
+++ b/en/intro.txt
@@ -1,4 +1,4 @@
-*intro.txt*     For Vim version 9.1.  Last change: 2025 Oct 11
+*intro.txt*     For Vim version 9.1.  Last change: 2025 Oct 12
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -99,7 +99,8 @@ There are several mailing lists for Vim:
 	For discussions about using and improving the Macintosh version of
 	Vim.
 <vim-security@googlegroups.com>			*vim-security*
-	This list is for (privately) discussing security relevant issues of Vim.
+	This list is for (privately) discussing security relevant issues of
+	Vim.
 
 See http://www.vim.org/maillist.php for the latest information.
 
@@ -236,7 +237,8 @@ Vim would never have become what it is now, without the help of these people!
 	Felix von Leitner	Previous maintainer of Vim Mailing Lists
 	David Leonard		Port of Python extensions to Unix
 	Avner Lottem		Edit in right-to-left windows
-	Flemming Madsen		X11 client-server, various features and patches
+	Flemming Madsen		X11 client-server, various features and
+				patches
 	Tony Mechelynck		answers many user questions
 	Paul Moore		Python interface extensions, many patches
 	Katsuhito Nagano	Work on multibyte versions
@@ -606,8 +608,8 @@ Operator-pending mode	This is like Normal mode, but after an operator
 
 Replace mode		Replace mode is a special case of Insert mode.  You
 			can do the same things as in Insert mode, but for
-			each character you enter, one character of the existing
-			text is deleted.  See |Replace-mode|.
+			each character you enter, one character of the
+			existing text is deleted.  See |Replace-mode|.
 			If the 'showmode' option is on "-- REPLACE --" is
 			shown at the bottom of the window.
 

--- a/en/mlang.txt
+++ b/en/mlang.txt
@@ -1,4 +1,4 @@
-*mlang.txt*     For Vim version 9.1.  Last change: 2024 Jul 11
+*mlang.txt*     For Vim version 9.1.  Last change: 2025 Oct 12
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -81,7 +81,7 @@ use of "-" and "_".
 			This sets $LC_TIME.
 			With the "collate" argument the language used for the
 			collation order is set.  This affects sorting of
-			characters. This sets $LC_COLLATE.
+			characters.  This sets $LC_COLLATE.
 			Without an argument all are set, and additionally
 			$LANG is set.
 			If available the LC_NUMERIC value will always be set


### PR DESCRIPTION
…th,if_ruby,if_tcl,intro,mlang.{txt,jax}

オリジナルは 2 spaces after a sentence と改行位置の変更だけです。ですので、.jax は日付だけの変更です。