### PR TITLE
Add a CI check for help tag labels between en and ja

### DIFF
--- a/.github/workflows/tagdiffcheck.yml
+++ b/.github/workflows/tagdiffcheck.yml
@@ -1,0 +1,21 @@
+name: "help tag diff check"
+on:
+  pull_request:
+    # ラベルの付け外しでも走らせる。既定の types だけだと、PR を出した後に
+    # ラベルを貼っても再発火せず、失敗したままの run が残る。
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  tagdiff:
+    name: Check help tag labels between en and ja
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-tag-diff') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+      - name: Setup Vim
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install vim
+      - name: help tag diff check
+        run: tools/script/check_tag_diff.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /_gh-pages/
 /_master/
 doc/tags-ja
+en/tags
 target
 tmp
 *.sw?

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ check:
 	nvcheck doc/*.jax vim_faq/*.jax
 	vim -eu tools/maketags.vim
 	tools/script/check_leading_space.sh
+	tools/script/check_tag_diff.sh
 
 replace:
 	nvcheck -i doc/*.jax vim_faq/*.jax

--- a/tools/script/check_tag_diff.sh
+++ b/tools/script/check_tag_diff.sh
@@ -1,0 +1,50 @@
+#! /bin/bash
+#
+# en/*.txt と doc/*.jax のヘルプタグを突き合わせて食い違いを検出する。
+# 翻訳のときにタグラベルを書き損なうと参照が切れるので、それを拾う。
+# タグの抽出には helptags を使うので判定は Vim 本体と同じになる。
+#
+# タグ名だけでなく、どのファイルにあるかまで見る。
+# 重複タグは vimhelptagcheck の担当なのでここでは扱わない。
+#
+# 2026-09-06 h_east       : Create initial file.
+
+set -u
+
+vim_cmd=${VIM_CMD:-vim}
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "${tmpdir}"' EXIT
+
+if ! "${vim_cmd}" -eu NONE -c 'helptags en' -c 'helptags doc' -c 'qa!'; then
+  echo "helptags に失敗しました" >&2
+  exit 1
+fi
+
+if [ ! -f en/tags ] || [ ! -f doc/tags-ja ]; then
+  echo "タグファイルが生成されませんでした" >&2
+  exit 1
+fi
+
+# タグ名とファイル名 (拡張子を除く) の組にそろえる
+cut -f1,2 en/tags | sed 's/\.txt$//' | sort >"${tmpdir}/en"
+grep -v '^!_TAG_FILE_ENCODING' doc/tags-ja | cut -f1,2 | sed 's/\.jax$//' | sort \
+  >"${tmpdir}/ja"
+
+# $1:一覧 $2:元ディレクトリ $3:元拡張子 $4:先ディレクトリ $5:先拡張子
+report() {
+  awk -F'\t' -v sd="$2" -v se="$3" -v dd="$4" -v de="$5" \
+    '{ printf "%s/%s%s: タグ *%s* が %s/%s%s にありません\n", sd, $2, se, $1, dd, $2, de }' \
+    "$1"
+}
+
+comm -23 "${tmpdir}/en" "${tmpdir}/ja" >"${tmpdir}/en_only"
+comm -13 "${tmpdir}/en" "${tmpdir}/ja" >"${tmpdir}/ja_only"
+
+if [ ! -s "${tmpdir}/en_only" ] && [ ! -s "${tmpdir}/ja_only" ]; then
+  exit 0
+fi
+
+report "${tmpdir}/en_only" en .txt doc .jax
+report "${tmpdir}/ja_only" doc .jax en .txt
+exit 1


### PR DESCRIPTION
fixes: #2112

`skip-tag-diff` ラベルを付けることでこのチェックをスキップできます。
後からラベルの付け外しで workflow 再発火します。