### PR TITLE
Update builtin.{txt,jax}

### DIFF
--- a/doc/builtin.jax
+++ b/doc/builtin.jax
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim バージョン 9.2.  Last change: 2026 Apr 21
+*builtin.txt*	For Vim バージョン 9.2.  Last change: 2026 Apr 28
 
 
 		  VIM リファレンスマニュアル	by Bram Moolenaar
@@ -756,6 +756,8 @@ tabpagebuflist([{arg}])		リスト	タブページ内のバッファ番号のリ
 tabpagenr([{arg}])		数値	現在または最後のタブページの番号
 tabpagewinnr({tabarg} [, {arg}])
 				数値	タブページ内の現在のウィンドウの番号
+tabpanel_getinfo()		辞書	タブパネルの現在の状態を取得する
+tabpanel_scroll({n} [, {opts}])	真偽値	タブパネルをスクロールする
 tagfiles()			リスト	使用しているタグファイルのリスト
 taglist({expr} [, {filename}])	リスト	{expr}にマッチするタグのリスト
 tan({expr})			浮動小数点数	{expr}のタンジェント
@@ -5653,7 +5655,7 @@ histadd({history}, {item})				*histadd()*
 		例: >
 			:call histadd("input", strftime("%Y %b %d"))
 			:let date=input("Enter date: ")
-<		サンドボックス|sandbox|の中では利用できない。
+<		この関数は |sandbox| 内では使用できない。
 
 		|method| としても使用でき、ベースは第2引数として渡される: >
 			GetHistory()->histadd('search')
@@ -6750,6 +6752,8 @@ listener_add({callback} [, {buf} [, {unbuffered}]])	*listener_add()*
 		|method| としても使用でき、ベースは第2引数として渡される: >
 			GetBuffer()->listener_add(callback)
 <
+		この関数は |sandbox| 内では使用できない。
+
 		戻り値の型: |Number|
 
 
@@ -6764,6 +6768,8 @@ listener_flush([{buf}])					*listener_flush()*
 		|method| としても使用できる: >
 			GetBuffer()->listener_flush()
 <
+		この関数は |sandbox| 内では使用できない。
+
 		戻り値の型: void
 
 
@@ -6775,6 +6781,8 @@ listener_remove({id})					*listener_remove()*
 		|method| としても使用できる: >
 			GetListenerId()->listener_remove()
 <
+		この関数は |sandbox| 内では使用できない。
+
 		戻り値の型: |Number|
 
 
@@ -7711,7 +7719,7 @@ mkdir({name} [, {flags} [, {prot}]])			*mkdir()* *E739*
 		例: >
 			:call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
 
-<		|sandbox|の中ではこの関数は使用できない。
+<		この関数は |sandbox| 内では使用できない。
 
 		ディレクトリが既に存在して、かつフラグ "p" が渡された場合エラー
 		は発生しない (パッチ 8.0.1708 より)。ただし、"p" オプション未
@@ -8697,6 +8705,8 @@ redraw_listener_add({opts})				*redraw_listener_add()*
 		|method| としても使用できる: >
 			GetOpts()->redraw_listener_add()
 <
+		この関数は |sandbox| 内では使用できない。
+
 		戻り値の型: |Number|
 
 
@@ -8839,7 +8849,7 @@ remote_expr({server}, {string} [, {idvar} [, {timeout}]])
 		する。それ以外ではタイムアウトとして 600 秒が使用される。
 
 		|clientserver| と |RemoteReply| も参照。
-		|sandbox| の中ではこの関数は利用できない。
+		この関数は |sandbox| 内では使用できない。
 		{|+clientserver| 機能付きでコンパイルされたときのみ利用可能}
 		Note: なんらかのエラーが発生した場合は、ローカルでエラーメッ
 		セージが表示され、戻り値は空文字列となる。
@@ -8868,7 +8878,7 @@ remote_foreground({server})				*remote_foreground()*
 		クライアントが仕事を行う。
 		Note: |foreground()| と違い、最小化されていたウィンドウを復元
 		しない。
-		|sandbox| の中ではこの関数は使用できない。
+		この関数は |sandbox| 内では使用できない。
 
 		|method| としても使用できる: >
 			ServerName()->remote_foreground()
@@ -8886,7 +8896,7 @@ remote_peek({serverid} [, {retvar}])			*remote_peek()*
 		取得できないならば0を返す。
 		なんらかの異状のときは-1を返す。
 		|clientserver|も参照。
-		|sandbox|の中ではこの関数は利用できない。
+		この関数は |sandbox| 内では使用できない。
 		{|+clientserver|機能付きでコンパイルされたときのみ利用可能}
 		例: >
 		    :let repl = ""
@@ -8905,7 +8915,7 @@ remote_read({serverid}, [{timeout}])			*remote_read()*
 		るようになるまで待機する。応答が利用できない場合、またはエラー
 		時は空の文字列を返す。
 		|clientserver|も参照。
-		|sandbox|の中ではこの関数は利用できない。
+		この関数は |sandbox| 内では使用できない。
 		{|+clientserver|機能付きでコンパイルされたときのみ利用可能}
 		例: >
 			:echo remote_read(id)
@@ -8928,7 +8938,7 @@ remote_send({server}, {string} [, {idvar}])		*remote_send()* *E241*
 		{serverid} がその変数に保存される。
 
 		|clientserver| と |RemoteReply| も参照。
-		|sandbox| の中ではこの関数は利用できない。
+		この関数は |sandbox| 内では使用できない。
 		{|+clientserver| 機能付きでコンパイルされたときのみ利用可能}
 
 		Note: なんらかのエラーが発生すると、サーバー側で報告され、表示
@@ -9014,7 +9024,7 @@ rename({from}, {to})					*rename()*
 		0、失敗すれば非ゼロになる。
 		NOTE: ファイル {to} がすでに存在する場合、警告なしに上書きされ
 		る。
-		|sandbox|の中ではこの関数は利用できない。
+		この関数は |sandbox| 内では使用できない。
 
 		|method| としても使用できる: >
 			GetOldName()->rename(newname)
@@ -9670,7 +9680,7 @@ setbufvar({buf}, {varname}, {val})			*setbufvar()*
 		例: >
 			:call setbufvar(1, "&mod", 1)
 			:call setbufvar("todo", "myvar", "foobar")
-<		サンドボックスの中ではこの関数は使用できない。
+<		この関数は |sandbox| 内では使用できない。
 
 		|method| としても使用でき、ベースは第3引数として渡される: >
 			GetValue()->setbufvar(buf, varname)
@@ -10152,7 +10162,7 @@ settabvar({tabnr}, {varname}, {val})			*settabvar()*
 		る。例えば、'filetype' を設定する時。
 		Note: 指定する変数名は "t:" を除いた名前。
 		タブの番号は 1 から始まる。
-		この関数はサンドボックス (|sandbox|) の中では使えない。
+		この関数は |sandbox| 内では使用できない。
 
 		|method| としても使用でき、ベースは第3引数として渡される: >
 			GetValue()->settabvar(tab, name)
@@ -10178,7 +10188,7 @@ settabwinvar({tabnr}, {winnr}, {varname}, {val})	*settabwinvar()*
 		例: >
 			:call settabwinvar(1, 1, "&list", 0)
 			:call settabwinvar(3, 2, "myvar", "foobar")
-<		この関数は|sandbox|の中では使用できない。
+<		この関数は |sandbox| 内では使用できない。
 
 		|method| としても使用でき、ベースは第4引数として渡される: >
 			GetValue()->settabwinvar(tab, winnr, name)
@@ -11055,7 +11065,12 @@ strptime({format}, {timestring})			*strptime()*
 		{timestring} の書式が分からないときは、非 0 の値が返るまで、異
 		なった {format} の値を試してみるとよい。
 
+		Note: MS-Windows では、C ランタイムに strptime() 関数が提供さ
+		れていないため、Vim はアクティブなロケールに関係なく常に英語の
+		ロケール名を使用する組み込みのフォールバック機能を使用する。
+
 		|strftime()| も参照。
+
 		例: >
 		  :echo strptime("%Y %b %d %X", "1997 Apr 27 11:49:23")
 <		  862156163 >
@@ -11596,6 +11611,39 @@ tabpagewinnr({tabarg} [, {arg}])			*tabpagewinnr()*
 		戻り値の型: |Number|
 
 
+tabpanel_getinfo()					*tabpanel_getinfo()*
+		タブパネルの現在の状態を表す |Dictionary| を返す (タブパネルを
+		参照)。辞書には以下のキーを持つ:
+			align		"left" または "right"
+			columns		画面上のカラムの幅
+			scrollbar	スクロールバーが表示されている場合は
+					|TRUE|
+			offset		現在のスクロールの行オフセット
+			total		レンダリングされた行の総数
+			max_offset	"offset" の有効な最大値
+
+		"total" と "max_offset" の値は、タブパネルが少なくとも一度描画
+		された後にのみ正確になる。
+
+		戻り値の型: dict<any>
+
+
+tabpanel_scroll({n} [, {opts}])				*tabpanel_scroll()*
+		タブパネルを {n} 行スクロールする。正の値は下方向にスクロール
+		し (後ろのタブが表示される)、負の値は上方向にスクロールする。
+		新しいオフセットは有効な範囲に制限される。
+
+		{opts} が |Dictionary| かつ、その "absolute" エントリが |TRUE|
+		の場合、変化量 (デルタ) の代わりに {n} が新しい絶対スクロール
+		オフセットとして使用される。
+
+		スクロールオフセットが変更された場合は |TRUE| を返し、それ以外
+		の場合は |FALSE| を返す (例えば、タブパネルが表示されていない
+		場合、またはオフセットが既に要求された値になっている場合)。
+
+		戻り値の型: |vim9-boolean|
+
+
 tagfiles()						*tagfiles()*
 		カレントバッファにおいて、タグを検索するときに使うファイルの名
 		前からなる |List| を返す。'tags' オプションを展開したものであ
@@ -11830,7 +11878,7 @@ timer_start({time}, {callback} [, {options}])
 		|method| としても使用できる: >
 			GetMsec()->timer_start(callback)
 
-<		|sandbox| では利用できない。
+<		|sandbox| 内では使用できない。
 
 		戻り値の型: |Number|
 

--- a/doc/builtin.jax
+++ b/doc/builtin.jax
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim バージョン 9.2.  Last change: 2026 Apr 28
+*builtin.txt*	For Vim バージョン 9.2.  Last change: 2026 May 04
 
 
 		  VIM リファレンスマニュアル	by Bram Moolenaar
@@ -11630,8 +11630,8 @@ tabpanel_getinfo()					*tabpanel_getinfo()*
 
 tabpanel_scroll({n} [, {opts}])				*tabpanel_scroll()*
 		タブパネルを {n} 行スクロールする。正の値は下方向にスクロール
-		し (後ろのタブが表示される)、負の値は上方向にスクロールする。
-		新しいオフセットは有効な範囲に制限される。
+		し (後ろのタブページが表示される)、負の値は上方向にスクロール
+		する。新しいオフセットは有効な範囲に制限される。
 
 		{opts} が |Dictionary| かつ、その "absolute" エントリが |TRUE|
 		の場合、変化量 (デルタ) の代わりに {n} が新しい絶対スクロール

--- a/en/builtin.txt
+++ b/en/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.2.  Last change: 2026 Apr 28
+*builtin.txt*	For Vim version 9.2.  Last change: 2026 May 04
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -11904,16 +11904,16 @@ tabpanel_getinfo()					*tabpanel_getinfo()*
 
 tabpanel_scroll({n} [, {opts}])				*tabpanel_scroll()*
 		Scroll the tabpanel by {n} rows.  Positive values scroll down
-		(later tabs become visible), negative values scroll up.  The
-		new offset is clamped to the valid range.
+		(later tab pages become visible), negative values scroll up.
+		The new offset is clamped to the valid range.
 
 		When {opts} is a |Dictionary| and its "absolute" entry is
-		|TRUE|, {n} is used as the new absolute scroll offset
-		instead of a delta.
+		|TRUE|, {n} is used as the new absolute scroll offset instead
+		of a delta.
 
-		Returns |TRUE| if the scroll offset changed, |FALSE|
-		otherwise (for example when the tabpanel is not shown, or
-		the offset is already at the requested value).
+		Returns |TRUE| if the scroll offset changed, |FALSE| otherwise
+		(for example when the tabpanel is not shown, or the offset is
+		already at the requested value).
 
 		Return type: |vim9-boolean|
 

--- a/en/builtin.txt
+++ b/en/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.2.  Last change: 2026 Apr 21
+*builtin.txt*	For Vim version 9.2.  Last change: 2026 Apr 28
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -705,6 +705,8 @@ tabpagebuflist([{arg}])		List	list of buffer numbers in tab page
 tabpagenr([{arg}])		Number	number of current or last tab page
 tabpagewinnr({tabarg} [, {arg}])
 				Number	number of current window in tab page
+tabpanel_getinfo()		Dict	get current state of the tabpanel
+tabpanel_scroll({n} [, {opts}])	Bool	scroll the tabpanel
 tagfiles()			List	tags files used
 taglist({expr} [, {filename}])	List	list of tags matching {expr}
 tan({expr})			Float	tangent of {expr}
@@ -6863,6 +6865,8 @@ listener_add({callback} [, {buf} [, {unbuffered}]])	*listener_add()*
 		second argument: >
 			GetBuffer()->listener_add(callback)
 <
+		This function is not available in the |sandbox|.
+
 		Return type: |Number|
 
 
@@ -6877,6 +6881,8 @@ listener_flush([{buf}])					*listener_flush()*
 		Can also be used as a |method|: >
 			GetBuffer()->listener_flush()
 <
+		This function is not available in the |sandbox|.
+
 		Return type: void
 
 
@@ -6888,6 +6894,8 @@ listener_remove({id})					*listener_remove()*
 		Can also be used as a |method|: >
 			GetListenerId()->listener_remove()
 <
+		This function is not available in the |sandbox|.
+
 		Return type: |Number|
 
 
@@ -8867,6 +8875,8 @@ redraw_listener_add({opts})				*redraw_listener_add()*
 		Can also be used as a |method|: >
 			GetOpts()->redraw_listener_add()
 <
+		This function is not available in the |sandbox|.
+
 		Return type: |Number|
 
 
@@ -11317,7 +11327,12 @@ strptime({format}, {timestring})			*strptime()*
 		can try different {format} values until you get a non-zero
 		result.
 
+		Note: On MS-Windows, where the C runtime does not provide
+		strptime(), Vim uses a built-in fallback that always uses
+		English locale names regardless of the active locale.
+
 		See also |strftime()|.
+
 		Examples: >
 		  :echo strptime("%Y %b %d %X", "1997 Apr 27 11:49:23")
 <		  862156163 >
@@ -11869,6 +11884,38 @@ tabpagewinnr({tabarg} [, {arg}])			*tabpagewinnr()*
 			GetTabpage()->tabpagewinnr()
 <
 		Return type: |Number|
+
+
+tabpanel_getinfo()					*tabpanel_getinfo()*
+		Return a |Dictionary| describing the current state of the
+		tabpanel (see |tabpanel|).  The dictionary has these keys:
+			align		"left" or "right"
+			columns		width in screen columns
+			scrollbar	|TRUE| if a scrollbar is shown
+			offset		current scroll offset in rows
+			total		total number of rows rendered
+			max_offset	largest valid value for "offset"
+
+		The "total" and "max_offset" values are only accurate after
+		the tabpanel has been drawn at least once.
+
+		Return type: dict<any>
+
+
+tabpanel_scroll({n} [, {opts}])				*tabpanel_scroll()*
+		Scroll the tabpanel by {n} rows.  Positive values scroll down
+		(later tabs become visible), negative values scroll up.  The
+		new offset is clamped to the valid range.
+
+		When {opts} is a |Dictionary| and its "absolute" entry is
+		|TRUE|, {n} is used as the new absolute scroll offset
+		instead of a delta.
+
+		Returns |TRUE| if the scroll offset changed, |FALSE|
+		otherwise (for example when the tabpanel is not shown, or
+		the offset is already at the requested value).
+
+		Return type: |vim9-boolean|
 
 
 tagfiles()						*tagfiles()*


### PR DESCRIPTION
`This function is not available in the |sandbox|.` の訳を (今回追加分以外も含めて) 見直しました。